### PR TITLE
fix(password): bypass password validation issue

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -643,6 +643,7 @@
     "allTimeInvestment": "All-time Investment",
     "allTimeProfit": "All-time Profit",
     "profitAndLoss": "Profit & Loss",
+    "walletCreationConfirmPasswordEmptyError" : "Please confirm your password",
     "alertDialogBitrefill": "Bitrefill",
     "showNoTradingWarning": "Warning",
     "showNoTradingWarningMessage": "Important: This is a development environment only. Please use test networks and demo assets exclusively for development and testing. KomodoPlatform does not support or permit real trading through this application. By using this app, you acknowledge that any potential losses or issues that may arise are your responsibility. Happy developing!",

--- a/lib/generated/codegen_loader.g.dart
+++ b/lib/generated/codegen_loader.g.dart
@@ -640,6 +640,7 @@ abstract class  LocaleKeys {
   static const allTimeInvestment = 'allTimeInvestment';
   static const allTimeProfit = 'allTimeProfit';
   static const profitAndLoss = 'profitAndLoss';
+  static const walletCreationConfirmPasswordEmptyError = 'walletCreationConfirmPasswordEmptyError';
   static const alertDialogBitrefill = 'alertDialogBitrefill';
   static const showNoTradingWarning = 'showNoTradingWarning';
   static const showNoTradingWarningMessage = 'showNoTradingWarningMessage';

--- a/lib/shared/utils/validators.dart
+++ b/lib/shared/utils/validators.dart
@@ -2,9 +2,12 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 
 String? validateConfirmPassword(String password, String confirmPassword) {
-  return password != confirmPassword
-      ? LocaleKeys.walletCreationConfirmPasswordError.tr()
-      : null;
+  if (confirmPassword.isEmpty) {
+    return LocaleKeys.walletCreationConfirmPasswordEmptyError.tr();
+  } else if (password != confirmPassword) {
+    return LocaleKeys.walletCreationConfirmPasswordError.tr();
+  }
+  return null;
 }
 
 /// unit test: [testValidatePassword]

--- a/packages/komodo_ui_kit/lib/src/inputs/ui_text_form_field.dart
+++ b/packages/komodo_ui_kit/lib/src/inputs/ui_text_form_field.dart
@@ -56,6 +56,7 @@ class UiTextFormField extends StatefulWidget {
     this.focusedBorder,
     this.errorStyle,
     this.validationMode = InputValidationMode.eager,
+    this.autovalidateMode = AutovalidateMode.onUserInteraction,
   });
 
   final String? initialValue;
@@ -95,6 +96,7 @@ class UiTextFormField extends StatefulWidget {
   final InputBorder? focusedBorder;
   final TextStyle? errorStyle;
   final InputValidationMode validationMode;
+  final AutovalidateMode autovalidateMode;
 
   @override
   State<UiTextFormField> createState() => _UiTextFormFieldState();
@@ -187,6 +189,18 @@ class _UiTextFormFieldState extends State<UiTextFormField> {
     return error;
   }
 
+  AutovalidateMode _getAutovalidateMode() {
+  switch (widget.validationMode) {
+    case InputValidationMode.aggressive:
+      return AutovalidateMode.always; // Validate immediately
+    case InputValidationMode.eager:
+      return AutovalidateMode.onUserInteraction; // Validate after first interaction
+    case InputValidationMode.passive:
+    case InputValidationMode.lazy:
+      return AutovalidateMode.disabled; // Only validate on submit
+  }
+}
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -234,7 +248,7 @@ class _UiTextFormFieldState extends State<UiTextFormField> {
       validator: (value) {
         // Don't update state during build, just return the validation result
         final error = widget.validator?.call(value) ?? widget.errorText;
-        return _shouldValidate ? error : null;
+        return error;
       },
       onChanged: (value) {
         widget.onChanged?.call(value);
@@ -253,9 +267,7 @@ class _UiTextFormFieldState extends State<UiTextFormField> {
       enableInteractiveSelection: widget.enableInteractiveSelection,
       textInputAction: widget.textInputAction,
       style: style,
-      autovalidateMode: _shouldValidate
-          ? AutovalidateMode.onUserInteraction
-          : AutovalidateMode.disabled,
+      autovalidateMode: _getAutovalidateMode(),
       keyboardType: widget.keyboardType,
       obscureText: widget.obscureText,
       autocorrect: widget.autocorrect,


### PR DESCRIPTION
This PR replaces the previous PR [#2576] due to conflict issues.

The password to confirm could be bypassed, now it will show an error that if it has not been filled in and it will show while the user is putting in their input.