### PR TITLE
fix(fiat-onramp): banxa onramp flow erroneous failure popup and return to komodo button

### DIFF
--- a/assets/web_pages/checkout_status_redirect.html
+++ b/assets/web_pages/checkout_status_redirect.html
@@ -1,48 +1,45 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <title>Komodo Payment Redirect</title>
 </head>
+
 <body>
   <script>
     // Extract URL parameters and put them into an object
     function getParams() {
-        var params = {};
-        window.location.search.substring(1).split("&").forEach(function (part) {
-            var item = part.split("=");
-            params[item[0]] = decodeURIComponent(item[1]);
-        });
-        return params;
+      var params = {};
+      window.location.search.substring(1).split("&").forEach(function (part) {
+        var item = part.split("=");
+        params[item[0]] = decodeURIComponent(item[1]);
+      });
+      return params;
     }
 
     // Send the parameters to the opener window
     var params = getParams();
-
     var status = params['status'];
 
     console.log('opener: ' + (window.opener?.location?.href ?? 'null'));
-    
+
     if (window.opener != null && !window.opener.closed) {
+      // Temporary work-around because of Banxa checkout bug. We are polling the status of the payment
+      // using the order ID in the main app, but this would be better if we could get the post message
+      // callback to work.
+      if (status == null) {
+        status = 'unknown';
+      }
 
-        // Temporary work-around because of Banxa checkout bug. We are polling the status of the payment
-        // using the order ID in the main app, but this would be better if we could get the post message
-        // callback to work.
-        if (status == null) {
-          status = 'unknown';
-        }
-
-        // Send the parameters to the opener window
-        window.opener.postMessage({ type: 'PAYMENT-STATUS', status: status, params: params }, '*');
-
-        // Change back to the opener tab
-        window.opener.focus();
-
-        // Close this tab
-        window.close();
-    } else {
-        // Navigate to the home page as a fallback
-        window.location.href = 'https://app.komodoplatform.com/';
+      // Send the parameters to the opener window
+      window.opener.postMessage({ type: 'PAYMENT-STATUS', status: status, params: params }, '*');
+      window.opener.focus();
     }
+
+    // Both Ramp and Banxa checkout pages are either opened in a new tab or a popup dialog webview,
+    // so we need to close the current window rather than redirecting back to the website.
+    window.close();
   </script>
 </body>
+
 </html>

--- a/assets/web_pages/fiat_widget.html
+++ b/assets/web_pages/fiat_widget.html
@@ -26,44 +26,79 @@
 
 <body>
   <iframe id="fiat-onramp-iframe"
-    sandbox="allow-same-origin allow-popups allow-scripts allow-forms allow-top-navigation" src="">
+    sandbox="allow-forms allow-scripts allow-same-origin allow-top-navigation allow-top-navigation-by-user-action allow-popups"
+    src="">
+    <!-- Placeholder fallback message -->
+    <p>Your browser does not support iframes.</p>
+    <p>Please use a modern browser to view this content.</p>
+    <p>If you are using a mobile device, please try opening this page in a different app or browser.</p>
+    <p>If you are using a desktop, please try opening this page in a different browser.</p>
   </iframe>
   <script>
     window.onmessage = _komodoOnMessageHandler;
     window.addEventListener('message', _komodoOnMessageHandler, false);
+    window.addEventListener('load', function () {
+      _komodoSetIframeUrlFromParams(_komodoGetUrlParameter('fiatUrl'));
+    });
 
