### PR TITLE
Implement hidden balance toggle

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -82,6 +82,7 @@
     "portfolio": "Portfolio",
     "editList": "Edit list",
     "withBalance": "Hide 0 balance assets",
+    "hideBalances": "Hide balances",
     "balance": "Balance",
     "transactions": "Transactions",
     "send": "Send",

--- a/lib/bloc/settings/settings_bloc.dart
+++ b/lib/bloc/settings/settings_bloc.dart
@@ -56,4 +56,14 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     );
     emitter(state.copyWith(testCoinsEnabled: event.testCoinsEnabled));
   }
+
+  Future<void> _onHideBalancesChanged(
+    HideBalancesChanged event,
+    Emitter<SettingsState> emitter,
+  ) async {
+    await _settingsRepo.updateSettings(
+      _storedSettings.copyWith(hideBalances: event.hideBalances),
+    );
+    emitter(state.copyWith(hideBalances: event.hideBalances));
+  }
 }

--- a/lib/bloc/settings/settings_event.dart
+++ b/lib/bloc/settings/settings_event.dart
@@ -19,6 +19,11 @@ class TestCoinsEnabledChanged extends SettingsEvent {
   final bool testCoinsEnabled;
 }
 
+class HideBalancesChanged extends SettingsEvent {
+  const HideBalancesChanged({required this.hideBalances});
+  final bool hideBalances;
+}
+
 class MarketMakerBotSettingsChanged extends SettingsEvent {
   const MarketMakerBotSettingsChanged(this.settings);
 

--- a/lib/bloc/settings/settings_state.dart
+++ b/lib/bloc/settings/settings_state.dart
@@ -8,6 +8,7 @@ class SettingsState extends Equatable {
     required this.themeMode,
     required this.mmBotSettings,
     required this.testCoinsEnabled,
+    required this.hideBalances,
   });
 
   factory SettingsState.fromStored(StoredSettings stored) {
@@ -15,29 +16,34 @@ class SettingsState extends Equatable {
       themeMode: stored.mode,
       mmBotSettings: stored.marketMakerBotSettings,
       testCoinsEnabled: stored.testCoinsEnabled,
+      hideBalances: stored.hideBalances,
     );
   }
 
   final ThemeMode themeMode;
   final MarketMakerBotSettings mmBotSettings;
   final bool testCoinsEnabled;
+  final bool hideBalances;
 
   @override
   List<Object?> get props => [
         themeMode,
         mmBotSettings,
         testCoinsEnabled,
+        hideBalances,
       ];
 
   SettingsState copyWith({
     ThemeMode? mode,
     MarketMakerBotSettings? marketMakerBotSettings,
     bool? testCoinsEnabled,
+    bool? hideBalances,
   }) {
     return SettingsState(
       themeMode: mode ?? themeMode,
       mmBotSettings: marketMakerBotSettings ?? mmBotSettings,
       testCoinsEnabled: testCoinsEnabled ?? this.testCoinsEnabled,
+      hideBalances: hideBalances ?? this.hideBalances,
     );
   }
 }

--- a/lib/generated/codegen_loader.g.dart
+++ b/lib/generated/codegen_loader.g.dart
@@ -86,6 +86,7 @@ abstract class  LocaleKeys {
   static const portfolio = 'portfolio';
   static const editList = 'editList';
   static const withBalance = 'withBalance';
+  static const hideBalances = 'hideBalances';
   static const balance = 'balance';
   static const transactions = 'transactions';
   static const send = 'send';

--- a/lib/model/stored_settings.dart
+++ b/lib/model/stored_settings.dart
@@ -9,12 +9,14 @@ class StoredSettings {
     required this.analytics,
     required this.marketMakerBotSettings,
     required this.testCoinsEnabled,
+    required this.hideBalances,
   });
 
   final ThemeMode mode;
   final AnalyticsSettings analytics;
   final MarketMakerBotSettings marketMakerBotSettings;
   final bool testCoinsEnabled;
+  final bool hideBalances;
 
   static StoredSettings initial() {
     return StoredSettings(
@@ -22,6 +24,7 @@ class StoredSettings {
       analytics: AnalyticsSettings.initial(),
       marketMakerBotSettings: MarketMakerBotSettings.initial(),
       testCoinsEnabled: true,
+      hideBalances: false,
     );
   }
 
@@ -35,6 +38,7 @@ class StoredSettings {
         json[storedMarketMakerSettingsKey],
       ),
       testCoinsEnabled: json['testCoinsEnabled'] ?? true,
+      hideBalances: json['hideBalances'] ?? false,
     );
   }
 
