### PR TITLE
fix(router): frozen layout on navigation and resize

### DIFF
--- a/lib/bloc/app_bloc_root.dart
+++ b/lib/bloc/app_bloc_root.dart
@@ -193,8 +193,10 @@ class AppBlocRoot extends StatelessWidget {
             )..add(CoinsStarted()),
           ),
           BlocProvider<PriceChartBloc>(
-            create: (context) => PriceChartBloc(binanceRepository)
-              ..add(
+            create: (context) => PriceChartBloc(
+              binanceRepository,
+              komodoDefiSdk,
+            )..add(
                 const PriceChartStarted(
                   symbols: ['KMD'],
                   period: Duration(days: 30),

--- a/lib/bloc/cex_market_data/price_chart/price_chart_bloc.dart
+++ b/lib/bloc/cex_market_data/price_chart/price_chart_bloc.dart
@@ -33,8 +33,10 @@ class PriceChartBloc extends Bloc<PriceChartEvent, PriceChartState> {
       if (state.availableCoins.isEmpty) {
         final coins = (await cexPriceRepository.getCoinList())
             .where((coin) => coin.currencies.contains('USDT'))
-            // filter out assets that are not in the known coins list to 
-            // prevent errors when using the SDK with the `.single` property
+            // `cexPriceRepository.getCoinList()` returns coins from a CEX
+            // (e.g. Binance), some of which are not in our known/available
+            // assets/coins list. This filter ensures that we only attempt to
+            // fetch and display data for supported coins
             .where((coin) => sdk.assets.assetsFromTicker(coin.id).length == 1)
             .map((coin) async {
           double? dayChangePercent = coinPrices[coin.symbol]?.change24h;

--- a/lib/bloc/cex_market_data/price_chart/price_chart_bloc.dart
+++ b/lib/bloc/cex_market_data/price_chart/price_chart_bloc.dart
@@ -37,7 +37,7 @@ class PriceChartBloc extends Bloc<PriceChartEvent, PriceChartState> {
             // (e.g. Binance), some of which are not in our known/available
             // assets/coins list. This filter ensures that we only attempt to
             // fetch and display data for supported coins
-            .where((coin) => sdk.assets.assetsFromTicker(coin.id).length == 1)
+            .where((coin) => sdk.assets.assetsFromTicker(coin.id).length >= 1)
             .map((coin) async {
           double? dayChangePercent = coinPrices[coin.symbol]?.change24h;
 

--- a/lib/router/navigators/app_router_delegate.dart
+++ b/lib/router/navigators/app_router_delegate.dart
@@ -38,7 +38,7 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
           return GestureDetector(
             onTap: () => runDropdownDismiss(context),
             child: MainLayout(
-              key: ValueKey('${isMobile}_${routingState.selectedMenu}'),
+              key: ValueKey('${routingState.selectedMenu}'),
             ),
           );
         },

--- a/lib/router/navigators/app_router_delegate.dart
+++ b/lib/router/navigators/app_router_delegate.dart
@@ -37,7 +37,9 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
           materialPageContext = context;
           return GestureDetector(
             onTap: () => runDropdownDismiss(context),
-            child: const MainLayout(),
+            child: MainLayout(
+              key: ValueKey('${isMobile}_${routingState.selectedMenu}'),
+            ),
           );
         },
       ),

--- a/packages/komodo_ui_kit/pubspec.lock
+++ b/packages/komodo_ui_kit/pubspec.lock
@@ -95,7 +95,7 @@ packages:
     description:
       path: "packages/komodo_defi_rpc_methods"
       ref: dev
-      resolved-ref: "9c75bb7b2d3a556cec4119ad29fdb7fa93fe599e"
+      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -104,7 +104,7 @@ packages:
     description:
       path: "packages/komodo_defi_types"
       ref: dev
-      resolved-ref: "9c75bb7b2d3a556cec4119ad29fdb7fa93fe599e"
+      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -113,7 +113,7 @@ packages:
     description:
       path: "packages/komodo_ui"
       ref: dev
-      resolved-ref: "9c75bb7b2d3a556cec4119ad29fdb7fa93fe599e"
+      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"

--- a/packages/komodo_ui_kit/pubspec.lock
+++ b/packages/komodo_ui_kit/pubspec.lock
@@ -95,7 +95,7 @@ packages:
     description:
       path: "packages/komodo_defi_rpc_methods"
       ref: dev
-      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
+      resolved-ref: afcdfd97b909b6f7cbd9f04c25f57a11031bcaf6
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -104,7 +104,7 @@ packages:
     description:
       path: "packages/komodo_defi_types"
       ref: dev
-      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
+      resolved-ref: afcdfd97b909b6f7cbd9f04c25f57a11031bcaf6
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -113,7 +113,7 @@ packages:
     description:
       path: "packages/komodo_ui"
       ref: dev
-      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
+      resolved-ref: afcdfd97b909b6f7cbd9f04c25f57a11031bcaf6
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -666,7 +666,7 @@ packages:
     description:
       path: "packages/komodo_coins"
       ref: dev
-      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
+      resolved-ref: afcdfd97b909b6f7cbd9f04c25f57a11031bcaf6
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -675,7 +675,7 @@ packages:
     description:
       path: "packages/komodo_defi_framework"
       ref: dev
-      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
+      resolved-ref: afcdfd97b909b6f7cbd9f04c25f57a11031bcaf6
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0"
@@ -684,7 +684,7 @@ packages:
     description:
       path: "packages/komodo_defi_local_auth"
       ref: dev
-      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
+      resolved-ref: afcdfd97b909b6f7cbd9f04c25f57a11031bcaf6
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -693,7 +693,7 @@ packages:
     description:
       path: "packages/komodo_defi_rpc_methods"
       ref: dev
-      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
+      resolved-ref: afcdfd97b909b6f7cbd9f04c25f57a11031bcaf6
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -702,7 +702,7 @@ packages:
     description:
       path: "packages/komodo_defi_sdk"
       ref: dev
-      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
+      resolved-ref: afcdfd97b909b6f7cbd9f04c25f57a11031bcaf6
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -711,7 +711,7 @@ packages:
     description:
       path: "packages/komodo_defi_types"
       ref: dev
-      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
+      resolved-ref: afcdfd97b909b6f7cbd9f04c25f57a11031bcaf6
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -727,7 +727,7 @@ packages:
     description:
       path: "packages/komodo_ui"
       ref: dev
-      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
+      resolved-ref: afcdfd97b909b6f7cbd9f04c25f57a11031bcaf6
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -743,7 +743,7 @@ packages:
     description:
       path: "packages/komodo_wallet_build_transformer"
       ref: dev
-      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
+      resolved-ref: afcdfd97b909b6f7cbd9f04c25f57a11031bcaf6
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -666,7 +666,7 @@ packages:
     description:
       path: "packages/komodo_coins"
       ref: dev
-      resolved-ref: "9c75bb7b2d3a556cec4119ad29fdb7fa93fe599e"
+      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -675,7 +675,7 @@ packages:
     description:
       path: "packages/komodo_defi_framework"
       ref: dev
-      resolved-ref: "9c75bb7b2d3a556cec4119ad29fdb7fa93fe599e"
+      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0"
@@ -684,7 +684,7 @@ packages:
     description:
       path: "packages/komodo_defi_local_auth"
       ref: dev
-      resolved-ref: "9c75bb7b2d3a556cec4119ad29fdb7fa93fe599e"
+      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -693,7 +693,7 @@ packages:
     description:
       path: "packages/komodo_defi_rpc_methods"
       ref: dev
-      resolved-ref: "9c75bb7b2d3a556cec4119ad29fdb7fa93fe599e"
+      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -702,7 +702,7 @@ packages:
     description:
       path: "packages/komodo_defi_sdk"
       ref: dev
-      resolved-ref: "9c75bb7b2d3a556cec4119ad29fdb7fa93fe599e"
+      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -711,7 +711,7 @@ packages:
     description:
       path: "packages/komodo_defi_types"
       ref: dev
-      resolved-ref: "9c75bb7b2d3a556cec4119ad29fdb7fa93fe599e"
+      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -727,7 +727,7 @@ packages:
     description:
       path: "packages/komodo_ui"
       ref: dev
-      resolved-ref: "9c75bb7b2d3a556cec4119ad29fdb7fa93fe599e"
+      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -743,7 +743,7 @@ packages:
     description:
       path: "packages/komodo_wallet_build_transformer"
       ref: dev
-      resolved-ref: "9c75bb7b2d3a556cec4119ad29fdb7fa93fe599e"
+      resolved-ref: b6fdae57512601f5ce01f83be22d2ae32169bf74
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"


### PR DESCRIPTION
Changes

- bump SDK version hash in `pubspec.lock` (`dev` branch is using an outdated SDK release)
- fixes the frozen layout when navigating and resizing
- fixes blank coin charts on the guest view (CEX asset not found in available coins list) 