-    function getUrlParameter(name) {
+    /**
+     * Initialize the iframe URL based on URL parameters
+     * 
+     * @param {object} params - The URL parameters to use for initialization
+     */
+    function _komodoSetIframeUrlFromParams(params) {
+      const urlParam = _komodoGetUrlParameter('fiatUrl');
+
+      let targetUrl = null;
+      if (urlParam) {
+        try {
+          targetUrl = atob(urlParam); // base64 decode the `url` parameter
+        } catch (error) {
+          console.error('Error decoding base64 url parameter', error);
+        }
+      }
+
+      if (targetUrl) {
+        document.getElementById('fiat-onramp-iframe').src = targetUrl;
+      } else {
+        console.error('No URL parameter provided');
+      }
+    }
+
+    /**
+     * Get URL parameter by name
+     * 
+     * @param {string} name - The name of the URL parameter to retrieve
+     * @returns {string|null} - The value of the URL parameter or null if not found
+     */
+    function _komodoGetUrlParameter(name) {
       const params = new URLSearchParams(window.location.search);
       return params.get(name);
     }
 
-    const urlParam = getUrlParameter('fiatUrl');
-    let targetUrl = null;
-
-    if (urlParam) {
-      try {
-        targetUrl = atob(urlParam); // base64 decode the `url` parameter
-      } catch (error) {
-        console.error('Error decoding base64 url parameter', error);
-      }
-    }
-
-    if (targetUrl) {
-      document.getElementById('fiat-onramp-iframe').src = targetUrl;
-    } else {
-      console.error('No URL parameter provided');
-    }
-
+    /** 
+     * Handle messages from the iframe
+     * 
+     * @param {MessageEvent} messageEvent 
+     */
     function _komodoOnMessageHandler(messageEvent) {
       let messageData;
       try {
-        messageData = JSON.parse(messageEvent.data);
+        messageData = typeof messageEvent.data === 'string' ? JSON.parse(messageEvent.data) : messageEvent.data;
       } catch (parseError) {
         messageData = messageEvent.data;
       }
 
+      // forward navigation requests to parent
+      if (messageData && typeof messageData === 'object') {
+        if ((messageData.type === 'navigation' || messageData.action === 'checkout_complete') && messageData.url) {
+          window.location.href = messageData.url;
+          return;
+        }
+      }
+
       try {
-        postMessageToParent(messageData);
+        _komodoPostMessageToParent(messageData);
       } catch (postError) {
         console.error('Error posting message', postError);
       }
@@ -74,8 +109,7 @@
      * 
      * @param {string|object} messageData 
      */
-    function postMessageToParent(messageData) {
-      // Convert messageData to a string if it is an object
+    function _komodoPostMessageToParent(messageData) {
       const messageString = (typeof messageData === 'object') ? JSON.stringify(messageData) : String(messageData);
 
       // flutter_inappwebview
@@ -90,7 +124,8 @@
         return window.parent.postMessage(messageString, "*");
       }
 
-      // Windows WebView2 (desktop_webview_window) - https://learn.microsoft.com/en-us/microsoft-edge/webview2/how-to/communicate-btwn-web-native 
+      // Windows WebView2 (desktop_webview_window)
+      // https://learn.microsoft.com/en-us/microsoft-edge/webview2/how-to/communicate-btwn-web-native 
       if (window.chrome && window.chrome.webview) {
         return window.chrome.webview.postMessage(messageString);
       }

--- a/assets/web_pages/fiat_widget.html
+++ b/assets/web_pages/fiat_widget.html
@@ -3,6 +3,7 @@
 
 <head>
   <title>Fiat OnRamp</title>
+  <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <style>
     body,
@@ -25,8 +26,8 @@
 </head>
 
 <body>
-  <iframe id="fiat-onramp-iframe"
-    sandbox="allow-forms allow-scripts allow-same-origin allow-top-navigation allow-top-navigation-by-user-action allow-popups"
+  <iframe id="fiat-onramp-iframe" title="Fiat On-Ramp Widget"
+    sandbox="allow-forms allow-scripts allow-same-origin allow-popups allow-top-navigation allow-top-navigation-by-user-action"
     src="">
     <!-- Placeholder fallback message -->
     <p>Your browser does not support iframes.</p>
@@ -86,14 +87,6 @@
         messageData = typeof messageEvent.data === 'string' ? JSON.parse(messageEvent.data) : messageEvent.data;
       } catch (parseError) {
         messageData = messageEvent.data;
-      }
-
-      // forward navigation requests to parent
-      if (messageData && typeof messageData === 'object') {
-        if ((messageData.type === 'navigation' || messageData.action === 'checkout_complete') && messageData.url) {
-          window.location.href = messageData.url;
-          return;
-        }
       }
 
       try {

--- a/assets/web_pages/fiat_widget.html
+++ b/assets/web_pages/fiat_widget.html
@@ -2,100 +2,102 @@
 <html style="height: 100%;">
 
 <head>
-    <title>Fiat OnRamp</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <style>
-        body,
-        html {
-            margin: 0;
-            padding: 0;
-            height: 100%;
-            overflow: hidden;
-        }
+  <title>Fiat OnRamp</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body,
+    html {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      overflow: hidden;
+    }
 
-        iframe {
-            position: relative;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            border: none;
-        }
-    </style>
+    iframe {
+      position: relative;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      border: none;
+    }
+  </style>
 </head>
 
 <body>
-    <iframe id="fiat-onramp-iframe" sandbox="allow-same-origin allow-popups allow-scripts allow-forms" src="">
-    </iframe>
-    <script>
-        window.onmessage = onMessageHandler;
+  <iframe id="fiat-onramp-iframe"
+    sandbox="allow-same-origin allow-popups allow-scripts allow-forms allow-top-navigation" src="">
+  </iframe>
+  <script>
+    window.onmessage = _komodoOnMessageHandler;
+    window.addEventListener('message', _komodoOnMessageHandler, false);
 
-        function getUrlParameter(name) {
-            const params = new URLSearchParams(window.location.search);
-            return params.get(name);
-        }
+    function getUrlParameter(name) {
+      const params = new URLSearchParams(window.location.search);
+      return params.get(name);
+    }
 
-        const urlParam = getUrlParameter('fiatUrl');
-        let targetUrl = null;
+    const urlParam = getUrlParameter('fiatUrl');
+    let targetUrl = null;
 
-        if (urlParam) {
-            try {
-                targetUrl = atob(urlParam); // base64 decode the `url` parameter
-            } catch (error) {
-                console.error('Error decoding base64 url parameter', error);
-            }
-        }
+    if (urlParam) {
+      try {
+        targetUrl = atob(urlParam); // base64 decode the `url` parameter
+      } catch (error) {
+        console.error('Error decoding base64 url parameter', error);
+      }
+    }
 
-        if (targetUrl) {
-            document.getElementById('fiat-onramp-iframe').src = targetUrl;
-        } else {
-            console.error('No URL parameter provided');
-        }
+    if (targetUrl) {
+      document.getElementById('fiat-onramp-iframe').src = targetUrl;
+    } else {
+      console.error('No URL parameter provided');
+    }
 
-        function onMessageHandler(messageEvent) {
-            let messageData;
-            try {
-                messageData = JSON.parse(messageEvent.data);
-            } catch (parseError) {
-                messageData = messageEvent.data;
-            }
+    function _komodoOnMessageHandler(messageEvent) {
+      let messageData;
+      try {
+        messageData = JSON.parse(messageEvent.data);
+      } catch (parseError) {
+        messageData = messageEvent.data;
+      }
 
-            try {
-                postMessageToParent(messageData);
-            } catch (postError) {
-                console.error('Error posting message', postError);
-            }
-        }
+      try {
+        postMessageToParent(messageData);
+      } catch (postError) {
+        console.error('Error posting message', postError);
+      }
+    }
 
-        /** 
-         * Post a message to the parent window
-         * 
-         * @param {string|object} messageData 
-         */
-        function postMessageToParent(messageData) {
-            // Convert messageData to a string if it is an object
-            const messageString = (typeof messageData === 'object') ? JSON.stringify(messageData) : String(messageData);
+    /** 
+     * Post a message to the parent window
+     * 
+     * @param {string|object} messageData 
+     */
+    function postMessageToParent(messageData) {
+      // Convert messageData to a string if it is an object
+      const messageString = (typeof messageData === 'object') ? JSON.stringify(messageData) : String(messageData);
 
-            // flutter_inappwebview
-            console.log(messageString);
+      // flutter_inappwebview
+      console.log(messageString);
 
-            // universal_url opener 
-            if (window.opener) {
-                return window.opener.postMessage(messageString, "*");
-            }
+      // universal_url opener 
+      if (window.opener) {
+        return window.opener.postMessage(messageString, "*");
+      }
 
-            if (window.parent && window.parent !== window) {
-                return window.parent.postMessage(messageString, "*");
-            }
+      if (window.parent && window.parent !== window) {
+        return window.parent.postMessage(messageString, "*");
+      }
 
-            // Windows WebView2 (desktop_webview_window) - https://learn.microsoft.com/en-us/microsoft-edge/webview2/how-to/communicate-btwn-web-native 
-            if (window.chrome && window.chrome.webview) {
-                return window.chrome.webview.postMessage(messageString);
-            }
+      // Windows WebView2 (desktop_webview_window) - https://learn.microsoft.com/en-us/microsoft-edge/webview2/how-to/communicate-btwn-web-native 
+      if (window.chrome && window.chrome.webview) {
+        return window.chrome.webview.postMessage(messageString);
+      }
 
-            console.error('No valid postMessage target found');
-        }
-    </script>
+      console.error('No valid postMessage target found');
+    }
+  </script>
 </body>
 
 </html>

--- a/assets/web_pages/fiat_widget.html
+++ b/assets/web_pages/fiat_widget.html
@@ -35,10 +35,9 @@
     <p>If you are using a desktop, please try opening this page in a different browser.</p>
   </iframe>
   <script>
-    window.onmessage = _komodoOnMessageHandler;
     window.addEventListener('message', _komodoOnMessageHandler, false);
     window.addEventListener('load', function () {
-      _komodoSetIframeUrlFromParams(_komodoGetUrlParameter('fiatUrl'));
+      _komodoSetIframeUrlFromParams();
     });
 
     /**
@@ -46,7 +45,7 @@
      * 
      * @param {object} params - The URL parameters to use for initialization
      */
-    function _komodoSetIframeUrlFromParams(params) {
+    function _komodoSetIframeUrlFromParams() {
       const urlParam = _komodoGetUrlParameter('fiatUrl');
 
       let targetUrl = null;

--- a/assets/web_pages/fiat_widget.html
+++ b/assets/web_pages/fiat_widget.html
@@ -47,7 +47,6 @@
         }
 
         if (targetUrl) {
-            // Set the iframe's src attribute
             document.getElementById('fiat-onramp-iframe').src = targetUrl;
         } else {
             console.error('No URL parameter provided');

--- a/assets/web_pages/fiat_widget.html
+++ b/assets/web_pages/fiat_widget.html
@@ -28,11 +28,6 @@
     <iframe id="fiat-onramp-iframe" sandbox="allow-same-origin allow-popups allow-scripts allow-forms" src="">
     </iframe>
     <script>
-        // Intercept console.log messages and route them through the onMessageHandler
-        // console.log = function (...args) {
-        //     onMessageHandler({ data: JSON.stringify(args) });
-        // };
-
         window.onmessage = onMessageHandler;
 
         function getUrlParameter(name) {
@@ -40,7 +35,6 @@
             return params.get(name);
         }
 
-        // Get the `url` parameter
         const urlParam = getUrlParameter('fiatUrl');
         let targetUrl = null;
 
@@ -62,10 +56,8 @@
         function onMessageHandler(messageEvent) {
             let messageData;
             try {
-                // Try parsing the data as JSON 
                 messageData = JSON.parse(messageEvent.data);
             } catch (parseError) {
-                // If parsing fails, just use it as a string
                 messageData = messageEvent.data;
             }
 

--- a/lib/app_config/app_config.dart
+++ b/lib/app_config/app_config.dart
@@ -99,6 +99,24 @@ const List<String> excludedAssetListTrezor = [
   'VAL',
 ];
 
+/// Some coins returned by the Banxa API are returning errors when attempting
+/// to create an order. This is a temporary workaround to filter out those coins
+/// until the issue is resolved.
+const banxaUnsupportedCoinsList = [
+  'APE', // chain not configured for APE
+  'AVAX', // avax & bep20 - invalid wallet address error
+  'DOT', // bep20 - invalid wallet address error
+  'FIL', // bep20 - invalid wallet address error
+  'ONE', // invalid wallet address error (one14**** format expected)
+  'TON', // erc20 - invalid wallet address error
+  'TRC', // bep20 - invalid wallet address error
+  'XML', // invalid wallet address error
+];
+
+const rampUnsupportedCoinsList = [
+  'ONE', // invalid wallet address error (one14**** format expected)
+];
+
 // Assets in wallet-only mode on app level,
 // global wallet-only assets are defined in coins config files.
 const List<String> appWalletOnlyAssetList = [

--- a/lib/app_config/app_config.dart
+++ b/lib/app_config/app_config.dart
@@ -107,14 +107,14 @@ const banxaUnsupportedCoinsList = [
   'AVAX', // avax & bep20 - invalid wallet address error
   'DOT', // bep20 - invalid wallet address error
   'FIL', // bep20 - invalid wallet address error
-  'ONE', // invalid wallet address error (one14**** format expected)
+  'ONE', // invalid wallet address error (one**** (native) format expected)
   'TON', // erc20 - invalid wallet address error
-  'TRC', // bep20 - invalid wallet address error
+  'TRX', // bep20 - invalid wallet address error
   'XML', // invalid wallet address error
 ];
 
 const rampUnsupportedCoinsList = [
-  'ONE', // invalid wallet address error (one14**** format expected)
+  'ONE', // invalid wallet address error (one**** format expected)
 ];
 
 // Assets in wallet-only mode on app level,

--- a/lib/bloc/fiat/banxa_fiat_provider.dart
+++ b/lib/bloc/fiat/banxa_fiat_provider.dart
@@ -24,7 +24,7 @@ class BanxaFiatProvider extends BaseFiatProvider {
   FiatOrderStatus _parseStatusFromResponse(Map<String, dynamic> response) {
     final statusString = response['data']?['order']?['status'] as String?;
 
-    return _parseOrderStatus(statusString ?? '');
+    return FiatOrderStatus.fromString(statusString ?? '');
   }
 
   Future<dynamic> _getPaymentMethods(
@@ -95,34 +95,6 @@ class BanxaFiatProvider extends BaseFiatProvider {
           'orderType': 'buy',
         },
       );
-
-  FiatOrderStatus _parseOrderStatus(String status) {
-    // The case statements are references to Banxa's order statuses. See the
-    // docs link here for more info: https://docs.banxa.com/docs/order-status
-    switch (status) {
-      case 'complete':
-        return FiatOrderStatus.success;
-
-      case 'cancelled':
-      case 'declined':
-      case 'expired':
-      case 'refunded':
-        return FiatOrderStatus.failed;
-
-      case 'extraVerification':
-      case 'pendingPayment':
-      case 'waitingPayment':
-        return FiatOrderStatus.pendingPayment;
-
-      case 'paymentReceived':
-      case 'inProgress':
-      case 'coinTransferred':
-        return FiatOrderStatus.inProgress;
-
-      default:
-        throw Exception('Unknown status: $status');
-    }
-  }
 
   // These will be in BLOC:
   @override

--- a/lib/bloc/fiat/banxa_fiat_provider.dart
+++ b/lib/bloc/fiat/banxa_fiat_provider.dart
@@ -112,7 +112,7 @@ class BanxaFiatProvider extends BaseFiatProvider {
       case 'extraVerification':
       case 'pendingPayment':
       case 'waitingPayment':
-        return FiatOrderStatus.pending;
+        return FiatOrderStatus.pendingPayment;
 
       case 'paymentReceived':
       case 'inProgress':

--- a/lib/bloc/fiat/banxa_fiat_provider.dart
+++ b/lib/bloc/fiat/banxa_fiat_provider.dart
@@ -182,9 +182,9 @@ class BanxaFiatProvider extends BaseFiatProvider {
         } else {
           // Default to zero for any other unexpected types
           minPurchaseAmount = Decimal.fromInt(0);
-          // ignore: lines_longer_than_80_chars
           _log.warning(
-              'Unexpected type for min_value: ${minValue.runtimeType}');
+            'Unexpected type for min_value: ${minValue.runtimeType}',
+          );
         }
 
         currencyList.add(
@@ -208,6 +208,11 @@ class BanxaFiatProvider extends BaseFiatProvider {
     String sourceAmount,
   ) async {
     try {
+      if (banxaUnsupportedCoinsList.contains(target.configSymbol)) {
+        _log.warning('Banxa does not support ${target.configSymbol}');
+        return [];
+      }
+
       final response =
           await _getPaymentMethods(source, target, sourceAmount: sourceAmount);
       final List<FiatPaymentMethod> paymentMethods = (response['data']

--- a/lib/bloc/fiat/banxa_fiat_provider.dart
+++ b/lib/bloc/fiat/banxa_fiat_provider.dart
@@ -153,6 +153,11 @@ class BanxaFiatProvider extends BaseFiatProvider {
     final List<CryptoCurrency> currencyList = [];
     for (final item in data) {
       final coinCode = item['coin_code'] as String;
+      if (banxaUnsupportedCoinsList.contains(coinCode)) {
+        _log.warning('Banxa does not support $coinCode');
+        continue;
+      }
+
       final coinName = item['coin_name'] as String;
       final blockchains = item['blockchains'] as List<dynamic>;
 

--- a/lib/bloc/fiat/base_fiat_provider.dart
+++ b/lib/bloc/fiat/base_fiat_provider.dart
@@ -58,11 +58,6 @@ abstract class BaseFiatProvider {
     final domainUri = Uri.parse(domain);
     Uri url;
 
-    // Remove the leading '/' if it exists in /api/fiats kind of an endpoint
-    if (endpoint.startsWith('/')) {
-      endpoint = endpoint.substring(1);
-    }
-
     // Add `is_test_mode` query param to all requests if we are in debug mode
     final passedQueryParams = <String, dynamic>{}
       ..addAll(queryParams ?? {})
@@ -73,7 +68,8 @@ abstract class BaseFiatProvider {
     url = Uri(
       scheme: domainUri.scheme,
       host: domainUri.host,
-      path: endpoint,
+      // Remove the leading '/' if it exists in /api/fiats kind of an endpoint
+      path: endpoint.startsWith('/') ? endpoint.substring(1) : endpoint,
       query: Uri(queryParameters: passedQueryParams).query,
     );
 
@@ -138,7 +134,6 @@ abstract class BaseFiatProvider {
         return 'MATIC';
       case CoinType.mvr20:
         return 'MOVR';
-      // ignore: no_default_cases
       default:
         return null;
     }

--- a/lib/bloc/fiat/base_fiat_provider.dart
+++ b/lib/bloc/fiat/base_fiat_provider.dart
@@ -235,6 +235,7 @@ abstract class BaseFiatProvider {
         return CoinType.etc;
       case 'FTM':
         return CoinType.ftm20;
+      case 'ARBITRUM':
       case 'ARB':
         return CoinType.arb20;
       case 'HARMONY':

--- a/lib/bloc/fiat/base_fiat_provider.dart
+++ b/lib/bloc/fiat/base_fiat_provider.dart
@@ -98,7 +98,13 @@ abstract class BaseFiatProvider {
         return json.decode(response.body);
       } else {
         _log.warning('Request failed with status: ${response.statusCode}');
-        return Future.error(json.decode(response.body) as Object);
+        dynamic decoded;
+        try {
+          decoded = json.decode(response.body);
+        } catch (_) {
+          decoded = response.body;
+        }
+        return Future.error(decoded as Object);
       }
     } catch (e, s) {
       _log.severe('Network error', e, s);

--- a/lib/bloc/fiat/fiat_onramp_form/fiat_form_bloc.dart
+++ b/lib/bloc/fiat/fiat_onramp_form/fiat_form_bloc.dart
@@ -249,8 +249,8 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
           return state;
         }
 
-        final asset =
-            _sdk.getSdkAsset(state.selectedAsset.value?.getAbbr() ?? 'BTC-segwit');
+        final asset = _sdk
+            .getSdkAsset(state.selectedAsset.value?.getAbbr() ?? 'BTC-segwit');
         final pubkeys = await _sdk.pubkeys.getPubkeys(asset);
         final address = pubkeys.keys.firstOrNull;
 
@@ -431,6 +431,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
       checkoutUrl: '',
       status: FiatFormStatus.failure,
       fiatOrderStatus: FiatOrderStatus.failed,
+      providerError: () => error.title,
     );
   }
 
@@ -472,6 +473,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
 
     yield state.copyWith(
       fiatAmount: _getAmountInputWithBounds(state.fiatAmount.value),
+      providerError: () => null,
     );
 
     try {
@@ -482,6 +484,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
       yield state.copyWith(
         paymentMethods: [],
         status: FiatFormStatus.failure,
+        providerError: () => null,
       );
     }
   }
@@ -491,6 +494,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
       yield state.copyWith(
         status: FiatFormStatus.loading,
         fiatOrderStatus: FiatOrderStatus.initial,
+        providerError: () => null,
       );
     } else {
       yield _defaultPaymentMethods();
@@ -513,6 +517,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
       yield state.copyWith(
         paymentMethods: [],
         status: FiatFormStatus.failure,
+        providerError: () => null,
       );
     }
   }
@@ -544,6 +549,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
           paymentMethods: methods,
           selectedPaymentMethod: method,
           status: FiatFormStatus.success,
+          providerError: () => null,
           fiatAmount: _getAmountInputWithBounds(
             state.fiatAmount.value,
             selectedPaymentMethod: method,
@@ -551,10 +557,16 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
         );
       }
 
-      return state.copyWith(status: FiatFormStatus.success);
+      return state.copyWith(
+        status: FiatFormStatus.success,
+        providerError: () => null,
+      );
     } catch (e, s) {
       _log.shout('Error updating payment methods', e, s);
-      return state.copyWith(paymentMethods: []);
+      return state.copyWith(
+        paymentMethods: [],
+        providerError: () => null,
+      );
     }
   }
 
@@ -564,6 +576,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
       selectedPaymentMethod: defaultFiatPaymentMethods.first,
       status: FiatFormStatus.initial,
       fiatOrderStatus: FiatOrderStatus.initial,
+      providerError: () => null,
     );
   }
 }

--- a/lib/bloc/fiat/fiat_onramp_form/fiat_form_bloc.dart
+++ b/lib/bloc/fiat/fiat_onramp_form/fiat_form_bloc.dart
@@ -470,7 +470,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
     final fiatAmount = paymentMethod.priceInfo.fiatAmount;
     final minPurchaseAmount =
         state.selectedAsset.value?.minPurchaseAmount ?? Decimal.zero;
-    if (coinAmount < minPurchaseAmount) {
+    if (coinAmount < minPurchaseAmount && coinAmount > Decimal.zero) {
       final minFiatAmount = ((minPurchaseAmount * fiatAmount) / coinAmount)
           .toDecimal(scaleOnInfinitePrecision: 18);
       minAmount = minAmount != null && minAmount > minFiatAmount

--- a/lib/bloc/fiat/fiat_onramp_form/fiat_form_bloc.dart
+++ b/lib/bloc/fiat/fiat_onramp_form/fiat_form_bloc.dart
@@ -210,11 +210,12 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
   WebViewDialogMode _determineWebViewMode() {
     final bool isLinux = !kIsWeb && !kIsWasm && Platform.isLinux;
     const bool isWeb = kIsWeb || kIsWasm;
+    final bool isBanxa = state.selectedPaymentMethod.providerId == 'Banxa';
 
     // Banxa "Return to Komodo" button attempts to navigate the top window to
     // the return URL, which is not supported in a dialog. So we need to open
     // it in a new tab.
-    if (isLinux) {
+    if (isLinux || (isWeb && isBanxa)) {
       return WebViewDialogMode.newTab;
     } else if (isWeb) {
       return WebViewDialogMode.dialog;

--- a/lib/bloc/fiat/fiat_onramp_form/fiat_form_bloc.dart
+++ b/lib/bloc/fiat/fiat_onramp_form/fiat_form_bloc.dart
@@ -182,7 +182,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
       // Only Ramp on web requires the intermediate html page to satisfy cors
       // rules and allow for console.log and postMessage events to be handled.
       // Banxa does not use `postMessage` and does not require this.
-      checkoutUrl = _wrapUrlIfNeeded(checkoutUrl);
+      checkoutUrl = BaseFiatProvider.fiatWrapperPageUrl(checkoutUrl);
       final webViewMode = _determineWebViewMode();
 
       emit(
@@ -211,6 +211,9 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
     final bool isLinux = !kIsWeb && !kIsWasm && Platform.isLinux;
     const bool isWeb = kIsWeb || kIsWasm;
 
+    // Banxa "Return to Komodo" button attempts to navigate the top window to
+    // the return URL, which is not supported in a dialog. So we need to open
+    // it in a new tab.
     if (isLinux) {
       return WebViewDialogMode.newTab;
     } else if (isWeb) {
@@ -218,17 +221,6 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
     } else {
       return WebViewDialogMode.fullscreen;
     }
-  }
-
-  /// Wraps the [url] if needed based on the platform and environment
-  String _wrapUrlIfNeeded(String url) {
-    // Banxa does not post messages to the parent window, so we do not need to
-    // wrap the URL in a HTML page.
-    final bool isBanxa = state.selectedPaymentMethod.providerId == 'Banxa';
-    if (kIsWeb && !isBanxa) {
-      return BaseFiatProvider.fiatWrapperPageUrl(url);
-    }
-    return url;
   }
 
   Future<void> _onRefreshForm(

--- a/lib/bloc/fiat/fiat_onramp_form/fiat_form_bloc.dart
+++ b/lib/bloc/fiat/fiat_onramp_form/fiat_form_bloc.dart
@@ -17,7 +17,6 @@ import 'package:web_dex/bloc/fiat/fiat_order_status.dart';
 import 'package:web_dex/bloc/fiat/fiat_repository.dart';
 import 'package:web_dex/bloc/fiat/models/models.dart';
 import 'package:web_dex/bloc/fiat/payment_status_type.dart';
-import 'package:web_dex/model/coin_type.dart';
 import 'package:web_dex/model/forms/fiat/currency_input.dart';
 import 'package:web_dex/model/forms/fiat/fiat_amount_input.dart';
 import 'package:web_dex/shared/utils/extensions/string_extensions.dart';
@@ -265,7 +264,9 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
             e,
             s,
           );
-          return state.copyWith(selectedAssetAddress: () => null);
+          if (state.selectedAssetAddress == null) {
+            return state.copyWith(selectedAssetAddress: () => null);
+          }
         }
 
         _log.warning(

--- a/lib/bloc/fiat/fiat_onramp_form/fiat_form_bloc.dart
+++ b/lib/bloc/fiat/fiat_onramp_form/fiat_form_bloc.dart
@@ -155,7 +155,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
     try {
       final newOrder = await _fiatRepository.buyCoin(
         accountReference: state.selectedAssetAddress!.address,
-        source: state.selectedFiat.value!.symbol,
+        source: state.selectedFiat.value!.getAbbr(),
         target: state.selectedAsset.value!,
         walletAddress: state.selectedAssetAddress!.address,
         paymentMethod: state.selectedPaymentMethod,
@@ -250,7 +250,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
         }
 
         final asset =
-            _sdk.getSdkAsset(state.selectedAsset.value?.symbol ?? 'BTC-segwit');
+            _sdk.getSdkAsset(state.selectedAsset.value?.getAbbr() ?? 'BTC-segwit');
         final pubkeys = await _sdk.pubkeys.getPubkeys(asset);
         final address = pubkeys.keys.firstOrNull;
 
@@ -499,7 +499,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
 
   Stream<FiatFormState> _fetchAndUpdatePaymentMethods() async* {
     final methodsStream = _fiatRepository.getPaymentMethodsList(
-      state.selectedFiat.value!.symbol,
+      state.selectedFiat.value!.getAbbr(),
       state.selectedAsset.value!,
       _getSourceAmount(),
     );

--- a/lib/bloc/fiat/fiat_onramp_form/fiat_form_state.dart
+++ b/lib/bloc/fiat/fiat_onramp_form/fiat_form_state.dart
@@ -22,6 +22,7 @@ final class FiatFormState extends Equatable with FormzMixin {
     this.fiatMode = FiatMode.onramp,
     this.selectedAssetAddress,
     this.selectedCoinPubkeys,
+    this.webViewMode = WebViewDialogMode.fullscreen,
   });
 
   /// Creates an initial state with default values.
@@ -43,7 +44,8 @@ final class FiatFormState extends Equatable with FormzMixin {
         coinList = const [],
         fiatOrderStatus = FiatOrderStatus.pending,
         fiatMode = FiatMode.onramp,
-        selectedCoinPubkeys = null;
+        selectedCoinPubkeys = null,
+        webViewMode = WebViewDialogMode.fullscreen;
 
   /// The selected fiat currency to use to purchase [selectedAsset].
   final CurrencyInput<FiatCurrency> selectedFiat;
@@ -90,6 +92,9 @@ final class FiatFormState extends Equatable with FormzMixin {
   /// once the order history tab is implemented
   final FiatMode fiatMode;
 
+  /// The mode to use for displaying the WebView dialog
+  final WebViewDialogMode webViewMode;
+
   /// Gets the transaction limit from the selected payment method
   FiatTransactionLimit? get transactionLimit =>
       selectedPaymentMethod.transactionLimits.firstOrNull;
@@ -129,6 +134,7 @@ final class FiatFormState extends Equatable with FormzMixin {
     FiatOrderStatus? fiatOrderStatus,
     FiatMode? fiatMode,
     ValueGetter<AssetPubkeys?>? selectedCoinPubkeys,
+    WebViewDialogMode? webViewMode,
   }) {
     return FiatFormState(
       selectedFiat: selectedFiat ?? this.selectedFiat,
@@ -150,6 +156,7 @@ final class FiatFormState extends Equatable with FormzMixin {
       selectedCoinPubkeys: selectedCoinPubkeys != null
           ? selectedCoinPubkeys()
           : this.selectedCoinPubkeys,
+      webViewMode: webViewMode ?? this.webViewMode,
     );
   }
 
@@ -176,5 +183,6 @@ final class FiatFormState extends Equatable with FormzMixin {
         fiatOrderStatus,
         fiatMode,
         selectedCoinPubkeys,
+        webViewMode,
       ];
 }

--- a/lib/bloc/fiat/fiat_onramp_form/fiat_form_state.dart
+++ b/lib/bloc/fiat/fiat_onramp_form/fiat_form_state.dart
@@ -119,7 +119,7 @@ final class FiatFormState extends Equatable with FormzMixin {
     CurrencyInput<CryptoCurrency>? selectedAsset,
     FiatAmountInput? fiatAmount,
     FiatPaymentMethod? selectedPaymentMethod,
-    PubkeyInfo? selectedAssetAddress,
+    ValueGetter<PubkeyInfo?>? selectedAssetAddress,
     String? checkoutUrl,
     String? orderId,
     FiatFormStatus? status,
@@ -128,14 +128,16 @@ final class FiatFormState extends Equatable with FormzMixin {
     Iterable<CryptoCurrency>? coinList,
     FiatOrderStatus? fiatOrderStatus,
     FiatMode? fiatMode,
-    AssetPubkeys? selectedCoinPubkeys,
+    ValueGetter<AssetPubkeys?>? selectedCoinPubkeys,
   }) {
     return FiatFormState(
       selectedFiat: selectedFiat ?? this.selectedFiat,
       selectedAsset: selectedAsset ?? this.selectedAsset,
       selectedPaymentMethod:
           selectedPaymentMethod ?? this.selectedPaymentMethod,
-      selectedAssetAddress: selectedAssetAddress ?? this.selectedAssetAddress,
+      selectedAssetAddress: selectedAssetAddress != null
+          ? selectedAssetAddress()
+          : this.selectedAssetAddress,
       checkoutUrl: checkoutUrl ?? this.checkoutUrl,
       orderId: orderId ?? this.orderId,
       fiatAmount: fiatAmount ?? this.fiatAmount,
@@ -145,7 +147,9 @@ final class FiatFormState extends Equatable with FormzMixin {
       coinList: coinList ?? this.coinList,
       fiatOrderStatus: fiatOrderStatus ?? this.fiatOrderStatus,
       fiatMode: fiatMode ?? this.fiatMode,
-      selectedCoinPubkeys: selectedCoinPubkeys ?? this.selectedCoinPubkeys,
+      selectedCoinPubkeys: selectedCoinPubkeys != null
+          ? selectedCoinPubkeys()
+          : this.selectedCoinPubkeys,
     );
   }
 

--- a/lib/bloc/fiat/fiat_onramp_form/fiat_form_state.dart
+++ b/lib/bloc/fiat/fiat_onramp_form/fiat_form_state.dart
@@ -28,12 +28,8 @@ final class FiatFormState extends Equatable with FormzMixin {
 
   /// Creates an initial state with default values.
   FiatFormState.initial()
-      : selectedFiat = const CurrencyInput.dirty(
-          FiatCurrency('USD', 'United States Dollar'),
-        ),
-        selectedAsset = const CurrencyInput.dirty(
-          CryptoCurrency('BTC-segwit', 'Bitcoin', CoinType.utxo),
-        ),
+      : selectedFiat = CurrencyInput.dirty(FiatCurrency.usd()),
+        selectedAsset = CurrencyInput.dirty(CryptoCurrency.bitcoin()),
         fiatAmount = const FiatAmountInput.pure(),
         selectedAssetAddress = null,
         selectedPaymentMethod = FiatPaymentMethod.none,
@@ -105,10 +101,10 @@ final class FiatFormState extends Equatable with FormzMixin {
       selectedPaymentMethod.transactionLimits.firstOrNull;
 
   /// The minimum fiat amount that is allowed for the selected payment method
-  Decimal? get minFiatAmount => transactionLimit?.min;
+  Decimal? get minFiatAmount => fiatAmount.minValue ?? transactionLimit?.min;
 
   /// The maximum fiat amount that is allowed for the selected payment method
-  Decimal? get maxFiatAmount => transactionLimit?.max;
+  Decimal? get maxFiatAmount => fiatAmount.maxValue ?? transactionLimit?.max;
 
   /// Whether currencies are still being loaded
   bool get isLoadingCurrencies => fiatList.length < 2 || coinList.length < 2;

--- a/lib/bloc/fiat/fiat_onramp_form/fiat_form_state.dart
+++ b/lib/bloc/fiat/fiat_onramp_form/fiat_form_state.dart
@@ -23,6 +23,7 @@ final class FiatFormState extends Equatable with FormzMixin {
     this.selectedAssetAddress,
     this.selectedCoinPubkeys,
     this.webViewMode = WebViewDialogMode.fullscreen,
+    this.providerError,
   });
 
   /// Creates an initial state with default values.
@@ -45,7 +46,8 @@ final class FiatFormState extends Equatable with FormzMixin {
         fiatOrderStatus = FiatOrderStatus.initial,
         fiatMode = FiatMode.onramp,
         selectedCoinPubkeys = null,
-        webViewMode = WebViewDialogMode.fullscreen;
+        webViewMode = WebViewDialogMode.fullscreen,
+        providerError = null;
 
   /// The selected fiat currency to use to purchase [selectedAsset].
   final CurrencyInput<FiatCurrency> selectedFiat;
@@ -95,6 +97,9 @@ final class FiatFormState extends Equatable with FormzMixin {
   /// The mode to use for displaying the WebView dialog
   final WebViewDialogMode webViewMode;
 
+  /// Raw error message from the provider when there is an order error
+  final String? providerError;
+
   /// Gets the transaction limit from the selected payment method
   FiatTransactionLimit? get transactionLimit =>
       selectedPaymentMethod.transactionLimits.firstOrNull;
@@ -135,6 +140,7 @@ final class FiatFormState extends Equatable with FormzMixin {
     FiatMode? fiatMode,
     ValueGetter<AssetPubkeys?>? selectedCoinPubkeys,
     WebViewDialogMode? webViewMode,
+    ValueGetter<String?>? providerError,
   }) {
     return FiatFormState(
       selectedFiat: selectedFiat ?? this.selectedFiat,
@@ -157,6 +163,8 @@ final class FiatFormState extends Equatable with FormzMixin {
           ? selectedCoinPubkeys()
           : this.selectedCoinPubkeys,
       webViewMode: webViewMode ?? this.webViewMode,
+      providerError:
+          providerError != null ? providerError() : this.providerError,
     );
   }
 
@@ -184,5 +192,6 @@ final class FiatFormState extends Equatable with FormzMixin {
         fiatMode,
         selectedCoinPubkeys,
         webViewMode,
+        providerError,
       ];
 }

--- a/lib/bloc/fiat/fiat_onramp_form/fiat_form_state.dart
+++ b/lib/bloc/fiat/fiat_onramp_form/fiat_form_state.dart
@@ -18,7 +18,7 @@ final class FiatFormState extends Equatable with FormzMixin {
     required this.fiatList,
     required this.coinList,
     this.status = FiatFormStatus.initial,
-    this.fiatOrderStatus = FiatOrderStatus.pending,
+    this.fiatOrderStatus = FiatOrderStatus.initial,
     this.fiatMode = FiatMode.onramp,
     this.selectedAssetAddress,
     this.selectedCoinPubkeys,
@@ -42,7 +42,7 @@ final class FiatFormState extends Equatable with FormzMixin {
         paymentMethods = const [],
         fiatList = const [],
         coinList = const [],
-        fiatOrderStatus = FiatOrderStatus.pending,
+        fiatOrderStatus = FiatOrderStatus.initial,
         fiatMode = FiatMode.onramp,
         selectedCoinPubkeys = null,
         webViewMode = WebViewDialogMode.fullscreen;

--- a/lib/bloc/fiat/fiat_order_status.dart
+++ b/lib/bloc/fiat/fiat_order_status.dart
@@ -28,7 +28,9 @@ enum FiatOrderStatus {
   bool get isTerminal =>
       this == FiatOrderStatus.success || this == FiatOrderStatus.failed;
   bool get isSubmitting =>
-      this == FiatOrderStatus.inProgress || this == FiatOrderStatus.submitted;
+      this == FiatOrderStatus.inProgress ||
+      this == FiatOrderStatus.submitted ||
+      this == FiatOrderStatus.pendingPayment;
   bool get isFailed => this == FiatOrderStatus.failed;
   bool get isSuccess => this == FiatOrderStatus.success;
 
@@ -60,9 +62,13 @@ enum FiatOrderStatus {
         return FiatOrderStatus.inProgress;
 
       default:
+        // Default to in progress if the status is not recognized
+        // to avoid alarming users with "Payment failed" popup messages
+        // unless we are sure that the payment has failed.
+        // Ideally, this section should not be reached.
         Logger('FiatOrderStatus')
-            .warning('Unknown status: $status, defaulting to failed');
-        return FiatOrderStatus.failed;
+            .warning('Unknown status: $status, defaulting to in progress');
+        return FiatOrderStatus.inProgress;
     }
   }
 }

--- a/lib/bloc/fiat/fiat_order_status.dart
+++ b/lib/bloc/fiat/fiat_order_status.dart
@@ -2,12 +2,15 @@
 import 'package:logging/logging.dart';
 
 enum FiatOrderStatus {
-  /// User has not yet started the payment process
-  pending,
+  /// Initial status: User has not yet started the payment process
+  initial,
 
   /// User has started the process, and the payment method has been opened.
   /// E.g. Ramp or Banxa websites have been opened
   submitted,
+
+  /// Payment is awaiting user action (e.g., user needs to complete payment)
+  pendingPayment,
 
   /// Payment has been submitted with the provider, and is being processed
   inProgress,
@@ -48,7 +51,7 @@ enum FiatOrderStatus {
       case 'extraVerification':
       case 'pendingPayment':
       case 'waitingPayment':
-        return FiatOrderStatus.pending;
+        return FiatOrderStatus.pendingPayment;
 
       case 'paymentReceived':
       case 'inProgress':

--- a/lib/bloc/fiat/fiat_order_status.dart
+++ b/lib/bloc/fiat/fiat_order_status.dart
@@ -1,4 +1,6 @@
 // TODO: Differentiate between different error and in-progress statuses
+import 'package:logging/logging.dart';
+
 enum FiatOrderStatus {
   /// User has not yet started the payment process
   pending,
@@ -14,9 +16,9 @@ enum FiatOrderStatus {
   success,
 
   /// Payment has been cancelled, declined, expired or refunded
-  failed, 
-  
-  /// The user closed the payment window using the provider close button 
+  failed,
+
+  /// The user closed the payment window using the provider close button
   /// or "return to Komodo Wallet" button
   windowCloseRequested;
 
@@ -32,7 +34,8 @@ enum FiatOrderStatus {
   static FiatOrderStatus fromString(String status) {
     // The case statements are references to Banxa's order statuses. See the
     // docs link here for more info: https://docs.banxa.com/docs/order-status
-    switch (status) {
+    final normalized = status.toLowerCase();
+    switch (normalized) {
       case 'complete':
         return FiatOrderStatus.success;
 
@@ -53,7 +56,9 @@ enum FiatOrderStatus {
         return FiatOrderStatus.inProgress;
 
       default:
-        throw Exception('Unknown status: $status');
+        Logger('FiatOrderStatus')
+            .warning('Unknown status: $status, defaulting to failed');
+        return FiatOrderStatus.failed;
     }
   }
 }

--- a/lib/bloc/fiat/fiat_order_status.dart
+++ b/lib/bloc/fiat/fiat_order_status.dart
@@ -48,14 +48,15 @@ enum FiatOrderStatus {
       case 'refunded':
         return FiatOrderStatus.failed;
 
-      case 'extraVerification':
-      case 'pendingPayment':
-      case 'waitingPayment':
+      case 'extraverification':
+      case 'pendingpayment':
+      case 'waitingpayment':
         return FiatOrderStatus.pendingPayment;
 
-      case 'paymentReceived':
-      case 'inProgress':
-      case 'coinTransferred':
+      case 'paymentreceived':
+      case 'inprogress':
+      case 'cointransferred':
+      case 'cryptotransferred':
         return FiatOrderStatus.inProgress;
 
       default:

--- a/lib/bloc/fiat/fiat_repository.dart
+++ b/lib/bloc/fiat/fiat_repository.dart
@@ -50,8 +50,12 @@ class FiatRepository {
 
     for (final currencyList in results) {
       for (final currency in currencyList) {
-        bool isCoinUnknown() => !knownCoins.containsKey(currency.getAbbr());
-        if (isCoin && (currency.isFiat || isCoinUnknown())) {
+        final isCoinSupported = knownCoins.containsKey(currency.getAbbr());
+        if (isCoin && (currency.isFiat || !isCoinSupported)) {
+          _log.fine(
+            'Skipping ${currency.getAbbr()} because it is not a coin or '
+            'not supported (${currency.configSymbol})',
+          );
           continue;
         }
 

--- a/lib/bloc/fiat/fiat_repository.dart
+++ b/lib/bloc/fiat/fiat_repository.dart
@@ -1,5 +1,4 @@
 import 'package:decimal/decimal.dart';
-import 'package:universal_html/html.dart';
 import 'package:web_dex/app_config/app_config.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_repo.dart';
 import 'package:web_dex/bloc/fiat/base_fiat_provider.dart';
@@ -252,15 +251,15 @@ class FiatRepository {
     );
   }
 
-  Future<FiatBuyOrderInfo> buyCoin(
-    String accountReference,
-    String source,
-    ICurrency target,
-    String walletAddress,
-    FiatPaymentMethod paymentMethod,
-    String sourceAmount,
-    String returnUrlOnSuccess,
-  ) async {
+  Future<FiatBuyOrderInfo> buyCoin({
+    required String accountReference,
+    required String source,
+    required ICurrency target,
+    required String walletAddress,
+    required FiatPaymentMethod paymentMethod,
+    required String sourceAmount,
+    required String returnUrlOnSuccess,
+  }) async {
     final provider = _getPaymentMethodProvider(paymentMethod);
     if (provider == null) return Future.error('Provider not found');
 

--- a/lib/bloc/fiat/models/fiat_buy_order_error.dart
+++ b/lib/bloc/fiat/models/fiat_buy_order_error.dart
@@ -18,6 +18,11 @@ class FiatBuyOrderError extends Equatable {
 
   const FiatBuyOrderError.none() : this(code: 0, status: 0, title: '');
 
+  /// Error indicating a parsing issue with the response data
+  const FiatBuyOrderError.parsing({
+    String message = 'Failed to parse response data',
+  }) : this(code: -1, status: 400, title: message);
+
   bool get isNone => this == const FiatBuyOrderError.none();
 
   final int code;

--- a/lib/bloc/fiat/models/fiat_buy_order_info.dart
+++ b/lib/bloc/fiat/models/fiat_buy_order_info.dart
@@ -59,12 +59,21 @@ class FiatBuyOrderInfo extends Equatable {
 
   factory FiatBuyOrderInfo.fromJson(Map<String, dynamic> json) {
     final jsonData = json['data'] as Map<String, dynamic>?;
-    if (json['data'] == null || jsonData?['order'] == null) {
+    final errors = json['errors'] as Map<String, dynamic>?;
+
+    if (json['data'] == null && errors == null) {
       return FiatBuyOrderInfo.empty().copyWith(
         error:
             const FiatBuyOrderError.parsing(message: 'Missing order payload'),
       );
     }
+
+    if (jsonData == null && errors != null) {
+      return FiatBuyOrderInfo.empty().copyWith(
+        error: FiatBuyOrderError.fromJson(errors),
+      );
+    }
+
     final data = jsonData!['order'] as Map<String, dynamic>;
 
     return FiatBuyOrderInfo(
@@ -81,8 +90,8 @@ class FiatBuyOrderInfo extends Equatable {
       paymentCode: data['payment_code'] as String? ?? '',
       checkoutUrl: data['checkout_url'] as String? ?? '',
       createdAt: assertString(data['created_at']) ?? '',
-      error: data['errors'] != null
-          ? FiatBuyOrderError.fromJson(data['errors'] as Map<String, dynamic>)
+      error: errors != null
+          ? FiatBuyOrderError.fromJson(errors)
           : const FiatBuyOrderError.none(),
     );
   }

--- a/lib/bloc/fiat/models/fiat_buy_order_info.dart
+++ b/lib/bloc/fiat/models/fiat_buy_order_info.dart
@@ -21,24 +21,6 @@ class FiatBuyOrderInfo extends Equatable {
     required this.error,
   });
 
-  FiatBuyOrderInfo.info()
-      : this(
-          id: '',
-          accountId: '',
-          accountReference: '',
-          orderType: '',
-          fiatCode: '',
-          fiatAmount: Decimal.zero,
-          coinCode: '',
-          walletAddress: '',
-          extAccountId: '',
-          network: '',
-          paymentCode: '',
-          checkoutUrl: '',
-          createdAt: '',
-          error: const FiatBuyOrderError.none(),
-        );
-
   FiatBuyOrderInfo.fromCheckoutUrl(String url)
       : this(
           id: '',
@@ -57,12 +39,33 @@ class FiatBuyOrderInfo extends Equatable {
           error: const FiatBuyOrderError.none(),
         );
 
+  FiatBuyOrderInfo.empty()
+      : this(
+          id: '',
+          accountId: '',
+          accountReference: '',
+          orderType: '',
+          fiatCode: '',
+          fiatAmount: Decimal.zero,
+          coinCode: '',
+          walletAddress: '',
+          extAccountId: '',
+          network: '',
+          paymentCode: '',
+          checkoutUrl: '',
+          createdAt: '',
+          error: const FiatBuyOrderError.none(),
+        );
+
   factory FiatBuyOrderInfo.fromJson(Map<String, dynamic> json) {
-    Map<String, dynamic> data = json;
-    if (json['data'] != null) {
-      final orderData = json['data'] as Map<String, dynamic>? ?? {};
-      data = orderData['order'] as Map<String, dynamic>? ?? {};
+    final jsonData = json['data'] as Map<String, dynamic>?;
+    if (json['data'] == null || jsonData?['order'] == null) {
+      return FiatBuyOrderInfo.empty().copyWith(
+        error:
+            const FiatBuyOrderError.parsing(message: 'Missing order payload'),
+      );
     }
+    final data = jsonData!['order'] as Map<String, dynamic>;
 
     return FiatBuyOrderInfo(
       id: data['id'] as String? ?? '',

--- a/lib/bloc/fiat/models/fiat_price_info.dart
+++ b/lib/bloc/fiat/models/fiat_price_info.dart
@@ -10,6 +10,17 @@ class FiatPriceInfo extends Equatable {
     required this.spotPriceIncludingFee,
   });
 
+  factory FiatPriceInfo.fromJson(Map<String, dynamic> json) {
+    return FiatPriceInfo(
+      fiatAmount: _safeParseDecimal(json['fiat_amount']),
+      coinAmount: _safeParseDecimal(json['coin_amount']),
+      fiatCode: json['fiat_code'] as String? ?? '',
+      coinCode: json['coin_code'] as String? ?? '',
+      spotPriceIncludingFee:
+          _safeParseDecimal(json['spot_price_including_fee']),
+    );
+  }
+
   static final zero = FiatPriceInfo(
     fiatAmount: Decimal.zero,
     coinAmount: Decimal.zero,
@@ -17,17 +28,6 @@ class FiatPriceInfo extends Equatable {
     coinCode: '',
     spotPriceIncludingFee: Decimal.zero,
   );
-
-  factory FiatPriceInfo.fromJson(Map<String, dynamic> json) {
-    return FiatPriceInfo(
-      fiatAmount: Decimal.parse(json['fiat_amount']?.toString() ?? '0'),
-      coinAmount: Decimal.parse(json['coin_amount']?.toString() ?? '0'),
-      fiatCode: json['fiat_code'] as String? ?? '',
-      coinCode: json['coin_code'] as String? ?? '',
-      spotPriceIncludingFee:
-          Decimal.parse(json['spot_price_including_fee']?.toString() ?? '0'),
-    );
-  }
 
   final Decimal fiatAmount;
   final Decimal coinAmount;
@@ -60,6 +60,14 @@ class FiatPriceInfo extends Equatable {
       'coin_code': coinCode,
       'spot_price_including_fee': spotPriceIncludingFee.toString(),
     };
+  }
+
+  static Decimal _safeParseDecimal(dynamic value) {
+    try {
+      return Decimal.parse(value?.toString() ?? '0');
+    } on FormatException {
+      return Decimal.zero;
+    }
   }
 
   @override

--- a/lib/bloc/fiat/models/i_currency.dart
+++ b/lib/bloc/fiat/models/i_currency.dart
@@ -1,3 +1,4 @@
+import 'package:decimal/decimal.dart';
 import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 import 'package:web_dex/bloc/coins_bloc/asset_coin_extension.dart';
@@ -6,10 +7,23 @@ import 'package:web_dex/model/coin_utils.dart';
 
 /// Base class for all currencies
 abstract class ICurrency {
-  const ICurrency(this.symbol, this.name);
+  const ICurrency({
+    required this.symbol,
+    required this.name,
+    required this.minPurchaseAmount,
+  });
 
+  /// The symbol/code of the currency (e.g. BTC, USD). Note that this usually
+  /// excludes any chain identifiers like "-segwit" or "-erc20".
   final String symbol;
+
+  /// The full name of the currency (e.g. Bitcoin, US Dollar).
   final String name;
+
+  /// The minimum purchase amount for this currency. This is used to
+  /// determine the minimum amount that can be purchased in a fiat
+  /// transaction.
+  final Decimal minPurchaseAmount;
 
   /// Returns true if the currency is a fiat currency (e.g. USD)
   bool get isFiat;
@@ -29,11 +43,22 @@ abstract class ICurrency {
   ICurrency copyWith({
     String? symbol,
     String? name,
+    Decimal? minPurchaseAmount,
   });
 }
 
 class FiatCurrency extends ICurrency {
-  const FiatCurrency(super.symbol, super.name);
+  const FiatCurrency({
+    required super.symbol,
+    required super.name,
+    required super.minPurchaseAmount,
+  });
+
+  factory FiatCurrency.usd() => FiatCurrency(
+        symbol: 'USD',
+        name: 'United States Dollar',
+        minPurchaseAmount: Decimal.zero,
+      );
 
   @override
   bool get isFiat => true;
@@ -48,23 +73,41 @@ class FiatCurrency extends ICurrency {
   FiatCurrency copyWith({
     String? symbol,
     String? name,
+    Decimal? minPurchaseAmount,
   }) {
     return FiatCurrency(
-      symbol ?? this.symbol,
-      name ?? this.name,
+      symbol: symbol ?? this.symbol,
+      name: name ?? this.name,
+      minPurchaseAmount: minPurchaseAmount ?? this.minPurchaseAmount,
     );
   }
 }
 
 class CryptoCurrency extends ICurrency {
-  const CryptoCurrency(super.symbol, super.name, this.chainType);
+  const CryptoCurrency({
+    required super.symbol,
+    required super.name,
+    required this.chainType,
+    required super.minPurchaseAmount,
+  });
 
-  factory CryptoCurrency.fromAsset(Asset asset) {
+  factory CryptoCurrency.bitcoin() => CryptoCurrency(
+        symbol: 'BTC-segwit',
+        name: 'Bitcoin',
+        chainType: CoinType.utxo,
+        minPurchaseAmount: Decimal.zero,
+      );
+
+  factory CryptoCurrency.fromAsset(
+    Asset asset, {
+    required Decimal minPurchaseAmount,
+  }) {
     final coin = asset.toCoin();
     return CryptoCurrency(
-      coin.id.id,
-      coin.name,
-      coin.type,
+      symbol: coin.id.id,
+      name: coin.name,
+      chainType: coin.type,
+      minPurchaseAmount: minPurchaseAmount,
     );
   }
 
@@ -118,11 +161,13 @@ class CryptoCurrency extends ICurrency {
     String? symbol,
     String? name,
     CoinType? chainType,
+    Decimal? minPurchaseAmount,
   }) {
     return CryptoCurrency(
-      symbol ?? this.symbol,
-      name ?? this.name,
-      chainType ?? this.chainType,
+      symbol: symbol ?? this.symbol,
+      name: name ?? this.name,
+      chainType: chainType ?? this.chainType,
+      minPurchaseAmount: minPurchaseAmount ?? this.minPurchaseAmount,
     );
   }
 }

--- a/lib/bloc/fiat/models/i_currency.dart
+++ b/lib/bloc/fiat/models/i_currency.dart
@@ -41,7 +41,6 @@ class FiatCurrency extends ICurrency {
   @override
   bool get isCrypto => false;
 
-  
   @override
   String get configSymbol => symbol;
 
@@ -82,10 +81,26 @@ class CryptoCurrency extends ICurrency {
 
   @override
   String getAbbr() {
-    return symbol;
+    // TODO: look into a better way to do this when migrating to the SDK
+    // Providers return "ETH" with chain type "ERC20", resultning in abbr of
+    // "ETH-ERC20", which is not how it is stored in our coins configuration
+    // files. "ETH" is the expected abbreviation, which would just be `symbol`.
+    if (chainType == CoinType.utxo ||
+        (chainType == CoinType.cosmos && symbol == 'ATOM') ||
+        (chainType == CoinType.erc20 && symbol == 'ETH') ||
+        (chainType == CoinType.bep20 && symbol == 'BNB') ||
+        (chainType == CoinType.avx20 && symbol == 'AVAX') ||
+        (chainType == CoinType.etc && symbol == 'ETC') ||
+        (chainType == CoinType.ftm20 && symbol == 'FTM') ||
+        (chainType == CoinType.arb20 && symbol == 'ARB') ||
+        (chainType == CoinType.hrc20 && symbol == 'ONE') ||
+        (chainType == CoinType.plg20 && symbol == 'MATIC') ||
+        (chainType == CoinType.mvr20 && symbol == 'MOVR') ||
+        (chainType == CoinType.krc20 && symbol == 'KCS')) {
+      return symbol;
+    }
 
-    // TODO: figure out if this is still necessary
-    // return '$symbol-${getCoinTypeName(chainType).replaceAll('-', '')}';
+    return '$symbol-${getCoinTypeName(chainType).replaceAll('-', '')}';
   }
 
   @override

--- a/lib/bloc/fiat/payment_status_type.dart
+++ b/lib/bloc/fiat/payment_status_type.dart
@@ -1,17 +1,17 @@
 enum PaymentStatusType {
-  widgetClose("WIDGET_CLOSE"),
-  widgetConfigDone("WIDGET_CONFIG_DONE"),
-  widgetConfigFailed("WIDGET_CONFIG_FAILED"),
-  widgetCloseRequest("WIDGET_CLOSE_REQUEST"),
-  widgetCloseRequestCancelled("WIDGET_CLOSE_REQUEST_CANCELLED"),
-  widgetCloseRequestConfirmed("WIDGET_CLOSE_REQUEST_CONFIRMED"),
-  purchaseCreated("PURCHASE_CREATED"),
-  offrampSaleCreated("OFFRAMP_SALE_CREATED"),
-  paymentStatus("PAYMENT-STATUS");
-
-  final String value;
+  widgetClose('WIDGET_CLOSE'),
+  widgetConfigDone('WIDGET_CONFIG_DONE'),
+  widgetConfigFailed('WIDGET_CONFIG_FAILED'),
+  widgetCloseRequest('WIDGET_CLOSE_REQUEST'),
+  widgetCloseRequestCancelled('WIDGET_CLOSE_REQUEST_CANCELLED'),
+  widgetCloseRequestConfirmed('WIDGET_CLOSE_REQUEST_CONFIRMED'),
+  purchaseCreated('PURCHASE_CREATED'),
+  offrampSaleCreated('OFFRAMP_SALE_CREATED'),
+  paymentStatus('PAYMENT-STATUS');
 
   const PaymentStatusType(this.value);
+
+  final String value;
 
   /// Creates a RampWidgetStatusEvents from a JSON input
   static PaymentStatusType fromJson(Map<String, dynamic> json) {
@@ -21,7 +21,7 @@ enum PaymentStatusType {
       if (json.containsKey('type')) {
         typeValue = json['type'] as String;
       } else {
-        throw FormatException('Missing "type" field in JSON object');
+        throw const FormatException('Missing "type" field in JSON object');
       }
 
       return PaymentStatusType.values.firstWhere(

--- a/lib/bloc/fiat/ramp/models/ramp_asset_info.dart
+++ b/lib/bloc/fiat/ramp/models/ramp_asset_info.dart
@@ -58,9 +58,6 @@ class RampAssetInfo {
     required this.symbol,
     required this.decimals,
     required this.price,
-    this.minPurchaseAmount,
-    this.maxPurchaseAmount,
-    this.address,
     required this.chain,
     required this.currencyCode,
     required this.enabled,
@@ -69,6 +66,9 @@ class RampAssetInfo {
     required this.minPurchaseCryptoAmount,
     required this.networkFee,
     required this.type,
+    this.minPurchaseAmount,
+    this.maxPurchaseAmount,
+    this.address,
   });
 
   /// Returns true if this asset has a valid minimum purchase amount.

--- a/lib/bloc/fiat/ramp/ramp_fiat_provider.dart
+++ b/lib/bloc/fiat/ramp/ramp_fiat_provider.dart
@@ -124,6 +124,11 @@ class RampFiatProvider extends BaseFiatProvider {
             return null;
           }
 
+          if (rampUnsupportedCoinsList.contains(item['symbol'] as String)) {
+            _log.warning('Ramp does not support ${item['symbol']}');
+            return null;
+          }
+
           // Parse minPurchaseAmount which can be a string, int, or double
           final dynamic minValue = item['minPurchaseAmount'];
           Decimal minPurchaseAmount;
@@ -140,7 +145,8 @@ class RampFiatProvider extends BaseFiatProvider {
             // Default to zero for any other unexpected types
             minPurchaseAmount = Decimal.fromInt(0);
             _log.warning(
-                'Unexpected type for minPurchaseAmount: ${minValue.runtimeType}',);
+              'Unexpected type for minPurchaseAmount: ${minValue.runtimeType}',
+            );
           }
 
           return CryptoCurrency(

--- a/lib/bloc/fiat/ramp/ramp_fiat_provider.dart
+++ b/lib/bloc/fiat/ramp/ramp_fiat_provider.dart
@@ -298,6 +298,8 @@ class RampFiatProvider extends BaseFiatProvider {
       'fiatCurrency': source,
       'fiatValue': sourceAmount,
       'defaultAsset': getFullCoinCode(target),
+      'hideExitButton': 'true',
+      // 'variant': 'hosted', // desktop, mobile, auto, hosted-mobile
       // if(coinsBloc.walletCoins.isNotEmpty)
       //   "swapAsset": coinsBloc.walletCoins.map((e) => e.abbr).toList().toString(),
       // "swapAsset": fullAssetCode, // This limits the crypto asset list at the redirect page

--- a/lib/shared/widgets/coin_item/coin_item.dart
+++ b/lib/shared/widgets/coin_item/coin_item.dart
@@ -6,8 +6,8 @@ import 'package:web_dex/shared/widgets/coin_item/coin_logo.dart';
 
 class CoinItem extends StatelessWidget {
   const CoinItem({
-    super.key,
     required this.coin,
+    super.key,
     this.amount,
     this.size = CoinItemSize.medium,
     this.subtitleText,

--- a/lib/views/fiat/fiat_asset_icon.dart
+++ b/lib/views/fiat/fiat_asset_icon.dart
@@ -24,12 +24,15 @@ class FiatAssetIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (currency.isFiat) {
-      return FiatIcon(symbol: currency.symbol);
+      return FiatIcon(symbol: currency.getAbbr());
     }
 
+    // TODO: standardise the icon layout. CoinItem contains the icon and the 
+    // coin name + protocol, but the provided icon Widget could be anything
+    // and on failure it's usually just the Icon
     if (assetExists ?? false) {
       final sdk = RepositoryProvider.of<KomodoDefiSdk>(context);
-      final asset = sdk.getSdkAsset(currency.symbol);
+      final asset = sdk.getSdkAsset(currency.getAbbr());
       return CoinItem(coin: asset.toCoin(), size: CoinItemSize.large);
     } else {
       return icon;

--- a/lib/views/fiat/fiat_currency_list_tile.dart
+++ b/lib/views/fiat/fiat_currency_list_tile.dart
@@ -51,7 +51,7 @@ class FiatCurrencyListTile extends StatelessWidget {
                 ),
               ],
             )
-          : SizedBox.shrink(),
+          : const SizedBox.shrink(),
       onTap: onTap,
     );
   }

--- a/lib/views/fiat/fiat_form.dart
+++ b/lib/views/fiat/fiat_form.dart
@@ -221,16 +221,18 @@ class _FiatFormState extends State<FiatForm> {
     }
 
     if (status != FiatOrderStatus.initial) {
-      await _showPaymentStatusDialog(status);
+      await _showPaymentStatusDialog(stateSnapshot);
     }
   }
 
-  Future<void> _showPaymentStatusDialog(FiatOrderStatus status) async {
+  Future<void> _showPaymentStatusDialog(FiatFormState state) async {
     if (!mounted) return;
 
     String? title;
     String? content;
     Icon? icon;
+
+    final status = state.fiatOrderStatus;
 
     switch (status) {
       case FiatOrderStatus.inProgress:
@@ -250,6 +252,10 @@ class _FiatFormState extends State<FiatForm> {
       case FiatOrderStatus.failed:
         title = LocaleKeys.fiatPaymentFailedTitle.tr();
         content = LocaleKeys.fiatPaymentFailedMessage.tr();
+        if (state.providerError != null && state.providerError!.isNotEmpty) {
+          content = '$content\n\n${LocaleKeys.errorDetails.tr()}: '
+              '${state.providerError}';
+        }
         icon = const Icon(Icons.error_outline, color: Colors.red);
     }
 

--- a/lib/views/fiat/fiat_form.dart
+++ b/lib/views/fiat/fiat_form.dart
@@ -8,7 +8,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
-import 'package:web_dex/bloc/coins_bloc/coins_bloc.dart';
 import 'package:web_dex/bloc/fiat/base_fiat_provider.dart';
 import 'package:web_dex/bloc/fiat/fiat_onramp_form/fiat_form_bloc.dart';
 import 'package:web_dex/bloc/fiat/fiat_order_status.dart';
@@ -152,7 +151,7 @@ class _FiatFormState extends State<FiatForm> {
   }
 
   void _completeOrder() =>
-      context.read<FiatFormBloc>().add(FiatFormSubmitted());
+      context.read<FiatFormBloc>().add(const FiatFormSubmitted());
 
   void _onFiatChanged(FiatCurrency value) => context.read<FiatFormBloc>()
     ..add(FiatFormFiatSelected(value))
@@ -230,7 +229,6 @@ class _FiatFormState extends State<FiatForm> {
 
     final status = stateSnapshot.fiatOrderStatus;
     if (status == FiatOrderStatus.submitted) {
-      // ignore: use_build_context_synchronously
       context.read<FiatFormBloc>().add(const FiatFormOrderStatusWatchStarted());
       await _openCheckoutPage(stateSnapshot.checkoutUrl, stateSnapshot.orderId);
       return;
@@ -285,6 +283,7 @@ class _FiatFormState extends State<FiatForm> {
 
     await showAdaptiveDialog<void>(
       context: context,
+      barrierDismissible: true,
       builder: (context) => AlertDialog.adaptive(
         title: Text(title!),
         icon: icon,

--- a/lib/views/fiat/fiat_form.dart
+++ b/lib/views/fiat/fiat_form.dart
@@ -288,7 +288,7 @@ extension on FiatAmountValidationError {
       case FiatAmountValidationError.belowMinimum:
         return LocaleKeys.fiatMinimumAmount.tr(
           args: [
-            state.minFiatAmount?.toString() ?? '',
+            state.minFiatAmount?.toStringAsFixed(2) ?? '',
             fiatId,
           ],
         );

--- a/lib/views/fiat/fiat_form.dart
+++ b/lib/views/fiat/fiat_form.dart
@@ -232,7 +232,7 @@ class _FiatFormState extends State<FiatForm> {
       Navigator.of(context).pop();
     }
 
-    if (status != FiatOrderStatus.pending) {
+    if (status != FiatOrderStatus.initial) {
       await _showPaymentStatusDialog(status);
     }
   }
@@ -242,14 +242,13 @@ class _FiatFormState extends State<FiatForm> {
 
     String? title;
     String? content;
-
-    // TODO: Use theme-based semantic colors
     Icon? icon;
 
     switch (status) {
       case FiatOrderStatus.inProgress:
       case FiatOrderStatus.windowCloseRequested:
-      case FiatOrderStatus.pending:
+      case FiatOrderStatus.initial:
+      case FiatOrderStatus.pendingPayment:
         debugPrint('Pending status should not be shown in dialog.');
         return;
       case FiatOrderStatus.submitted:

--- a/lib/views/fiat/fiat_form.dart
+++ b/lib/views/fiat/fiat_form.dart
@@ -2,13 +2,11 @@ import 'dart:async';
 
 import 'package:app_theme/app_theme.dart';
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
-import 'package:web_dex/bloc/fiat/base_fiat_provider.dart';
 import 'package:web_dex/bloc/fiat/fiat_onramp_form/fiat_form_bloc.dart';
 import 'package:web_dex/bloc/fiat/fiat_order_status.dart';
 import 'package:web_dex/bloc/fiat/models/fiat_mode.dart';
@@ -21,6 +19,7 @@ import 'package:web_dex/shared/widgets/connect_wallet/connect_wallet_wrapper.dar
 import 'package:web_dex/views/fiat/fiat_action_tab.dart';
 import 'package:web_dex/views/fiat/fiat_inputs.dart';
 import 'package:web_dex/views/fiat/fiat_payment_methods_grid.dart';
+import 'package:web_dex/views/fiat/fiat_provider_web_view_settings.dart';
 import 'package:web_dex/views/fiat/webview_dialog.dart';
 import 'package:web_dex/views/wallets_manager/wallets_manager_events_factory.dart';
 
@@ -184,14 +183,6 @@ class _FiatFormState extends State<FiatForm> {
     }
   }
 
-  void _showOrderFailedSnackbar() {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(LocaleKeys.orderFailedTryAgain.tr()),
-      ),
-    );
-  }
-
   void _onConsoleMessage(String message) {
     context
         .read<FiatFormBloc>()
@@ -219,13 +210,10 @@ class _FiatFormState extends State<FiatForm> {
         url: stateSnapshot.checkoutUrl,
         mode: stateSnapshot.webViewMode,
         title: LocaleKeys.buy.tr(),
-        onConsoleMessage: _onConsoleMessage,
+        onMessage: _onConsoleMessage,
         onCloseWindow: _onCloseWebView,
+        settings: FiatProviderWebViewSettings.createSecureProviderSettings(),
       );
-    }
-
-    if (status == FiatOrderStatus.failed) {
-      _showOrderFailedSnackbar();
     }
 
     if (status == FiatOrderStatus.windowCloseRequested) {

--- a/lib/views/fiat/fiat_inputs.dart
+++ b/lib/views/fiat/fiat_inputs.dart
@@ -135,8 +135,8 @@ class FiatInputsState extends State<FiatInputs> {
             disabled: fiatListLoading,
             currency: widget.initialFiat,
             icon: FiatIcon(
-              key: Key('fiat_icon_${widget.initialFiat.symbol}'),
-              symbol: widget.initialFiat.symbol,
+              key: Key('fiat_icon_${widget.initialFiat.getAbbr()}'),
+              symbol: widget.initialFiat.getAbbr(),
             ),
             onTap: () => _showAssetSelectionDialog('fiat'),
             isListTile: false,

--- a/lib/views/fiat/fiat_inputs.dart
+++ b/lib/views/fiat/fiat_inputs.dart
@@ -116,10 +116,12 @@ class FiatInputsState extends State<FiatInputs> {
     final fiatListLoading = widget.fiatList.length <= 1;
     final coinListLoading = widget.coinList.length <= 1;
 
-    final boundariesString = widget.fiatMaxAmount == null &&
-            widget.fiatMinAmount == null
-        ? ''
-        : '(${widget.fiatMinAmount ?? '1'} - ${widget.fiatMaxAmount ?? '∞'})';
+    final minFiatAmount = widget.fiatMinAmount?.toStringAsFixed(2);
+    final maxFiatAmount = widget.fiatMaxAmount?.toStringAsFixed(2);
+    final boundariesString =
+        widget.fiatMaxAmount == null && widget.fiatMinAmount == null
+            ? ''
+            : '(${minFiatAmount ?? '1'} - ${maxFiatAmount ?? '∞'})';
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [

--- a/lib/views/fiat/fiat_payment_methods_grid.dart
+++ b/lib/views/fiat/fiat_payment_methods_grid.dart
@@ -43,8 +43,8 @@ class FiatPaymentMethodsGrid extends StatelessWidget {
         child: Text(
           LocaleKeys.noOptionsToPurchase.tr(
             args: [
-              state.selectedAsset.value!.symbol,
-              state.selectedFiat.value!.symbol,
+              state.selectedAsset.value!.getAbbr(),
+              state.selectedFiat.value!.getAbbr(),
             ],
           ),
           textAlign: TextAlign.center,

--- a/lib/views/fiat/fiat_provider_web_view_settings.dart
+++ b/lib/views/fiat/fiat_provider_web_view_settings.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+/// Default trusted domains for the WebView content blockers
+const List<String> kDefaultTrustedDomainFilters = [
+  r'komodo\.banxa\.com.*',
+  r'app\.demo\.ramp\.network.*',
+  r'app\.ramp\.network.*',
+  r'embed\.bitrefill\.com.*',
+];
+
+/// Factory methods for creating webview settings for specific providers
+class FiatProviderWebViewSettings {
+  /// Creates secure webview settings for fiat providers like Banxa, Ramp, etc.
+  ///
+  /// The [trustedDomainFilters] parameter allows filtering content to only
+  /// trusted domains for security.
+  static InAppWebViewSettings createSecureProviderSettings({
+    List<String> trustedDomainFilters = kDefaultTrustedDomainFilters,
+  }) {
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+    return InAppWebViewSettings(
+      isInspectable: kDebugMode,
+      iframeSandbox: {
+        // Required for cookies and localStorage access
+        Sandbox.ALLOW_SAME_ORIGIN,
+        // Required for dynamic iframe content to load in Banxa and Ramp
+        // webviews.
+        Sandbox.ALLOW_SCRIPTS,
+        // Required for Ramp and Banxa form submissions throughout the KYC
+        // and payment process.
+        Sandbox.ALLOW_FORMS,
+        // Required for Ramp "Check transaction status" button after payment
+        // to work.
+        Sandbox.ALLOW_POPUPS,
+        // Deliberately NOT including ALLOW_TOP_NAVIGATION to prevent
+        // parent navigation
+      },
+      contentBlockers: [
+        // Block all content by default
+        ContentBlocker(
+          trigger: ContentBlockerTrigger(
+            urlFilter: '.*',
+          ),
+          action: ContentBlockerAction(
+            type: ContentBlockerActionType.BLOCK,
+          ),
+        ),
+        // Allow the specific domains we trust
+        ...trustedDomainFilters.map(
+          (urlFilter) => ContentBlocker(
+            trigger: ContentBlockerTrigger(
+              urlFilter: urlFilter,
+            ),
+            action: ContentBlockerAction(
+              type: ContentBlockerActionType.IGNORE_PREVIOUS_RULES,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/views/fiat/webview_dialog.dart
+++ b/lib/views/fiat/webview_dialog.dart
@@ -7,6 +7,11 @@ import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/shared/utils/utils.dart';
 
 class WebViewDialog {
+  /// Shows a webview dialog with the given [url] and [title].
+  /// The [onConsoleMessage] callback is called with the console messages from
+  /// the webview.
+  /// The [onCloseWindow] callback is called when the webview is closed.
+  /// The [settings] parameter allows you to customize [InAppWebViewSettings]
   static Future<void> show(
     BuildContext context, {
     required String url,
@@ -84,9 +89,10 @@ class InAppWebviewDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return Dialog(
       shape: RoundedRectangleBorder(
-        borderRadius:
-            BorderRadius.circular(12.0), // Match your app's corner radius
+        borderRadius: BorderRadius.circular(12.0),
       ),
+      insetPadding:
+          const EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0),
       child: SizedBox(
         width: 700,
         height: 700,
@@ -156,6 +162,13 @@ class FullscreenInAppWebview extends StatelessWidget {
         title: Text(title),
         foregroundColor: Theme.of(context).textTheme.bodyMedium?.color,
         elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () {
+            onCloseWindow?.call();
+            Navigator.of(context).pop();
+          },
+        ),
       ),
       body: SafeArea(
         child: MessageInAppWebView(
@@ -204,22 +217,22 @@ class _MessageInAppWebviewState extends State<MessageInAppWebView> {
       onLoadStop: (controller, url) async {
         await controller.evaluateJavascript(
           source: '''
-            window.addEventListener("message", (event) => {
-              let messageData;
-              try {
-                  messageData = JSON.parse(event.data);
-              } catch (parseError) {
-                  messageData = event.data;
-              }
+              window.addEventListener("message", (event) => {
+                let messageData;
+                try {
+                    messageData = JSON.parse(event.data);
+                } catch (parseError) {
+                    messageData = event.data;
+                }
 
-              try {
-                const messageString = (typeof messageData === 'object') ? JSON.stringify(messageData) : String(messageData);
-                console.log(messageString);
-              } catch (postError) {
-                  console.error('Error posting message', postError);
-              }
-            }, false);
-          ''',
+                try {
+                  const messageString = (typeof messageData === 'object') ? JSON.stringify(messageData) : String(messageData);
+                  console.log(messageString);
+                } catch (postError) {
+                    console.error('Error posting message', postError);
+                }
+              }, false);
+            ''',
         );
       },
     );

--- a/lib/views/fiat/webview_dialog.dart
+++ b/lib/views/fiat/webview_dialog.dart
@@ -59,7 +59,7 @@ class WebViewDialog {
     final bool shouldOpenInNewTab =
         resolvedMode == WebViewDialogMode.newTab || isLinux;
     if (shouldOpenInNewTab) {
-      await launchURLString(url);
+      await launchURLString(url, inSeparateTab: true);
       return;
     }
 

--- a/lib/views/fiat/webview_dialog.dart
+++ b/lib/views/fiat/webview_dialog.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/shared/utils/utils.dart';
+import 'package:web_dex/shared/utils/window/window.dart';
 
 enum WebViewDialogMode {
   dialog,
@@ -276,7 +277,7 @@ class _MessageInAppWebviewState extends State<MessageInAppWebView> {
     WebUri? url,
     bool? isReload,
   ) {
-    if (url.toString() == 'https://app.komodoplatform.com/') {
+    if (url.toString() == getOriginUrl()) {
       Navigator.of(context).pop();
     }
   }


### PR DESCRIPTION
Fixes the issues mentioned in [#2570](https://github.com/KomodoPlatform/komodo-wallet/pull/2570#issuecomment-2800411995) where the Banxa flow incorrectly triggered a payment failed popup and failed to do anything when the button was pressed. The "Komodo" text appears to be linked to the partner name configured on the Banxa dashboard.

We are pinned to Banxa API v1.3. Further adjustments would be required to migrate to v2 (v2.1 being the latest). Ramp also has newer API versions that we could upgrade to (v2 and v3).

## Changes

- Banxa page now opens in a new tab rather than a webview dialog to circumvent dialog/popup z-order issues.
- Fixed a coin abbreviation/ticker parsing regression, so there are now more coins available in the coin selection dropdown (mostly from [Banxa](https://docs.banxa.com/docs/available-cryptocurrencies-and-blockchains))
- The provider error response is now shown if order creation fails when clicking "Buy Now". Incorrect address formats and minimum coin amounts are likely reasons for this, and the additional information could help with debugging/support.
- Improved documentation/explanation comments, refactoring, and implementation of coderabbitai recommendations around error handling from main PR
- Disabled the following coins due to address format errors, mostly on Banxa's side (done in [app_config.dart](https://github.com/KomodoPlatform/komodo-wallet/pull/2608/files#diff-3e5d75c494efdef3049c274ec12518d4a8f4bc56a7562faf1caa8425821c4b5e))
  <details>
  <summary>Disabled coins for fiat onramp</summary>
  
  Banxa:
  | Coin | Reason |
  |------|--------|
  | APE | Chain not configured for APE |
  | AVAX | Invalid wallet address error (avax & bep20) |
  | DOT | Invalid wallet address error (bep20) |
  | FIL | Invalid wallet address error (bep20) |
  | ONE | Invalid wallet address error (one**** native format expected) |
  | TON | Invalid wallet address error (erc20) |
  | TRX | Invalid wallet address error (bep20) |
  | XML | Invalid wallet address error |
  
  Ramp:
  | Coin | Reason |
  |------|--------|
  | ONE | Invalid wallet address error (one14**** format expected) |

  </details>

## Demo environment limitations

Due to limitations with Banxa demo environment, testing with real fiat transfers is required to confirm that the payment failure popup is not shown when payment succeeds.

Both Ramp and Banxa stop or fail before completing the mock transaction (no final success status).

<details>
<summary>Banxa & Ramp limitations</summary>

  - Ramp has test coins that are not currently displayed and will require significant changes to display (dynamic custom token importing or adding Ramp test network coins to `coins` config file).
  - Banxa returns a "cancelled" (failure) status at the end of the demo transaction flow, resulting in the failure popup being shown.
  
 </details>

<details>
<summary>Banxa demo testing information *Updated*</summary>

Banxa [demo testing information](https://docs.banxa.com/v1.3/docs/testing-information) can be used to test local `debug` builds up until the payment processing step. Note that Banxa returns a payment failed status at the end, so the payment failure popup is expected in the local `debug` builds with the demo environment.

- Select USD as the payment currency
- Verification code (Email or SMS): 7203
- Credit card: 4111 1111 1111 1111 (any expiry + CVV combination into the future should work)
- Identification number if required: Use one of the [country-specific demo identity numbers](https://docs.banxa.com/v1.3/docs/testing-information#local-payment-methods)
</details>

<details>
<summary>Ramp demo testing information</summary>

Note: The demo environment does not release funds currently, so the transaction status will remain in the "Processing transaction" state, and the transaction will not succeed.

1. Select "EUR" as the currency
2. Select an EVM coin in the "You Receive" dropdown (e.g. ETH, MATIC, BNB, etc.)
3. Select "Manual Bank Transfer" as the payment method.
4. Proceed with the payment, and select "I have transferred the funds" to complete the transaction.
5. Click on "Check transaction status", which should open a new tab with the transaction status window
6. Click on "Release the funds (test environments only)
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced multiple display modes for fiat payment webviews: dialog, fullscreen, and new browser tab/external browser.
  - Added secure webview settings restricting content to trusted payment provider domains.
  - Improved iframe sandbox permissions and added fallback content for unsupported browsers.

- **Improvements**
  - Enhanced payment status tracking with new and renamed statuses for clearer state representation.
  - Streamlined payment flow and webview handling for consistent cross-platform experience.
  - Improved error handling and JSON parsing for fiat order responses.
  - Strengthened type safety and input validation in fiat provider integrations.
  - Updated state management with lazy evaluation and platform-aware webview mode selection.
  - Refined fiat currency symbol abbreviation logic for consistency.
  - Enhanced UI components to use standardized currency abbreviations.
  - Added filtering and logging for unsupported coins in fiat providers.
  - Improved minimum purchase amount handling across currencies and payment methods.
  - Enhanced error reporting with provider-specific messages in payment dialogs.
  - Added new constants listing unsupported coins for Banxa and Ramp providers.

- **Bug Fixes**
  - Fixed error handling when parsing response data from fiat providers.

- **Refactor**
  - Modularized and clarified JavaScript and Dart code for maintainability.
  - Removed unused methods and imports to clean up the codebase.
  - Simplified webview message handling and removed redundant injected scripts.
  - Reordered constructor parameters for clarity without behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->