@@ -44,6 +48,7 @@ class StoredSettings {
       storedAnalyticsSettingsKey: analytics.toJson(),
       storedMarketMakerSettingsKey: marketMakerBotSettings.toJson(),
       'testCoinsEnabled': testCoinsEnabled,
+      'hideBalances': hideBalances,
     };
   }
 
@@ -52,6 +57,7 @@ class StoredSettings {
     AnalyticsSettings? analytics,
     MarketMakerBotSettings? marketMakerBotSettings,
     bool? testCoinsEnabled,
+    bool? hideBalances,
   }) {
     return StoredSettings(
       mode: mode ?? this.mode,
@@ -59,6 +65,7 @@ class StoredSettings {
       marketMakerBotSettings:
           marketMakerBotSettings ?? this.marketMakerBotSettings,
       testCoinsEnabled: testCoinsEnabled ?? this.testCoinsEnabled,
+      hideBalances: hideBalances ?? this.hideBalances,
     );
   }
 }

--- a/lib/shared/widgets/coin_balance.dart
+++ b/lib/shared/widgets/coin_balance.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:web_dex/bloc/settings/settings_bloc.dart';
 import 'package:web_dex/model/coin.dart';
 import 'package:web_dex/shared/utils/utils.dart';
 import 'package:web_dex/shared/widgets/auto_scroll_text.dart';
@@ -11,10 +13,12 @@ class CoinBalance extends StatelessWidget {
     super.key,
     required this.coin,
     this.isVertical = false,
+    this.forceVisible = false,
   });
 
   final Coin coin;
   final bool isVertical;
