### PR TITLE
Fix/show best offer

### DIFF
--- a/lib/views/fiat/fiat_payment_method_card.dart
+++ b/lib/views/fiat/fiat_payment_method_card.dart
@@ -28,7 +28,8 @@ class FiatPaymentMethodCardState extends State<FiatPaymentMethodCard> {
         widget.selectedPaymentMethod!.id == widget.paymentMethodData.id;
 
     final relativePercent = widget.paymentMethodData.relativePercent as double?;
-    final isBestOffer = relativePercent == null;
+    final isBestOffer = relativePercent == null || relativePercent == 0;
+
 
     return InkWell(
       onTap: () {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the logic for highlighting the best offer on fiat payment methods. Payment cards now correctly display as the best offer when the discount value is either not provided or explicitly zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->