### PR TITLE
fix(transaction-history): incorrect transaction history shown when switching coins

### DIFF
--- a/lib/bloc/coins_bloc/coins_bloc.dart
+++ b/lib/bloc/coins_bloc/coins_bloc.dart
@@ -30,10 +30,10 @@ class CoinsBloc extends Bloc<CoinsEvent, CoinsState> {
     // TODO: move auth listener to ui layer: bloclistener fires auth events
     on<CoinsBalanceMonitoringStarted>(_onCoinsBalanceMonitoringStarted);
     on<CoinsBalanceMonitoringStopped>(_onCoinsBalanceMonitoringStopped);
-    on<CoinsBalancesRefreshed>(_onCoinsRefreshed, transformer: sequential());
+    on<CoinsBalancesRefreshed>(_onCoinsRefreshed, transformer: droppable());
     on<CoinsActivated>(_onCoinsActivated, transformer: concurrent());
     on<CoinsDeactivated>(_onCoinsDeactivated, transformer: concurrent());
-    on<CoinsPricesUpdated>(_onPricesUpdated, transformer: sequential());
+    on<CoinsPricesUpdated>(_onPricesUpdated, transformer: droppable());
     on<CoinsSessionStarted>(_onLogin, transformer: droppable());
     on<CoinsSessionEnded>(_onLogout, transformer: droppable());
     on<CoinsSuspendedReactivated>(
@@ -161,7 +161,7 @@ class CoinsBloc extends Bloc<CoinsEvent, CoinsState> {
   ) async {
     _updateBalancesTimer?.cancel();
     _updateBalancesTimer = Timer.periodic(
-      const Duration(seconds: 30),
+      const Duration(minutes: 1),
       (timer) {
         add(CoinsBalancesRefreshed());
       },

--- a/lib/bloc/coins_bloc/coins_repo.dart
+++ b/lib/bloc/coins_bloc/coins_repo.dart
@@ -436,15 +436,6 @@ class CoinsRepo {
     return prices;
   }
 
-  Future<Balance?> getBalanceInfo(AssetId coinId) async {
-    final asset = _kdfSdk.assets.available[coinId];
-    if (asset == null) {
-      throw ArgumentError.value(coinId, 'getBalanceInfo', 'Asset not found');
-    }
-    final pubkeys = await _kdfSdk.pubkeys.getPubkeys(asset);
-    return pubkeys.balance;
-  }
-
   Future<Map<String, Coin>> updateTrezorBalances(
     Map<String, Coin> walletCoins,
   ) async {
@@ -459,9 +450,7 @@ class CoinsRepo {
     return walletCoinsCopy;
   }
 
-  Stream<Coin> updateIguanaBalances(
-    Map<String, Coin> walletCoins,
-  ) async* {
+  Stream<Coin> updateIguanaBalances(Map<String, Coin> walletCoins) async* {
     final walletCoinsCopy = Map<String, Coin>.from(walletCoins);
     final coins =
         walletCoinsCopy.values.where((coin) => coin.isActive).toList();

--- a/lib/bloc/taker_form/taker_bloc.dart
+++ b/lib/bloc/taker_form/taker_bloc.dart
@@ -394,7 +394,7 @@ class TakerBloc extends Bloc<TakerEvent, TakerState> {
           availableBalanceState: () => AvailableBalanceState.loading));
     }
 
-    if (!_isLoggedIn) {
+    if (!_isLoggedIn || !state.sellCoin!.isActive) {
       emitter(state.copyWith(
           availableBalanceState: () => AvailableBalanceState.unavailable));
     } else {

--- a/lib/bloc/transaction_history/transaction_history_bloc.dart
+++ b/lib/bloc/transaction_history/transaction_history_bloc.dart
@@ -42,13 +42,24 @@ class TransactionHistoryBloc
     TransactionHistorySubscribe event,
     Emitter<TransactionHistoryState> emit,
   ) async {
-    if (!hasTxHistorySupport(event.coin)) return;
+    emit(const TransactionHistoryState.initial());
+
+    if (!hasTxHistorySupport(event.coin)) {
+      emit(
+        state.copyWith(
+          loading: false,
+          error: TextError(
+            error: 'Transaction history is not supported for this coin.',
+          ),
+          transactions: const [],
+        ),
+      );
+      return;
+    }
 
     await _historySubscription?.cancel();
     await _newTransactionsSubscription?.cancel();
     _processedTxIds.clear();
-
-    emit(const TransactionHistoryState.initial());
 
     try {
       add(const TransactionHistoryStartedLoading());

--- a/lib/bloc/transaction_history/transaction_history_bloc.dart
+++ b/lib/bloc/transaction_history/transaction_history_bloc.dart
@@ -57,11 +57,11 @@ class TransactionHistoryBloc
       return;
     }
 
-    await _historySubscription?.cancel();
-    await _newTransactionsSubscription?.cancel();
-    _processedTxIds.clear();
-
     try {
+      await _historySubscription?.cancel();
+      await _newTransactionsSubscription?.cancel();
+      _processedTxIds.clear();
+
       add(const TransactionHistoryStartedLoading());
       final asset = _sdk.assets.available[event.coin.id];
       if (asset == null) {
@@ -101,7 +101,9 @@ class TransactionHistoryBloc
           );
         },
         onDone: () {
-          add(TransactionHistoryUpdated(transactions: state.transactions));
+          if (state.error == null && state.loading) {
+            add(TransactionHistoryUpdated(transactions: state.transactions));
+          }
           // Once historical load is complete, start watching for new transactions
           _subscribeToNewTransactions(asset, event.coin);
         },

--- a/lib/bloc/transaction_history/transaction_history_state.dart
+++ b/lib/bloc/transaction_history/transaction_history_state.dart
@@ -14,7 +14,7 @@ final class TransactionHistoryState extends Equatable {
   final BaseError? error;
 
   @override
-  List<Object?> get props => [transactions, loading];
+  List<Object?> get props => [transactions, loading, error];
 
   const TransactionHistoryState.initial()
       : transactions = const [],

--- a/lib/generated/codegen_loader.g.dart
+++ b/lib/generated/codegen_loader.g.dart
@@ -191,8 +191,6 @@ abstract class  LocaleKeys {
   static const logoutPopupTitle = 'logoutPopupTitle';
   static const logoutPopupDescriptionWalletOnly = 'logoutPopupDescriptionWalletOnly';
   static const logoutPopupDescription = 'logoutPopupDescription';
-  static const logoutPopupDescriptionWalletOnly =
-      'logoutPopupDescriptionWalletOnly';
   static const transactionDetailsTitle = 'transactionDetailsTitle';
   static const customSeedWarningText = 'customSeedWarningText';
   static const customSeedIUnderstand = 'customSeedIUnderstand';

--- a/lib/router/parsers/root_route_parser.dart
+++ b/lib/router/parsers/root_route_parser.dart
@@ -40,8 +40,8 @@ class RootRouteInformationParser extends RouteInformationParser<AppRoutePath> {
   }
 
   BaseRouteParser _getRoutParser(Uri uri) {
-    const defaultRouteParser =
-        kIsWalletOnly ? walletRouteParser : dexRouteParser;
+    final defaultRouteParser =
+        kIsWalletOnly ? _parsers[firstUriSegment.wallet]! : dexRouteParser;
 
     if (uri.pathSegments.isEmpty) return defaultRouteParser;
     return _parsers[uri.pathSegments.first] ?? defaultRouteParser;


### PR DESCRIPTION
Fixes two bugs when switching between coins to view transaction histories:
- Previously visited coins transaction histories were shown when switching between coins. This might be the state not resetting, and appears to be fixed by emitting a reset state on each new subscription before any other logic.
- Infinite spinner shown when switching to a coin with no transactions. The transaction history bloc stream returned to the `onDone` handler without adding an event or emitting a state, so `loading` stayed true.

In addition:
- Increased balance refresh timer to 1 minute (from 30 seconds) to reduce balance refresh request frequency in an attempt to reduce the RPC spamming.
- Changed the balance and price refresh events from `sequential` to `droppable`, to drop any new events that occur while a balance refresh is already running. This also prevents requests from piling up and infinitely requesting wallet balance updates