+  final bool forceVisible;
 
   @override
   Widget build(BuildContext context) {
@@ -25,6 +29,11 @@ class CoinBalance extends StatelessWidget {
 
     final balance =
         context.sdk.balances.lastKnown(coin.id)?.spendable.toDouble() ?? 0.0;
+    final hideBalances =
+        context.select((SettingsBloc bloc) => bloc.state.hideBalances);
+    final balanceStr = hideBalances && !forceVisible
+        ? '*****'
+        : doubleToString(balance);
 
     final children = [
       Row(
@@ -33,7 +42,7 @@ class CoinBalance extends StatelessWidget {
           Flexible(
             child: AutoScrollText(
               key: Key('coin-balance-asset-${coin.abbr.toLowerCase()}'),
-              text: doubleToString(balance),
+              text: balanceStr,
               style: balanceStyle,
               textAlign: TextAlign.right,
             ),
@@ -54,6 +63,7 @@ class CoinBalance extends StatelessWidget {
             CoinFiatBalance(
               coin,
               isAutoScrollEnabled: true,
+              forceVisible: forceVisible,
             ),
             Text(')', style: balanceStyle),
           ],

--- a/lib/shared/widgets/coin_fiat_balance.dart
+++ b/lib/shared/widgets/coin_fiat_balance.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:web_dex/bloc/settings/settings_bloc.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 import 'package:web_dex/model/coin.dart';
 import 'package:web_dex/shared/utils/formatters.dart';
@@ -12,12 +14,14 @@ class CoinFiatBalance extends StatelessWidget {
     this.style,
     this.isSelectable = false,
     this.isAutoScrollEnabled = false,
+    this.forceVisible = false,
   });
 
   final Coin coin;
   final TextStyle? style;
   final bool isSelectable;
   final bool isAutoScrollEnabled;
+  final bool forceVisible;
 
   @override
   Widget build(BuildContext context) {
@@ -37,17 +41,22 @@ class CoinFiatBalance extends StatelessWidget {
             coin.lastKnownUsdBalance(context.sdk),
           );
 
+          final hideBalances =
+              context.select((SettingsBloc bloc) => bloc.state.hideBalances);
+          final displayStr =
+              hideBalances && !forceVisible ? '*****' : balanceStr;
+
           if (isAutoScrollEnabled) {
             return AutoScrollText(
-              text: balanceStr,
+              text: displayStr,
               style: mergedStyle,
               isSelectable: isSelectable,
             );
           }
 
           return isSelectable
-              ? SelectableText(balanceStr, style: mergedStyle)
-              : Text(balanceStr, style: mergedStyle);
+              ? SelectableText(displayStr, style: mergedStyle)
+              : Text(displayStr, style: mergedStyle);
         });
   }
 }

--- a/lib/shared/widgets/redacted_statistic_card.dart
+++ b/lib/shared/widgets/redacted_statistic_card.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+
+class RedactedStatisticCard extends StatelessWidget {
+  const RedactedStatisticCard({
+    super.key,
+    required this.caption,
+    required this.footer,
+    required this.actionIcon,
+    this.onPressed,
+  });
+
+  final Widget caption;
+  final Widget footer;
+  final Widget actionIcon;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme(
+      data: ThemeData.from(
+        colorScheme: Theme.of(context).colorScheme,
+        useMaterial3: true,
+      ),
+      child: Card(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: LimitedBox(
+          maxHeight: 148,
+          maxWidth: 300,
+          child: Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              gradient: RadialGradient(
+                colors: [
+                  Theme.of(context)
+                      .colorScheme
+                      .primaryContainer
+                      .withOpacity(0.25),
+                  Colors.transparent,
+                ],
+                center: const Alignment(0.2, 0.1),
+                radius: 1.5,
+              ),
+            ),
+            padding: const EdgeInsets.all(16.0),
+            child: Row(
+              children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    DefaultTextStyle(
+                      style: Theme.of(context).textTheme.titleLarge!,
+                      child: const Text('*****'),
+                    ),
+                    const SizedBox(height: 6),
+                    DefaultTextStyle(
+                      style: Theme.of(context).textTheme.bodySmall!,
+                      child: caption,
+                    ),
+                    const Spacer(),
+                    DefaultTextStyle(
+                      style: Theme.of(context).textTheme.bodySmall!,
+                      child: footer,
+                    ),
+                  ],
+                ),
+                const Spacer(),
+                Align(
+                  alignment: Alignment.topRight,
+                  child: SizedBox(
+                    width: 64,
+                    height: 64,
+                    child: IconButton.filledTonal(
+                      isSelected: false,
+                      icon: actionIcon,
+                      iconSize: 42,
+                      onPressed: onPressed,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/dex/simple/form/tables/coins_table/coins_table_item.dart
+++ b/lib/views/dex/simple/form/tables/coins_table/coins_table_item.dart
@@ -34,7 +34,8 @@ class CoinsTableItem<T> extends StatelessWidget {
             subtitleText: subtitleText,
           ),
           const SizedBox(width: 8),
-          if (coin.isActive) CoinBalance(coin: coin, isVertical: true),
+          if (coin.isActive)
+            CoinBalance(coin: coin, isVertical: true, forceVisible: true),
         ],
       ),
     );

--- a/lib/views/wallet/wallet_page/wallet_main/wallet_manage_section.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/wallet_manage_section.dart
@@ -4,6 +4,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 import 'package:web_dex/bloc/coins_manager/coins_manager_bloc.dart';
 import 'package:web_dex/common/screen.dart';
+import 'package:web_dex/bloc/settings/settings_bloc.dart';
+import 'package:web_dex/bloc/settings/settings_event.dart';
+import 'package:web_dex/bloc/settings/settings_state.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/authorize_mode.dart';
 import 'package:web_dex/router/state/routing_state.dart';
@@ -63,6 +66,8 @@ class WalletManageSection extends StatelessWidget {
                     withBalance: withBalance,
                     onWithBalanceChange: onWithBalanceChange,
                   ),
+                  const SizedBox(width: 24),
+                  const HideBalancesSwitcher(),
                   SizedBox(width: 24),
                   UiPrimaryButton(
                     buttonKey: const Key('add-assets-button'),
@@ -128,6 +133,8 @@ class WalletManageSection extends StatelessWidget {
                   onWithBalanceChange: onWithBalanceChange,
                 ),
               ),
+              const SizedBox(width: 24),
+              const HideBalancesSwitcher(),
             ],
           ),
         ],
@@ -164,6 +171,30 @@ class CoinsWithBalanceCheckbox extends StatelessWidget {
           onChanged: onWithBalanceChange,
         ),
       ],
