### PR TITLE
test: KDF `dev` branch with coins `chain-id-struct` branch 

### DIFF
--- a/packages/komodo_ui_kit/pubspec.lock
+++ b/packages/komodo_ui_kit/pubspec.lock
@@ -95,7 +95,7 @@ packages:
     description:
       path: "packages/komodo_defi_rpc_methods"
       ref: "test/chain-id-dev"
-      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
+      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -104,7 +104,7 @@ packages:
     description:
       path: "packages/komodo_defi_types"
       ref: "test/chain-id-dev"
-      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
+      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -113,7 +113,7 @@ packages:
     description:
       path: "packages/komodo_ui"
       ref: "test/chain-id-dev"
-      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
+      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"

--- a/packages/komodo_ui_kit/pubspec.lock
+++ b/packages/komodo_ui_kit/pubspec.lock
@@ -94,8 +94,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/komodo_defi_rpc_methods"
-      ref: dev
-      resolved-ref: "51e4f0e933c5a28bc3a3dd04fbdb2104c1b7c105"
+      ref: "test/chain-id-dev"
+      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -103,8 +103,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/komodo_defi_types"
-      ref: dev
-      resolved-ref: "51e4f0e933c5a28bc3a3dd04fbdb2104c1b7c105"
+      ref: "test/chain-id-dev"
+      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -112,8 +112,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/komodo_ui"
-      ref: dev
-      resolved-ref: "51e4f0e933c5a28bc3a3dd04fbdb2104c1b7c105"
+      ref: "test/chain-id-dev"
+      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"

--- a/packages/komodo_ui_kit/pubspec.lock
+++ b/packages/komodo_ui_kit/pubspec.lock
@@ -95,7 +95,7 @@ packages:
     description:
       path: "packages/komodo_defi_rpc_methods"
       ref: "test/chain-id-dev"
-      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
+      resolved-ref: "39145ec9b8010e9b3854443f9b0afb95edfdd188"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -104,7 +104,7 @@ packages:
     description:
       path: "packages/komodo_defi_types"
       ref: "test/chain-id-dev"
-      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
+      resolved-ref: "39145ec9b8010e9b3854443f9b0afb95edfdd188"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -113,7 +113,7 @@ packages:
     description:
       path: "packages/komodo_ui"
       ref: "test/chain-id-dev"
-      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
+      resolved-ref: "39145ec9b8010e9b3854443f9b0afb95edfdd188"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"

--- a/packages/komodo_ui_kit/pubspec.yaml
+++ b/packages/komodo_ui_kit/pubspec.yaml
@@ -18,14 +18,14 @@ dependencies:
     git:
       url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
       path: packages/komodo_defi_types
-      ref: dev
+      ref: test/chain-id-dev
 
   komodo_ui:
     # path: ../../sdk/packages/komodo_ui # Requires symlink to the SDK in the root of the project
     git:
       url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
       path: packages/komodo_ui
-      ref: dev
+      ref: test/chain-id-dev
 
 dev_dependencies:
   flutter_lints: ^5.0.0 # flutter.dev

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -648,7 +648,7 @@ packages:
     description:
       path: "packages/komodo_cex_market_data"
       ref: "test/chain-id-dev"
-      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
+      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.0.1"
@@ -657,7 +657,7 @@ packages:
     description:
       path: "packages/komodo_coins"
       ref: "test/chain-id-dev"
-      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
+      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -666,7 +666,7 @@ packages:
     description:
       path: "packages/komodo_defi_framework"
       ref: "test/chain-id-dev"
-      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
+      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0"
@@ -675,7 +675,7 @@ packages:
     description:
       path: "packages/komodo_defi_local_auth"
       ref: "test/chain-id-dev"
-      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
+      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -684,7 +684,7 @@ packages:
     description:
       path: "packages/komodo_defi_rpc_methods"
       ref: "test/chain-id-dev"
-      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
+      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -693,7 +693,7 @@ packages:
     description:
       path: "packages/komodo_defi_sdk"
       ref: "test/chain-id-dev"
-      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
+      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -702,7 +702,7 @@ packages:
     description:
       path: "packages/komodo_defi_types"
       ref: "test/chain-id-dev"
-      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
+      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -718,7 +718,7 @@ packages:
     description:
       path: "packages/komodo_ui"
       ref: "test/chain-id-dev"
-      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
+      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -734,7 +734,7 @@ packages:
     description:
       path: "packages/komodo_wallet_build_transformer"
       ref: "test/chain-id-dev"
-      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
+      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -862,10 +862,10 @@ packages:
     dependency: transitive
     description:
       name: mobile_scanner
-      sha256: "9cb9e371ee9b5b548714f9ab5fd33b530d799745c83d5729ecd1e8ab2935dbd1"
+      sha256: f536c5b8cadcf73d764bdce09c94744f06aa832264730f8971b21a60c5666826
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.7"
+    version: "6.0.10"
   mutex:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -648,7 +648,7 @@ packages:
     description:
       path: "packages/komodo_cex_market_data"
       ref: "test/chain-id-dev"
-      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
+      resolved-ref: "39145ec9b8010e9b3854443f9b0afb95edfdd188"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.0.1"
@@ -657,7 +657,7 @@ packages:
     description:
       path: "packages/komodo_coins"
       ref: "test/chain-id-dev"
-      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
+      resolved-ref: "39145ec9b8010e9b3854443f9b0afb95edfdd188"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -666,7 +666,7 @@ packages:
     description:
       path: "packages/komodo_defi_framework"
       ref: "test/chain-id-dev"
