### PR TITLE
feat(feedback): add api key management via envied and .env files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+TRELLO_API_KEY=your_api_key
+TRELLO_TOKEN=your_token
+TRELLO_BOARD_ID=your_board_id
+TRELLO_LIST_ID=your_list_id

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,9 @@ venv/
 # FVM Version Cache
 .fvm/
 /macos/build
+
+# ENVied environment variables and generated files.
+# NOTE: the generated files contain the environment variables from the .env file
+# and should not be committed to version control, even when obfuscated.
+.env
+lib/services/feedback/feedback_env.g.dart

--- a/lib/services/feedback/feedback_env.dart
+++ b/lib/services/feedback/feedback_env.dart
@@ -2,6 +2,9 @@ import 'package:envied/envied.dart';
 
 // NOTE: The generated file contains the actual environment variables
 // and should not be committed to the repository (even when obfuscated).
+// To generate this file, run either of the following commands:
+//  dart run build_runner build
+//  flutter pub run build_runner build
 part 'feedback_env.g.dart';
 
 @Envied(path: '.env', allowOptionalFields: true, obfuscate: true)

--- a/lib/services/feedback/feedback_env.dart
+++ b/lib/services/feedback/feedback_env.dart
@@ -1,0 +1,31 @@
+import 'package:envied/envied.dart';
+
+// NOTE: The generated file contains the actual environment variables
+// and should not be committed to the repository (even when obfuscated).
+part 'feedback_env.g.dart';
+
+@Envied(path: '.env', allowOptionalFields: true, obfuscate: true)
+abstract class FeedbackEnv {
+  @EnviedField(varName: 'TRELLO_API_KEY')
+  static String? apiKey = _FeedbackEnv.apiKey;
+
+  @EnviedField(varName: 'TRELLO_TOKEN')
+  static String? token = _FeedbackEnv.token;
+
+  @EnviedField(varName: 'TRELLO_BOARD_ID')
+  static String? boardId = _FeedbackEnv.boardId;
+
+  @EnviedField(varName: 'TRELLO_LIST_ID')
+  static String? listId = _FeedbackEnv.listId;
+
+  /// Returns true if all required environment variables are available
+  static bool hasAllVariables() {
+    return hasApiKey() && hasToken() && hasBoardId() && hasListId();
+  }
+
+  /// Returns true if specific variable is defined and not empty
+  static bool hasApiKey() => apiKey != null && apiKey!.isNotEmpty;
+  static bool hasToken() => token != null && token!.isNotEmpty;
+  static bool hasBoardId() => boardId != null && boardId!.isNotEmpty;
+  static bool hasListId() => listId != null && listId!.isNotEmpty;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -88,6 +88,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  build:
+    dependency: transitive
+    description:
+      name: build
+      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  build_config:
+    dependency: transitive
+    description:
+      name: build_config
+      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.4"
+  build_resolvers:
+    dependency: transitive
+    description:
+      name: build_resolvers
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.4"
+  build_runner:
+    dependency: "direct dev"
+    description:
+      name: build_runner
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.15"
+  build_runner_core:
+    dependency: transitive
+    description:
+      name: build_runner_core
+      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
+  built_value:
+    dependency: transitive
+    description:
+      name: built_value
+      sha256: ea90e81dc4a25a043d9bee692d20ed6d1c4a1662a28c03a96417446c093ed6b4
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.9.5"
   characters:
     dependency: transitive
     description:
@@ -104,6 +168,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  checked_yaml:
+    dependency: transitive
+    description:
+      name: checked_yaml
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
   clock:
     dependency: transitive
     description:
@@ -112,6 +184,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_builder:
+    dependency: transitive
+    description:
+      name: code_builder
+      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.10.1"
   collection:
     dependency: transitive
     description:
@@ -160,6 +240,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  dart_style:
+    dependency: transitive
+    description:
+      name: dart_style
+      sha256: "27eb0ae77836989a3bc541ce55595e8ceee0992807f14511552a898ddd0d88ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   decimal:
     dependency: "direct main"
     description:
@@ -208,6 +296,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.3"
+  envied:
+    dependency: "direct main"
+    description:
+      name: envied
+      sha256: a4e2b1d0caa479b5d61332ae516518c175a6d09328a35a0bc0a53894cc5d7e4d
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  envied_generator:
+    dependency: "direct dev"
+    description:
+      name: envied_generator
+      sha256: "894f6c5eb624c60a1ce6f642b6fd7ec68bc3440aa6f1881837aa9acbbeade0c8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   equatable:
     dependency: "direct main"
     description:
@@ -550,6 +654,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   hive:
     dependency: "direct main"
     description:
@@ -1036,6 +1148,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   qr:
     dependency: transitive
     description:
@@ -1060,6 +1180,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
+  recase:
+    dependency: transitive
+    description:
+      name: recase
+      sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   share_plus:
     dependency: "direct main"
     description:
@@ -1169,6 +1297,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  source_gen:
+    dependency: transitive
+    description:
+      name: source_gen
+      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -1273,6 +1409,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.8"
+  timing:
+    dependency: transitive
+    description:
+      name: timing
+      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -169,6 +169,7 @@ dependencies:
       path: packages/komodo_ui
       ref: dev
   feedback: ^3.1.0
+  envied: ^1.1.1
 
 dev_dependencies:
   integration_test: # SDK
@@ -181,6 +182,8 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^5.0.0 # flutter.dev
+  build_runner: ^2.4.15
+  envied_generator: ^1.1.1
 
 dependency_overrides:
   # Temporary until Flutter's pinned version is updated


### PR DESCRIPTION
Adds the [ENVied](https://pub.dev/packages/envied) package to manage the Trello API keys via .env files. The main benefit that ENVied has over `--dart-define` is obfuscation of the API key in the final binary, making it slightly more difficult to decode, although it is still possible.

Possible issues with this implementation:
- Client-side API keys are accessible and should be considered public, even with obfuscation enabled. Permissions have to be configured with this in mind.
- Developers will be required to run `dart run build_runner build` when opening the project for the first time and whenever the `.env` file is modified.
  - The environment variable values are stored inside the generated dart file, so build_runner is necessary to update the values in the generated file

See the ClickUp comparison doc for further information: https://app.clickup.com/9015263475/docs/8cnm07k-5195. 