### PR TITLE
Update binance_provider.dart

### DIFF
--- a/packages/komodo_cex_market_data/lib/src/binance/data/binance_provider.dart
+++ b/packages/komodo_cex_market_data/lib/src/binance/data/binance_provider.dart
@@ -8,7 +8,7 @@ import 'package:komodo_cex_market_data/src/models/coin_ohlc.dart';
 /// A provider class for fetching data from the Binance API.
 class BinanceProvider {
   /// Creates a new BinanceProvider instance.
-  const BinanceProvider({this.apiUrl = 'https://api.binance.com/api/v3'});
+  const BinanceProvider({this.apiUrl = 'https://api.binance.us/api/v3'});
 
   /// The base URL for the Binance API.
   /// Defaults to 'https://api.binance.com/api/v3'.


### PR DESCRIPTION
update to .us instead of .com restrictions for binance.com api usage

for international use worldwide

the .com api is restricted only to China mainland

.us should be open internationally (except for China mainland or something)

one API for all? sure why not

see changes please

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated Binance API endpoint to use Binance.US URL
	- Enhanced error handling for API requests with specific status code (451)

- **Bug Fixes**
	- Improved resilience of API data retrieval when encountering legal restrictions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->