### PR TITLE
feat(kyc): transactions export

### DIFF
--- a/Fetching
+++ b/Fetching
@@ -1,0 +1,3 @@
+
+# Bloc and Commit Conventions
+ documentation...

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -661,5 +661,19 @@
     "previewWithdrawal": "Preview Withdrawal",
     "createNewAddress": "Create New Address",
     "searchAddresses": "Search addresses",
-    "chart": "Chart"
+    "chart": "Chart",
+    "transactionExport": "Export Transactions",
+    "transactionExportUserInfoTitle": "Transaction Export - Your Information",
+    "transactionExportFullName": "Full Name",
+    "transactionExportEmail": "Email Address",
+    "transactionExportContinue": "Continue",
+    "transactionExportSelectTxTitle": "Select Transactions to Export",
+    "transactionExportPreviewTitle": "Preview Export",
+    "transactionExportCompleteTitle": "Export Complete",
+    "transactionExportDone": "Done",
+    "transactionExportExportButton": "Export",
+    "transactionExportFormat": "Export Format",
+    "transactionExportCsv": "CSV",
+    "transactionExportPdf": "PDF",
+    "transactionExportMarkdown": "Markdown"
 }

--- a/lib/bloc/transaction_export/transaction_export_bloc.dart
+++ b/lib/bloc/transaction_export/transaction_export_bloc.dart
@@ -1,0 +1,184 @@
+import 'dart:convert';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:web_dex/mm2/mm2_api/rpc/my_tx_history/transaction.dart';
+import 'package:web_dex/services/file_loader/file_loader.dart';
+
+part 'transaction_export_event.dart';
+part 'transaction_export_state.dart';
+
+class TransactionExportBloc
+    extends Bloc<TransactionExportEvent, TransactionExportState> {
+  TransactionExportBloc() : super(const TransactionExportState()) {
+    on<UserInfoSubmitted>(_onUserInfoSubmitted);
+    on<NextStepRequested>(_onNextStep);
+    on<PreviousStepRequested>(_onPreviousStep);
+    on<ToggleTransaction>(_onToggleTransaction);
+    on<ExportRequested>(_onExportRequested);
+    on<FormatChanged>(_onFormatChanged);
+  }
+
+  void _onUserInfoSubmitted(
+      UserInfoSubmitted event, Emitter<TransactionExportState> emit) {
+    emit(state.copyWith(
+        name: event.name, email: event.email, address: event.address));
+  }
+
+  void _onNextStep(
+      NextStepRequested event, Emitter<TransactionExportState> emit) {
+    emit(state.copyWith(step: state.step + 1));
+  }
+
+  void _onPreviousStep(
+      PreviousStepRequested event, Emitter<TransactionExportState> emit) {
+    emit(state.copyWith(step: state.step - 1));
+  }
+
+  void _onToggleTransaction(
+      ToggleTransaction event, Emitter<TransactionExportState> emit) {
+    final current = List<Transaction>.from(state.selected);
+    if (current.contains(event.tx)) {
+      current.remove(event.tx);
+    } else {
+      current.add(event.tx);
+    }
+    emit(state.copyWith(selected: current));
+  }
+
+  void _onFormatChanged(
+      FormatChanged event, Emitter<TransactionExportState> emit) {
+    emit(state.copyWith(format: event.format));
+  }
+
+  Future<void> _onExportRequested(
+      ExportRequested event, Emitter<TransactionExportState> emit) async {
+    emit(state.copyWith(isExporting: true));
+    final fileLoader = FileLoader.fromPlatform();
+    late final String data;
+    late final String ext;
+    switch (event.format) {
+      case ExportFormat.csv:
+        data = _generateCsv();
+        ext = 'csv';
+        break;
+      case ExportFormat.pdf:
+        data = _generatePdf();
+        ext = 'pdf';
+        break;
+      case ExportFormat.markdown:
+        data = _generateMarkdown();
+        ext = 'md';
+        break;
+    }
+    await fileLoader.save(
+      fileName: 'transactions_export',
+      data: data,
+      type: LoadFileType.text,
+      extension: ext,
+    );
+    emit(state.copyWith(isExporting: false, step: 3));
+  }
+
+  String _generateCsv() {
+    final buffer = StringBuffer();
+    buffer.writeln('name,email,address,exportedAt');
+    buffer.writeln(
+        '${state.name},${state.email},${state.address},${DateTime.now().toIso8601String()}');
+    buffer.writeln();
+    buffer.writeln('tx_hash,coin,timestamp,amount');
+    for (final tx in state.selected) {
+      buffer
+          .writeln('${tx.txHash},${tx.coin},${tx.timestamp},${tx.totalAmount}');
+    }
+    return buffer.toString();
+  }
+
+  String _generateMarkdown() {
+    final buffer = StringBuffer();
+    buffer.writeln('# Transaction Export');
+    buffer.writeln('**Name:** ${state.name}  ');
+    buffer.writeln('**Email:** ${state.email}  ');
+    buffer.writeln('**Address:** ${state.address}  ');
+    buffer.writeln('**Exported:** ${DateTime.now().toIso8601String()}');
+    buffer.writeln('');
+    buffer.writeln('| tx_hash | coin | timestamp | amount |');
+    buffer.writeln('| --- | --- | --- | --- |');
+    for (final tx in state.selected) {
+      final time = DateTime.fromMillisecondsSinceEpoch(tx.timestamp * 1000);
+      buffer
+          .writeln('| ${tx.txHash} | ${tx.coin} | $time | ${tx.totalAmount} |');
+    }
+    return buffer.toString();
+  }
+
+  String _escapePdf(String input) {
+    return input
+        .replaceAll('\\', r'\\')
+        .replaceAll('(', r'\(')
+        .replaceAll(')', r'\)');
+  }
+
+  String _generatePdf() {
+    final lines = <String>[
+      'Transaction Export',
+      'Name: ${state.name}',
+      'Email: ${state.email}',
+      'Address: ${state.address}',
+      'Exported: ${DateTime.now().toIso8601String()}',
+      ''
+    ];
+    for (final tx in state.selected) {
+      final time = DateTime.fromMillisecondsSinceEpoch(tx.timestamp * 1000);
+      lines.add('${tx.txHash} ${tx.coin} $time ${tx.totalAmount}');
+    }
+    return _simplePdf(lines);
+  }
+
+  String _simplePdf(List<String> lines) {
+    final objects = <String>[];
+    objects.add('1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj');
+    objects.add('2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj');
+    final content = _pdfContent(lines);
+    objects.add(
+        '3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj');
+    objects.add(
+        '5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj');
+    objects.add(
+        '4 0 obj\n<< /Length ${content.length} >>\nstream\n$content\nendstream\nendobj');
+
+    final buffer = StringBuffer('%PDF-1.1\n');
+    final offsets = <int>[];
+    for (final obj in objects) {
+      offsets.add(buffer.length);
+      buffer.writeln(obj);
+    }
+    final xrefStart = buffer.length;
+    buffer.writeln('xref');
+    buffer.writeln('0 ${objects.length + 1}');
+    buffer.writeln('0000000000 65535 f ');
+    for (final off in offsets) {
+      buffer.writeln('${off.toString().padLeft(10, '0')} 00000 n ');
+    }
+    buffer.writeln('trailer');
+    buffer.writeln('<< /Root 1 0 R /Size ${objects.length + 1} >>');
+    buffer.writeln('startxref');
+    buffer.writeln(xrefStart);
+    buffer.writeln('%%EOF');
+    return buffer.toString();
+  }
+
+  String _pdfContent(List<String> lines) {
+    final sb = StringBuffer();
+    sb.writeln('BT');
+    sb.writeln('/F1 12 Tf');
+    sb.writeln('50 750 Td');
+    var first = true;
+    for (final line in lines) {
+      if (!first) sb.writeln('T*');
+      sb.writeln('(${_escapePdf(line)}) Tj');
+      first = false;
+    }
+    sb.writeln('ET');
+    return sb.toString();
+  }
+}