-      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
+      resolved-ref: "39145ec9b8010e9b3854443f9b0afb95edfdd188"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0"
@@ -675,7 +675,7 @@ packages:
     description:
       path: "packages/komodo_defi_local_auth"
       ref: "test/chain-id-dev"
-      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
+      resolved-ref: "39145ec9b8010e9b3854443f9b0afb95edfdd188"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -684,7 +684,7 @@ packages:
     description:
       path: "packages/komodo_defi_rpc_methods"
       ref: "test/chain-id-dev"
-      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
+      resolved-ref: "39145ec9b8010e9b3854443f9b0afb95edfdd188"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -693,7 +693,7 @@ packages:
     description:
       path: "packages/komodo_defi_sdk"
       ref: "test/chain-id-dev"
-      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
+      resolved-ref: "39145ec9b8010e9b3854443f9b0afb95edfdd188"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -702,7 +702,7 @@ packages:
     description:
       path: "packages/komodo_defi_types"
       ref: "test/chain-id-dev"
-      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
+      resolved-ref: "39145ec9b8010e9b3854443f9b0afb95edfdd188"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -718,7 +718,7 @@ packages:
     description:
       path: "packages/komodo_ui"
       ref: "test/chain-id-dev"
-      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
+      resolved-ref: "39145ec9b8010e9b3854443f9b0afb95edfdd188"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -734,7 +734,7 @@ packages:
     description:
       path: "packages/komodo_wallet_build_transformer"
       ref: "test/chain-id-dev"
-      resolved-ref: "4b65d4f45a7159277ecf5ad70adeb64468974790"
+      resolved-ref: "39145ec9b8010e9b3854443f9b0afb95edfdd188"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -647,8 +647,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/komodo_cex_market_data"
-      ref: dev
-      resolved-ref: "51e4f0e933c5a28bc3a3dd04fbdb2104c1b7c105"
+      ref: "test/chain-id-dev"
+      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.0.1"
@@ -656,8 +656,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/komodo_coins"
-      ref: dev
-      resolved-ref: "51e4f0e933c5a28bc3a3dd04fbdb2104c1b7c105"
+      ref: "test/chain-id-dev"
+      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -665,8 +665,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/komodo_defi_framework"
-      ref: dev
-      resolved-ref: "51e4f0e933c5a28bc3a3dd04fbdb2104c1b7c105"
+      ref: "test/chain-id-dev"
+      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0"
@@ -674,8 +674,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/komodo_defi_local_auth"
-      ref: dev
-      resolved-ref: "51e4f0e933c5a28bc3a3dd04fbdb2104c1b7c105"
+      ref: "test/chain-id-dev"
+      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -683,8 +683,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/komodo_defi_rpc_methods"
-      ref: dev
-      resolved-ref: "51e4f0e933c5a28bc3a3dd04fbdb2104c1b7c105"
+      ref: "test/chain-id-dev"
+      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -692,8 +692,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/komodo_defi_sdk"
-      ref: dev
-      resolved-ref: "51e4f0e933c5a28bc3a3dd04fbdb2104c1b7c105"
+      ref: "test/chain-id-dev"
+      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -701,8 +701,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/komodo_defi_types"
-      ref: dev
-      resolved-ref: "51e4f0e933c5a28bc3a3dd04fbdb2104c1b7c105"
+      ref: "test/chain-id-dev"
+      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -717,8 +717,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/komodo_ui"
-      ref: dev
-      resolved-ref: "51e4f0e933c5a28bc3a3dd04fbdb2104c1b7c105"
+      ref: "test/chain-id-dev"
+      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -733,8 +733,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/komodo_wallet_build_transformer"
-      ref: dev
-      resolved-ref: "51e4f0e933c5a28bc3a3dd04fbdb2104c1b7c105"
+      ref: "test/chain-id-dev"
+      resolved-ref: "5834fd4c0ff164533264c29cbc136c3735c6c142"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
     git:
       url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
       path: packages/komodo_cex_market_data
-      ref: dev
+      ref: test/chain-id-dev
 
   ## ---- KomodoPlatform pub.dev packages (First-party)
 
@@ -145,21 +145,21 @@ dependencies:
     git:
       url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
       path: packages/komodo_defi_sdk
-      ref: dev
+      ref: test/chain-id-dev
 
   komodo_defi_types:
     # path: sdk/packages/komodo_defi_types # Requires symlink to the SDK in the root of the project
     git:
       url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
       path: packages/komodo_defi_types
-      ref: dev
+      ref: test/chain-id-dev
 
   komodo_ui:
     # path: sdk/packages/komodo_ui # Requires symlink to the SDK in the root of the project
     git:
       url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
       path: packages/komodo_ui
-      ref: dev
+      ref: test/chain-id-dev
   feedback: ^3.1.0
 
 dev_dependencies:


### PR DESCRIPTION
KDF branch: `dev`
KDF commit: `ecb17ecf1a8b8fdded17e68f378856285acea4e1`

NOTE: 
- The coins and coins config are both downloaded at runtime from the following URLs: 
  - https://raw.githubusercontent.com/KomodoPlatform/coins/refs/heads/chain-id-struct/coins
  - https://raw.githubusercontent.com/KomodoPlatform/coins/refs/heads/chain-id-struct/utils/coins_config_unfiltered.json
- Refreshing the page should fetch the latest config from GitHub, so no CI rebuild is required for changes to the coins repo branch.

Coin icons (png) are statically linked to the following branch and commit:

- coins branch: `chain-id-struct`
- coins commit: `ae2c6a5bd477216bdea92e76e4b3b2fb29e9ba0f`