### PR TITLE
chore(deps): switch to SDK KDF 2.4.0 update branch

### DIFF
--- a/packages/komodo_ui_kit/pubspec.lock
+++ b/packages/komodo_ui_kit/pubspec.lock
@@ -94,8 +94,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/komodo_defi_rpc_methods"
-      ref: dev
-      resolved-ref: "5960abfcc01b067e994504218a7f64a3c142ac08"
+      ref: "chore/kdf-2.4.0-update"
+      resolved-ref: "9d419ad84e6d0af220103dcf664a3262e72aebf3"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -103,8 +103,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/komodo_defi_types"
-      ref: dev
-      resolved-ref: "5960abfcc01b067e994504218a7f64a3c142ac08"
+      ref: "chore/kdf-2.4.0-update"
+      resolved-ref: "9d419ad84e6d0af220103dcf664a3262e72aebf3"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -112,8 +112,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/komodo_ui"
-      ref: dev
-      resolved-ref: "5960abfcc01b067e994504218a7f64a3c142ac08"
+      ref: "chore/kdf-2.4.0-update"
+      resolved-ref: "9d419ad84e6d0af220103dcf664a3262e72aebf3"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"

--- a/packages/komodo_ui_kit/pubspec.yaml
+++ b/packages/komodo_ui_kit/pubspec.yaml
@@ -18,14 +18,14 @@ dependencies:
     git:
       url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
       path: packages/komodo_defi_types
-      ref: dev
+      ref: chore/kdf-2.4.0-update
 
   komodo_ui:
     # path: ../../sdk/packages/komodo_ui # Requires symlink to the SDK in the root of the project
     git:
       url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
       path: packages/komodo_ui
-      ref: dev
+      ref: chore/kdf-2.4.0-update
 
 dev_dependencies:
   flutter_lints: ^5.0.0 # flutter.dev

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -656,8 +656,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/komodo_coins"
-      ref: dev
-      resolved-ref: "5960abfcc01b067e994504218a7f64a3c142ac08"
+      ref: "chore/kdf-2.4.0-update"
+      resolved-ref: "9d419ad84e6d0af220103dcf664a3262e72aebf3"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -665,8 +665,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/komodo_defi_framework"
-      ref: dev
-      resolved-ref: "5960abfcc01b067e994504218a7f64a3c142ac08"
+      ref: "chore/kdf-2.4.0-update"
+      resolved-ref: "9d419ad84e6d0af220103dcf664a3262e72aebf3"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0"
@@ -674,8 +674,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/komodo_defi_local_auth"
-      ref: dev
-      resolved-ref: "5960abfcc01b067e994504218a7f64a3c142ac08"
+      ref: "chore/kdf-2.4.0-update"
+      resolved-ref: "9d419ad84e6d0af220103dcf664a3262e72aebf3"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -683,8 +683,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/komodo_defi_rpc_methods"
-      ref: dev
-      resolved-ref: "5960abfcc01b067e994504218a7f64a3c142ac08"
+      ref: "chore/kdf-2.4.0-update"
+      resolved-ref: "9d419ad84e6d0af220103dcf664a3262e72aebf3"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -692,8 +692,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/komodo_defi_sdk"
-      ref: dev
-      resolved-ref: "5960abfcc01b067e994504218a7f64a3c142ac08"
+      ref: "chore/kdf-2.4.0-update"
+      resolved-ref: "9d419ad84e6d0af220103dcf664a3262e72aebf3"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -701,8 +701,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/komodo_defi_types"
-      ref: dev
-      resolved-ref: "5960abfcc01b067e994504218a7f64a3c142ac08"
+      ref: "chore/kdf-2.4.0-update"
+      resolved-ref: "9d419ad84e6d0af220103dcf664a3262e72aebf3"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -717,8 +717,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/komodo_ui"
-      ref: dev
-      resolved-ref: "5960abfcc01b067e994504218a7f64a3c142ac08"
+      ref: "chore/kdf-2.4.0-update"
+      resolved-ref: "9d419ad84e6d0af220103dcf664a3262e72aebf3"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -733,8 +733,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/komodo_wallet_build_transformer"
-      ref: dev
-      resolved-ref: "5960abfcc01b067e994504218a7f64a3c142ac08"
+      ref: "chore/kdf-2.4.0-update"
+      resolved-ref: "9d419ad84e6d0af220103dcf664a3262e72aebf3"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -150,21 +150,21 @@ dependencies:
     git:
       url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
       path: packages/komodo_defi_sdk
-      ref: dev
+      ref: chore/kdf-2.4.0-update
 
   komodo_defi_types:
     # path: sdk/packages/komodo_defi_types # Requires symlink to the SDK in the root of the project
     git:
       url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
       path: packages/komodo_defi_types
-      ref: dev
+      ref: chore/kdf-2.4.0-update
 
   komodo_ui:
     # path: sdk/packages/komodo_ui # Requires symlink to the SDK in the root of the project
     git:
       url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
       path: packages/komodo_ui
-      ref: dev
+      ref: chore/kdf-2.4.0-update
 
 dev_dependencies:
   integration_test: # SDK


### PR DESCRIPTION
Switches the SDK reference to the KDF 2.4.0 update branch in the SDK repository, [#32](https://github.com/KomodoPlatform/komodo-defi-sdk-flutter/pull/32).

The SDK is now responsible for the KDF and coin asset file downloading, so the `build_config.json` needs to be updated in that repository. The plan is to eventually remove the `build_config.json` from this repository, once the bundled coins commit feature in the Settings menu is migrated to the SDK.