### PR TITLE
feat: v0.9.2 trading feature changes

### DIFF
--- a/lib/app_config/app_config.dart
+++ b/lib/app_config/app_config.dart
@@ -30,7 +30,7 @@ const bool isBitrefillIntegrationEnabled = false;
 ///! You are solely responsible for any losses/damage that may occur. Komodo
 ///! Platform does not condone the use of this app for trading purposes and
 ///! unequivocally forbids it.
-const bool kIsWalletOnly = !kDebugMode;
+const bool kIsWalletOnly = false;
 
 const Duration kPerformanceLogInterval = Duration(minutes: 1);
 

--- a/lib/app_config/app_config.dart
+++ b/lib/app_config/app_config.dart
@@ -31,6 +31,7 @@ const bool isBitrefillIntegrationEnabled = false;
 ///! Platform does not condone the use of this app for trading purposes and
 ///! unequivocally forbids it.
 const bool kIsWalletOnly = false;
+const bool kShowTradingDisclaimer = false;
 
 const Duration kPerformanceLogInterval = Duration(minutes: 1);
 

--- a/lib/views/main_layout/main_layout.dart
+++ b/lib/views/main_layout/main_layout.dart
@@ -33,7 +33,8 @@ class _MainLayoutState extends State<MainLayout> {
       await AlphaVersionWarningService().run();
       await updateBloc.init();
 
-      if (!kIsWalletOnly && !await _hasAgreedNoTrading()) {
+      final showTradingDisclaimer = kShowTradingDisclaimer && !kIsWalletOnly;
+      if (showTradingDisclaimer && !await _hasAgreedNoTrading()) {
         _showNoTradingWarning().ignore();
       }
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.9.0+0
+version: 0.9.1+0
 
 environment:
   # TODO: Upgrade mininum Dart version to 3.7.0 only after the release is concluded because


### PR DESCRIPTION
## Summary
- enable trading features
- bump version to v0.9.1

## Testing
- `flutter pub get --offline --enforce-lockfile` *(fails: Resolving dependencies)*
- `flutter analyze --no-pub`