### PR TITLE
chore: add vscode config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ sdk/
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
-.vscode/
+# .vscode/
 .vs/
 
 # Firebase extras

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,15 @@
             "name": "komodo-wallet",
             "request": "launch",
             "program": "lib/main.dart",
-            "env": {
-                "testing_mode": "true"
-            },
+            "args": [
+                "--web-port=55353"
+            ],
+            "type": "dart"
+        },
+        {
+            "name": "komodo-wallet (no-cache)",
+            "request": "launch",
+            "program": "lib/main.dart",
             "type": "dart"
         },
         {
@@ -18,6 +24,11 @@
             "request": "launch",
             "type": "dart",
             "program": "lib/main.dart",
+            "args": [
+                "--web-port=55353"
+            ],
+            // Specify testing mode here to show more verbose logging
+            // despite not being in debug mode.
             "env": {
                 "testing_mode": "true"
             },
@@ -28,7 +39,10 @@
             "request": "launch",
             "type": "dart",
             "program": "lib/main.dart",
-            "flutterMode": "release"
+            "flutterMode": "release",
+            "args": [
+                "--web-port=55353"
+            ]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "komodo-wallet",
+            "request": "launch",
+            "program": "lib/main.dart",
+            "env": {
+                "testing_mode": "true"
+            },
+            "type": "dart"
+        },
+        {
+            "name": "komodo-wallet (profile mode)",
+            "request": "launch",
+            "type": "dart",
+            "program": "lib/main.dart",
+            "env": {
+                "testing_mode": "true"
+            },
+            "flutterMode": "profile"
+        },
+        {
+            "name": "komodo-wallet (release mode)",
+            "request": "launch",
+            "type": "dart",
+            "program": "lib/main.dart",
+            "flutterMode": "release"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,36 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "dart",
+            "group": {
+                "kind": "build",
+                "isDefault": false,
+            },
+            "label": "Flutter: run unit tests",
+            "command": "flutter",
+            "args": [
+                "test",
+                "test_units/main.dart",
+            ]
+        },
+        {
+            "type": "dart",
+            "group": {
+                "kind": "build",
+                "isDefault": false,
+            },
+            "label": "Flutter: run integration tests",
+            "command": "dart",
+            "args": [
+                "run_integration_tests.dart",
+                "--browser_name=chrome",
+                "-k",
+                "-b",
+                "1600,1024",
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Simplifies the following use-cases:
- Initial project setup
- [Git worktrees workflow](https://www.gitkraken.com/learn/git/git-worktree) - simplifies juggling multiple branches

Includes the `--web-port=` flag to simplify testing (login rather than register/restore)