+    );
+  }
+}
+
+class HideBalancesSwitcher extends StatelessWidget {
+  const HideBalancesSwitcher({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<SettingsBloc, SettingsState>(
+      builder: (context, state) {
+        return Row(
+          children: [
+            UiSwitcher(
+              key: const Key('hide-balances-switcher'),
+              value: state.hideBalances,
+              onChanged: (value) =>
+                  context.read<SettingsBloc>().add(HideBalancesChanged(hideBalances: value)),
+            ),
+            const SizedBox(width: 8),
+            Text(LocaleKeys.hideBalances.tr()),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/views/wallet/wallet_page/wallet_main/wallet_overview.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/wallet_overview.dart
@@ -5,6 +5,8 @@ import 'package:komodo_ui/komodo_ui.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 import 'package:web_dex/bloc/assets_overview/bloc/asset_overview_bloc.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_bloc.dart';
+import 'package:web_dex/bloc/settings/settings_bloc.dart';
+import 'package:web_dex/shared/widgets/redacted_statistic_card.dart';
 import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 
@@ -32,17 +34,46 @@ class WalletOverview extends StatelessWidget {
                 as PortfolioAssetsOverviewLoadSuccess
             : null;
 
+        final hideBalances =
+            context.select((SettingsBloc bloc) => bloc.state.hideBalances);
         return Wrap(
           runSpacing: 16,
           children: [
             FractionallySizedBox(
               widthFactor: isMobile ? 1 : 0.5,
-              child: StatisticCard(
-                key: const Key('overview-total-balance'),
-                caption: Text(LocaleKeys.allTimeInvestment.tr()),
-                value: stateWithData?.totalInvestment.value ?? 0,
-                actionIcon: const Icon(CustomIcons.fiatIconCircle),
-                onPressed: onPortfolioGrowthPressed,
+              child: hideBalances
+                  ? RedactedStatisticCard(
+                      caption: Text(LocaleKeys.allTimeInvestment.tr()),
+                      footer: Container(
+                        height: 28,
+                        decoration: BoxDecoration(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .surfaceContainerLowest,
+                          borderRadius: BorderRadius.circular(28),
+                        ),
+                        padding: const EdgeInsets.symmetric(horizontal: 12),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            const Icon(
+                              Icons.pie_chart,
+                              size: 16,
+                            ),
+                            const SizedBox(width: 4),
+                            Text('$assetCount ${LocaleKeys.assets.tr()}'),
+                          ],
+                        ),
+                      ),
+                      actionIcon: const Icon(CustomIcons.fiatIconCircle),
+                      onPressed: onPortfolioGrowthPressed,
+                    )
+                  : StatisticCard(
+                    key: const Key('overview-total-balance'),
+                    caption: Text(LocaleKeys.allTimeInvestment.tr()),
+                    value: stateWithData?.totalInvestment.value ?? 0,
+                    actionIcon: const Icon(CustomIcons.fiatIconCircle),
+                    onPressed: onPortfolioGrowthPressed,
                 footer: Container(
                   height: 28,
                   decoration: BoxDecoration(
@@ -66,15 +97,26 @@ class WalletOverview extends StatelessWidget {
             ),
             FractionallySizedBox(
               widthFactor: isMobile ? 1 : 0.5,
-              child: StatisticCard(
-                caption: Text(LocaleKeys.allTimeProfit.tr()),
-                value: stateWithData?.profitAmount.value ?? 0,
-                footer: TrendPercentageText(
-                  percentage: stateWithData?.profitIncreasePercentage ?? 0,
-                ),
-                actionIcon: const Icon(Icons.trending_up),
-                onPressed: onPortfolioProfitLossPressed,
-              ),
+              child: hideBalances
+                  ? RedactedStatisticCard(
+                      caption: Text(LocaleKeys.allTimeProfit.tr()),
+                      footer: TrendPercentageText(
+                        percentage:
+                            stateWithData?.profitIncreasePercentage ?? 0,
+                      ),
+                      actionIcon: const Icon(Icons.trending_up),
+                      onPressed: onPortfolioProfitLossPressed,
+                    )
+                  : StatisticCard(
+                      caption: Text(LocaleKeys.allTimeProfit.tr()),
+                      value: stateWithData?.profitAmount.value ?? 0,
+                      footer: TrendPercentageText(
+                        percentage:
+                            stateWithData?.profitIncreasePercentage ?? 0,
+                      ),
+                      actionIcon: const Icon(Icons.trending_up),
+                      onPressed: onPortfolioProfitLossPressed,
+                    ),
             ),
           ],
         );


### PR DESCRIPTION
## Summary
- add hidden balance toggle in wallet
- store hidden balance preference in settings
- redact amounts across wallet when enabled

## Testing
- `dart format -o none .`
- `flutter analyze` *(fails: 521 issues)*