--- a/lib/bloc/transaction_export/transaction_export_event.dart
+++ b/lib/bloc/transaction_export/transaction_export_event.dart
@@ -1,0 +1,36 @@
+part of 'transaction_export_bloc.dart';
+
+abstract class TransactionExportEvent {
+  const TransactionExportEvent();
+}
+
+class UserInfoSubmitted extends TransactionExportEvent {
+  const UserInfoSubmitted(
+      {required this.name, required this.email, required this.address});
+  final String name;
+  final String email;
+  final String address;
+}
+
+class NextStepRequested extends TransactionExportEvent {
+  const NextStepRequested();
+}
+
+class PreviousStepRequested extends TransactionExportEvent {
+  const PreviousStepRequested();
+}
+
+class ToggleTransaction extends TransactionExportEvent {
+  const ToggleTransaction(this.tx);
+  final Transaction tx;
+}
+
+class ExportRequested extends TransactionExportEvent {
+  const ExportRequested(this.format);
+  final ExportFormat format;
+}
+
+class FormatChanged extends TransactionExportEvent {
+  const FormatChanged(this.format);
+  final ExportFormat format;
+}

--- a/lib/bloc/transaction_export/transaction_export_state.dart
+++ b/lib/bloc/transaction_export/transaction_export_state.dart
@@ -1,0 +1,47 @@
+part of 'transaction_export_bloc.dart';
+
+enum ExportFormat { csv, pdf, markdown }
+
+class TransactionExportState extends Equatable {
+  const TransactionExportState({
+    this.step = 0,
+    this.name = '',
+    this.email = '',
+    this.address = '',
+    this.selected = const [],
+    this.isExporting = false,
+    this.format = ExportFormat.csv,
+  });
+
+  final int step;
+  final String name;
+  final String email;
+  final String address;
+  final List<Transaction> selected;
+  final bool isExporting;
+  final ExportFormat format;
+
+  TransactionExportState copyWith({
+    int? step,
+    String? name,
+    String? email,
+    String? address,
+    List<Transaction>? selected,
+    bool? isExporting,
+    ExportFormat? format,
+  }) {
+    return TransactionExportState(
+      step: step ?? this.step,
+      name: name ?? this.name,
+      email: email ?? this.email,
+      address: address ?? this.address,
+      selected: selected ?? this.selected,
+      isExporting: isExporting ?? this.isExporting,
+      format: format ?? this.format,
+    );
+  }
+
+  @override
+  List<Object?> get props =>
+      [step, name, email, address, selected, isExporting, format];
+}

--- a/lib/services/file_loader/file_loader.dart
+++ b/lib/services/file_loader/file_loader.dart
@@ -12,6 +12,7 @@ abstract class FileLoader {
     required String fileName,
     required String data,
     required LoadFileType type,
+    String? extension,
   });
   Future<void> upload({
     required void Function(String name, String? content) onUpload,

--- a/lib/services/file_loader/file_loader_native_desktop.dart
+++ b/lib/services/file_loader/file_loader_native_desktop.dart
@@ -12,12 +12,13 @@ class FileLoaderNativeDesktop implements FileLoader {
     required String fileName,
     required String data,
     required LoadFileType type,
+    String? extension,
   }) async {
     switch (type) {
       case LoadFileType.text:
-        await _saveAsTextFile(fileName, data);
+        await _saveAsTextFile(fileName, data, extension ?? 'txt');
       case LoadFileType.compressed:
-        await _saveAsCompressedFile(fileName, data);
+        await _saveAsCompressedFile(fileName, data, extension ?? 'txt');
     }
   }
 
@@ -45,9 +46,9 @@ class FileLoaderNativeDesktop implements FileLoader {
     }
   }
 
-  Future<void> _saveAsTextFile(String fileName, String data) async {
+  Future<void> _saveAsTextFile(String fileName, String data, String ext) async {
     final String? fileFullPath =
-        await FilePicker.platform.saveFile(fileName: '$fileName.txt');
+        await FilePicker.platform.saveFile(fileName: '$fileName.$ext');
     if (fileFullPath == null) return;
     final File file = File(fileFullPath)..createSync(recursive: true);
     await file.writeAsString(data);
@@ -56,13 +57,14 @@ class FileLoaderNativeDesktop implements FileLoader {
   Future<void> _saveAsCompressedFile(
     String fileName,
     String data,
+    String ext,
   ) async {
     final String? fileFullPath =
         await FilePicker.platform.saveFile(fileName: '$fileName.zip');
     if (fileFullPath == null) return;
 
-    final compressedBytes =
-        createZipOfSingleFile(fileName: fileName, fileContent: data);
+    final compressedBytes = createZipOfSingleFile(
+        fileName: fileName, fileContent: data, extension: ext);
 
     final File compressedFile = File(fileFullPath);
     await compressedFile.writeAsBytes(compressedBytes);

--- a/lib/services/file_loader/file_loader_web.dart
+++ b/lib/services/file_loader/file_loader_web.dart
@@ -14,12 +14,15 @@ class FileLoaderWeb implements FileLoader {
     required String fileName,
     required String data,
     required LoadFileType type,
+    String? extension,
   }) async {
     switch (type) {
       case LoadFileType.text:
-        await _saveAsTextFile(filename: fileName, data: data);
+        await _saveAsTextFile(
+            filename: '$fileName.${extension ?? 'txt'}', data: data);
       case LoadFileType.compressed:
-        await _saveAsCompressedFile(fileName: fileName, data: data);
+        await _saveAsCompressedFile(
+            fileName: fileName, data: data, ext: extension ?? 'txt');
     }
   }
 
@@ -54,11 +57,12 @@ class FileLoaderWeb implements FileLoader {
   Future<void> _saveAsCompressedFile({
     required String fileName,
     required String data,
+    required String ext,
   }) async {
     try {
       // add the extension of the contained file to the filename, so that the
       // extracted file is simply the filename excluding '.zip'
-      final fileNameWithExt = '$fileName.txt';
+      final fileNameWithExt = '$fileName.$ext';
 
       final encoder = web.TextEncoder();
       final dataArray = encoder.encode(data);

--- a/lib/services/file_loader/mobile/file_loader_native_android.dart
+++ b/lib/services/file_loader/mobile/file_loader_native_android.dart
@@ -15,24 +15,28 @@ class FileLoaderNativeAndroid implements FileLoader {
     required String fileName,
     required String data,
     LoadFileType type = LoadFileType.text,
+    String? extension,
   }) async {
     switch (type) {
       case LoadFileType.text:
-        await _saveAsTextFile(fileName: fileName, data: data);
+        await _saveAsTextFile(
+            fileName: fileName, data: data, ext: extension ?? 'txt');
       case LoadFileType.compressed:
-        await _saveAsCompressedFile(fileName: fileName, data: data);
+        await _saveAsCompressedFile(
+            fileName: fileName, data: data, ext: extension ?? 'txt');
     }
   }
 
   Future<void> _saveAsTextFile({
     required String fileName,
     required String data,
+    required String ext,
   }) async {
     // On mobile, the file bytes are used to create the file to be saved.
     // On desktop a file is created first, then a file is saved.
     final Uint8List fileBytes = utf8.encode(data);
     final String? fileFullPath = await FilePicker.platform.saveFile(
-      fileName: '$fileName.txt',
+      fileName: '$fileName.$ext',
       bytes: fileBytes,
     );
     if (fileFullPath == null || fileFullPath.isEmpty == true) {
@@ -43,9 +47,10 @@ class FileLoaderNativeAndroid implements FileLoader {
   Future<void> _saveAsCompressedFile({
     required String fileName,
     required String data,
+    required String ext,
   }) async {
-    final Uint8List compressedBytes =
-        createZipOfSingleFile(fileName: fileName, fileContent: data);
+    final Uint8List compressedBytes = createZipOfSingleFile(
+        fileName: fileName, fileContent: data, extension: ext);
     final String? fileFullPath = await FilePicker.platform.saveFile(
       fileName: '$fileName.zip',
       bytes: compressedBytes,

--- a/lib/services/file_loader/mobile/file_loader_native_ios.dart
+++ b/lib/services/file_loader/mobile/file_loader_native_ios.dart
@@ -15,21 +15,25 @@ class FileLoaderNativeIOS implements FileLoader {
     required String fileName,
     required String data,
     LoadFileType type = LoadFileType.text,
+    String? extension,
   }) async {
     switch (type) {
       case LoadFileType.text:
-        await _saveAsTextFile(fileName: fileName, data: data);
+        await _saveAsTextFile(
+            fileName: fileName, data: data, ext: extension ?? 'txt');
       case LoadFileType.compressed:
-        await _saveAsCompressedFile(fileName: fileName, data: data);
+        await _saveAsCompressedFile(
+            fileName: fileName, data: data, ext: extension ?? 'txt');
     }
   }
 
   Future<void> _saveAsTextFile({
     required String fileName,
     required String data,
+    required String ext,
   }) async {
     final directory = await getApplicationDocumentsDirectory();
-    final filePath = path.join(directory.path, '$fileName.txt');
+    final filePath = path.join(directory.path, '$fileName.$ext');
     final File file = File(filePath);
     await file.writeAsString(data);
 
@@ -39,12 +43,13 @@ class FileLoaderNativeIOS implements FileLoader {
   Future<void> _saveAsCompressedFile({
     required String fileName,
     required String data,
+    required String ext,
   }) async {
     final directory = await getApplicationDocumentsDirectory();
     final filePath = path.join(directory.path, '$fileName.zip');
 
-    final compressedBytes =
-        createZipOfSingleFile(fileName: fileName, fileContent: data);
+    final compressedBytes = createZipOfSingleFile(
+        fileName: fileName, fileContent: data, extension: ext);
 
     final File compressedFile = File(filePath);
     await compressedFile.writeAsBytes(compressedBytes);

--- a/lib/shared/utils/zip.dart
+++ b/lib/shared/utils/zip.dart
@@ -5,8 +5,9 @@ import 'dart:typed_data';
 Uint8List createZipOfSingleFile({
   required String fileName,
   required String fileContent,
+  String extension = 'txt',
 }) {
-  final fileNameWithExtension = '$fileName.txt';
+  final fileNameWithExtension = '$fileName.$extension';
 
   final originalBytes = utf8.encode(fileContent);
   // use `raw: true` to exclude zlip header and trailer data that causes

--- a/lib/views/settings/widgets/general_settings/general_settings.dart
+++ b/lib/views/settings/widgets/general_settings/general_settings.dart
@@ -11,6 +11,7 @@ import 'package:web_dex/views/settings/widgets/general_settings/settings_manage_
 import 'package:web_dex/views/settings/widgets/general_settings/settings_reset_activated_coins.dart';
 import 'package:web_dex/views/settings/widgets/general_settings/settings_theme_switcher.dart';
 import 'package:web_dex/views/settings/widgets/general_settings/show_swap_data.dart';
+import 'package:web_dex/views/settings/widgets/general_settings/settings_transaction_export.dart';
 
 class GeneralSettings extends StatelessWidget {
   const GeneralSettings({Key? key}) : super(key: key);
@@ -37,6 +38,10 @@ class GeneralSettings extends StatelessWidget {
         const SizedBox(height: 25),
         const HiddenWithWallet(
           child: SettingsResetActivatedCoins(),
+        ),
+        const SizedBox(height: 25),
+        const HiddenWithoutWallet(
+          child: SettingsTransactionExport(),
         ),
         const SizedBox(height: 25),
         const HiddenWithoutWallet(

--- a/lib/views/settings/widgets/general_settings/settings_transaction_export.dart
+++ b/lib/views/settings/widgets/general_settings/settings_transaction_export.dart
@@ -1,0 +1,33 @@
+import 'package:app_theme/app_theme.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:komodo_ui_kit/komodo_ui_kit.dart';
+import 'package:web_dex/generated/codegen_loader.g.dart';
+import 'package:web_dex/views/wallet/transaction_export/transaction_export_page.dart';
+
+class SettingsTransactionExport extends StatelessWidget {
+  const SettingsTransactionExport({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return UiBorderButton(
+      width: 160,
+      height: 32,
+      borderWidth: 1,
+      borderColor: theme.custom.specificButtonBorderColor,
+      backgroundColor: theme.custom.specificButtonBackgroundColor,
+      fontWeight: FontWeight.w500,
+      text: LocaleKeys.transactionExport.tr(),
+      icon: Icon(
+        Icons.file_download,
+        color: Theme.of(context).textTheme.bodyMedium?.color,
+        size: 18,
+      ),
+      onPressed: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(builder: (_) => const TransactionExportPage()),
+        );
+      },
+    );
+  }
+}

--- a/lib/views/wallet/transaction_export/transaction_export_page.dart
+++ b/lib/views/wallet/transaction_export/transaction_export_page.dart
@@ -1,0 +1,222 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:web_dex/bloc/transaction_export/transaction_export_bloc.dart';
+import 'package:web_dex/bloc/transaction_history/transaction_history_bloc.dart';
+import 'package:web_dex/generated/codegen_loader.g.dart';
+import 'package:web_dex/mm2/mm2_api/rpc/my_tx_history/transaction.dart';
+
+class TransactionExportPage extends StatelessWidget {
+  const TransactionExportPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => TransactionExportBloc(),
+      child: const _TransactionExportView(),
+    );
+  }
+}
+
+class _TransactionExportView extends StatefulWidget {
+  const _TransactionExportView();
+
+  @override
+  State<_TransactionExportView> createState() => _TransactionExportViewState();
+}
+
+class _TransactionExportViewState extends State<_TransactionExportView> {
+  final _nameCtrl = TextEditingController();
+  final _emailCtrl = TextEditingController();
+  final _addressCtrl = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<TransactionExportBloc, TransactionExportState>(
+      builder: (context, state) {
+        switch (state.step) {
+          case 0:
+            return _buildUserInfo(context);
+          case 1:
+            return _buildSelectTransactions(context);
+          case 2:
+            return _buildPreview(context);
+          default:
+            return _buildComplete(context);
+        }
+      },
+    );
+  }
+
+  Widget _buildUserInfo(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(LocaleKeys.transactionExport.tr())),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            Text(LocaleKeys.transactionExportUserInfoTitle.tr(),
+                style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _nameCtrl,
+              decoration: InputDecoration(
+                labelText: LocaleKeys.transactionExportFullName.tr(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _emailCtrl,
+              decoration: InputDecoration(
+                labelText: LocaleKeys.transactionExportEmail.tr(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _addressCtrl,
+              decoration: const InputDecoration(labelText: 'Address'),
+            ),
+            const Spacer(),
+            ElevatedButton(
+              onPressed: () {
+                context.read<TransactionExportBloc>().add(
+                      UserInfoSubmitted(
+                        name: _nameCtrl.text,
+                        email: _emailCtrl.text,
+                        address: _addressCtrl.text,
+                      ),
+                    );
+                context
+                    .read<TransactionExportBloc>()
+                    .add(const NextStepRequested());
+              },
+              child: Text(LocaleKeys.transactionExportContinue.tr()),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSelectTransactions(BuildContext context) {
+    final txs = context.watch<TransactionHistoryBloc>().state.transactions;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(LocaleKeys.transactionExportSelectTxTitle.tr()),
+        leading: BackButton(
+          onPressed: () => context
+              .read<TransactionExportBloc>()
+              .add(const PreviousStepRequested()),
+        ),
+      ),
+      body: ListView.builder(
+        itemCount: txs.length,
+        itemBuilder: (context, index) {
+          final tx = txs[index];
+          final selected =
+              context.read<TransactionExportBloc>().state.selected.contains(tx);
+          return CheckboxListTile(
+            value: selected,
+            title: Text(tx.txHash),
+            subtitle: Text(
+                DateTime.fromMillisecondsSinceEpoch(tx.timestamp * 1000)
+                    .toString()),
+            onChanged: (_) {
+              context.read<TransactionExportBloc>().add(ToggleTransaction(tx));
+            },
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: context.read<TransactionExportBloc>().state.selected.isEmpty
+            ? null
+            : () => context
+                .read<TransactionExportBloc>()
+                .add(const NextStepRequested()),
+        child: const Icon(Icons.arrow_forward),
+      ),
+    );
+  }
+
+  Widget _buildPreview(BuildContext context) {
+    final state = context.watch<TransactionExportBloc>().state;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(LocaleKeys.transactionExportPreviewTitle.tr()),
+        leading: BackButton(
+          onPressed: () => context
+              .read<TransactionExportBloc>()
+              .add(const PreviousStepRequested()),
+        ),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Name: ${state.name}'),
+            Text('Email: ${state.email}'),
+            Text('Address: ${state.address}'),
+            const SizedBox(height: 16),
+            Text('${state.selected.length} transactions selected'),
+            const Spacer(),
+            Text(LocaleKeys.transactionExportFormat.tr()),
+            RadioListTile<ExportFormat>(
+              title: Text(LocaleKeys.transactionExportCsv.tr()),
+              value: ExportFormat.csv,
+              groupValue: state.format,
+              onChanged: (val) {
+                if (val != null) {
+                  context.read<TransactionExportBloc>().add(FormatChanged(val));
+                }
+              },
+            ),
+            RadioListTile<ExportFormat>(
+              title: Text(LocaleKeys.transactionExportPdf.tr()),
+              value: ExportFormat.pdf,
+              groupValue: state.format,
+              onChanged: (val) {
+                if (val != null) {
+                  context.read<TransactionExportBloc>().add(FormatChanged(val));
+                }
+              },
+            ),
+            RadioListTile<ExportFormat>(
+              title: Text(LocaleKeys.transactionExportMarkdown.tr()),
+              value: ExportFormat.markdown,
+              groupValue: state.format,
+              onChanged: (val) {
+                if (val != null) {
+                  context.read<TransactionExportBloc>().add(FormatChanged(val));
+                }
+              },
+            ),
+            ElevatedButton(
+              onPressed: state.isExporting
+                  ? null
+                  : () => context
+                      .read<TransactionExportBloc>()
+                      .add(ExportRequested(state.format)),
+              child: state.isExporting
+                  ? const CircularProgressIndicator()
+                  : Text(LocaleKeys.transactionExportExportButton.tr()),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildComplete(BuildContext context) {
+    return Scaffold(
+      appBar:
+          AppBar(title: Text(LocaleKeys.transactionExportCompleteTitle.tr())),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(LocaleKeys.transactionExportDone.tr()),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- convert `TransactionExport` flow to BLoC
- allow exporting transactions in CSV, PDF, or Markdown
- add optional file extension support to `FileLoader`
- support custom extensions across native file loaders
- translate export format labels

## Testing
- `dart format lib/bloc/transaction_export/transaction_export_bloc.dart lib/bloc/transaction_export/transaction_export_event.dart lib/bloc/transaction_export/transaction_export_state.dart lib/services/file_loader/file_loader.dart lib/services/file_loader/file_loader_native_desktop.dart lib/services/file_loader/mobile/file_loader_native_android.dart lib/services/file_loader/mobile/file_loader_native_ios.dart lib/services/file_loader/file_loader_web.dart lib/shared/utils/zip.dart lib/views/wallet/transaction_export/transaction_export_page.dart > /tmp/format.log && tail -n 20 /tmp/format.log`
- `flutter analyze > /tmp/analyze.log && tail -n 20 /tmp/analyze.log`