### PR TITLE
Log portfolio pnl viewed analytics events

### DIFF
--- a/Fetching
+++ b/Fetching
@@ -1,0 +1,3 @@
+
+# Bloc and Commit Conventions
+ documentation...

--- a/lib/analytics/analytics_factory.dart
+++ b/lib/analytics/analytics_factory.dart
@@ -1,0 +1,205 @@
+import '../bloc/analytics/analytics_repo.dart';
+
+class PortfolioPnlViewedEvent extends AnalyticsEventData {
+  PortfolioPnlViewedEvent({
+    required this.timeframe,
+    required this.realizedPnl,
+    required this.unrealizedPnl,
+  }) {
+    name = 'portfolio_pnl_viewed';
+  }
+
+  final String timeframe;
+  final double realizedPnl;
+  final double unrealizedPnl;
+
+  @override
+  Map<String, Object> get parameters => {
+        'timeframe': timeframe,
+        'realized_pnl': realizedPnl,
+        'unrealized_pnl': unrealizedPnl,
+      };
+}
+
+class AppOpenedEvent extends AnalyticsEventData {
+  AppOpenedEvent({required this.platform, required this.appVersion}) {
+    name = 'app_open';
+  }
+
+  final String platform;
+  final String appVersion;
+
+  @override
+  JsonMap get parameters => {
+        'platform': platform,
+        'app_version': appVersion,
+      };
+}
+
+class OnboardingStartedEvent extends AnalyticsEventData {
+  OnboardingStartedEvent({required this.method, this.referralSource}) {
+    name = 'onboarding_start';
+  }
+
+  final String method;
+  final String? referralSource;
+
+  @override
+  JsonMap get parameters => {
+        'method': method,
+        if (referralSource != null) 'referral_source': referralSource!,
+      };
+}
+
+class WalletCreatedEvent extends AnalyticsEventData {
+  WalletCreatedEvent({required this.source, required this.walletType}) {
+    name = 'wallet_created';
+  }
+
+  final String source;
+  final String walletType;
+
+  @override
+  JsonMap get parameters => {
+        'source': source,
+        'wallet_type': walletType,
+      };
+}
+
+class WalletImportedEvent extends AnalyticsEventData {
+  WalletImportedEvent({
+    required this.source,
+    required this.importType,
+    required this.walletType,
+  }) {
+    name = 'wallet_imported';
+  }
+
+  final String source;
+  final String importType;
+  final String walletType;
+
+  @override
+  JsonMap get parameters => {
+        'source': source,
+        'import_type': importType,
+        'wallet_type': walletType,
+      };
+}
+
+class BackupCompletedEvent extends AnalyticsEventData {
+  BackupCompletedEvent({
+    required this.backupTime,
+    required this.method,
+    required this.walletType,
+  }) {
+    name = 'backup_complete';
+  }
+
+  final int backupTime;
+  final String method;
+  final String walletType;
+
+  @override
+  JsonMap get parameters => {
+        'backup_time': backupTime,
+        'method': method,
+        'wallet_type': walletType,
+      };
+}
+
+class BackupSkippedEvent extends AnalyticsEventData {
+  BackupSkippedEvent({required this.stageSkipped, required this.walletType}) {
+    name = 'backup_skipped';
+  }
+
+  final String stageSkipped;
+  final String walletType;
+
+  @override
+  JsonMap get parameters => {
+        'stage_skipped': stageSkipped,
+        'wallet_type': walletType,
+      };
+}
+
+class AnalyticsEvents {
+  const AnalyticsEvents._();
+
+  /// Portfolio P&L viewed event
+  static PortfolioPnlViewedEvent portfolioPnlViewed({
+    required String timeframe,
+    required double realizedPnl,
+    required double unrealizedPnl,
+  }) {
+    return PortfolioPnlViewedEvent(
+      timeframe: timeframe,
+      realizedPnl: realizedPnl,
+      unrealizedPnl: unrealizedPnl,
+    );
+  }
+
+  /// App opened / foregrounded event
+  static AppOpenedEvent appOpened({
+    required String platform,
+    required String appVersion,
+  }) {
+    return AppOpenedEvent(platform: platform, appVersion: appVersion);
+  }
+
+  /// Onboarding started event
+  static OnboardingStartedEvent onboardingStarted({
+    required String method,
+    String? referralSource,
+  }) {
+    return OnboardingStartedEvent(
+      method: method,
+      referralSource: referralSource,
+    );
+  }
+
+  /// Wallet created event
+  static WalletCreatedEvent walletCreated({
+    required String source,
+    required String walletType,
+  }) {
+    return WalletCreatedEvent(source: source, walletType: walletType);
+  }
+
+  /// Wallet imported event
+  static WalletImportedEvent walletImported({
+    required String source,
+    required String importType,
+    required String walletType,
+  }) {
+    return WalletImportedEvent(
+      source: source,
+      importType: importType,
+      walletType: walletType,
+    );
+  }
+
+  /// Seed backup completed event
+  static BackupCompletedEvent backupCompleted({
+    required int backupTime,
+    required String method,
+    required String walletType,
+  }) {
+    return BackupCompletedEvent(
+      backupTime: backupTime,
+      method: method,
+      walletType: walletType,
+    );
+  }
+
+  /// Backup skipped event
+  static BackupSkippedEvent backupSkipped({
+    required String stageSkipped,
+    required String walletType,
+  }) {
+    return BackupSkippedEvent(
+      stageSkipped: stageSkipped,
+      walletType: walletType,
+    );
+  }
+}

--- a/lib/views/settings/widgets/security_settings/seed_settings/seed_confirmation/seed_confirmation.dart
+++ b/lib/views/settings/widgets/security_settings/seed_settings/seed_confirmation/seed_confirmation.dart
@@ -5,6 +5,9 @@ import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
 import 'package:web_dex/bloc/security_settings/security_settings_bloc.dart';
 import 'package:web_dex/bloc/security_settings/security_settings_event.dart';
 import 'package:web_dex/common/screen.dart';
+import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
+import 'package:web_dex/bloc/analytics/analytics_event.dart';
+import 'package:web_dex/analytics/analytics_factory.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/text_error.dart';
 import 'package:web_dex/views/settings/widgets/security_settings/seed_settings/seed_back_button.dart';
@@ -50,9 +53,27 @@ class _SeedConfirmationState extends State<SeedConfirmation> {
               Padding(
                 padding: const EdgeInsets.only(bottom: 16.0),
                 child: SeedBackButton(
-                  () => context
-                      .read<SecuritySettingsBloc>()
-                      .add(const ShowSeedEvent()),
+                  () {
+                    context.read<AnalyticsBloc>().add(
+                          AnalyticsSendDataEvent(
+                            AnalyticsEvents.backupSkipped(
+                              stageSkipped: 'seed_confirm',
+                              walletType: context
+                                      .read<AuthBloc>()
+                                      .state
+                                      .currentUser
+                                      ?.wallet
+                                      .config
+                                      .type
+                                      .name ??
+                                  '',
+                            ),
+                          ),
+                        );
+                    context
+                        .read<SecuritySettingsBloc>()
+                        .add(const ShowSeedEvent());
+                  },
                 ),
               ),
             ConstrainedBox(
@@ -115,6 +136,18 @@ class _SeedConfirmationState extends State<SeedConfirmation> {
       final settingsBloc = context.read<SecuritySettingsBloc>();
       settingsBloc.add(const SeedConfirmedEvent());
       context.read<AuthBloc>().add(AuthSeedBackupConfirmed());
+      final walletType =
+          context.read<AuthBloc>().state.currentUser?.wallet.config.type.name ??
+              '';
+      context.read<AnalyticsBloc>().add(
+            AnalyticsSendDataEvent(
+              AnalyticsEvents.backupCompleted(
+                backupTime: 0,
+                method: 'manual',
+                walletType: walletType,
+              ),
+            ),
+          );
       return;
     }
     setState(() {

--- a/lib/views/settings/widgets/security_settings/seed_settings/seed_show.dart
+++ b/lib/views/settings/widgets/security_settings/seed_settings/seed_show.dart
@@ -8,6 +8,10 @@ import 'package:web_dex/bloc/security_settings/security_settings_bloc.dart';
 import 'package:web_dex/bloc/security_settings/security_settings_event.dart';
 import 'package:web_dex/bloc/security_settings/security_settings_state.dart';
 import 'package:web_dex/common/screen.dart';
+import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
+import 'package:web_dex/bloc/analytics/analytics_event.dart';
+import 'package:web_dex/analytics/analytics_factory.dart';
+import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/coin.dart';
 import 'package:web_dex/shared/utils/formatters.dart';
@@ -40,9 +44,25 @@ class SeedShow extends StatelessWidget {
             if (!isMobile)
               Padding(
                 padding: const EdgeInsets.only(bottom: 16.0),
-                child: SeedBackButton(() => context
-                    .read<SecuritySettingsBloc>()
-                    .add(const ResetEvent())),
+                child: SeedBackButton(() {
+                  context.read<AnalyticsBloc>().add(
+                        AnalyticsSendDataEvent(
+                          AnalyticsEvents.backupSkipped(
+                            stageSkipped: 'seed_show',
+                            walletType: context
+                                    .read<AuthBloc>()
+                                    .state
+                                    .currentUser
+                                    ?.wallet
+                                    .config
+                                    .type
+                                    .name ??
+                                '',
+                          ),
+                        ),
+                      );
+                  context.read<SecuritySettingsBloc>().add(const ResetEvent());
+                }),
               ),
             ConstrainedBox(
               constraints: const BoxConstraints(maxWidth: 680),

--- a/lib/views/wallet/coin_details/coin_details_info/charts/animated_portfolio_charts.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/charts/animated_portfolio_charts.dart
@@ -2,6 +2,10 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:web_dex/bloc/cex_market_data/portfolio_growth/portfolio_growth_bloc.dart';
+import 'package:web_dex/bloc/cex_market_data/profit_loss/profit_loss_bloc.dart';
+import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
+import 'package:web_dex/bloc/analytics/analytics_event.dart';
+import 'package:web_dex/analytics/analytics_factory.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/coin.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_details_info/charts/portfolio_growth_chart.dart';
@@ -43,6 +47,32 @@ class _AnimatedPortfolioChartsState extends State<AnimatedPortfolioCharts> {
         _userHasInteracted = true;
       });
     }
+
+    if (widget.tabController.index == 1 &&
+        !widget.tabController.indexIsChanging) {
+      final profitLossState = context.read<ProfitLossBloc>().state;
+      if (profitLossState is PortfolioProfitLossChartLoadSuccess) {
+        final timeframe = _formatDuration(profitLossState.selectedPeriod);
+        context.read<AnalyticsBloc>().add(
+              AnalyticsSendDataEvent(
+                AnalyticsEvents.portfolioPnlViewed(
+                  timeframe: timeframe,
+                  realizedPnl: profitLossState.totalValue,
+                  unrealizedPnl: 0,
+                ),
+              ),
+            );
+      }
+    }
+  }
+
+  String _formatDuration(Duration duration) {
+    if (duration.inDays >= 365) return '${duration.inDays ~/ 365}y';
+    if (duration.inDays >= 30) return '${duration.inDays ~/ 30}M';
+    if (duration.inDays >= 1) return '${duration.inDays}d';
+    if (duration.inHours >= 1) return '${duration.inHours}h';
+    if (duration.inMinutes >= 1) return '${duration.inMinutes}m';
+    return '${duration.inSeconds}s';
   }
 
   @override

--- a/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
@@ -9,6 +9,9 @@ import 'package:web_dex/app_config/app_config.dart';
 import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
 import 'package:web_dex/bloc/cex_market_data/portfolio_growth/portfolio_growth_bloc.dart';
 import 'package:web_dex/bloc/cex_market_data/profit_loss/profit_loss_bloc.dart';
+import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
+import 'package:web_dex/bloc/analytics/analytics_event.dart';
+import 'package:web_dex/analytics/analytics_factory.dart';
 import 'package:web_dex/bloc/coin_addresses/bloc/coin_addresses_bloc.dart';
 import 'package:web_dex/bloc/coin_addresses/bloc/coin_addresses_event.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_bloc.dart';
@@ -405,7 +408,32 @@ class _CoinDetailsMarketMetricsTabBarState
           _currentIndex = _tabController!.index;
         });
       }
+
+      if (_tabController!.index == 1 && !_tabController!.indexIsChanging) {
+        final profitLossState = context.read<ProfitLossBloc>().state;
+        if (profitLossState is PortfolioProfitLossChartLoadSuccess) {
+          final timeframe = _formatDuration(profitLossState.selectedPeriod);
+          context.read<AnalyticsBloc>().add(
+                AnalyticsSendDataEvent(
+                  AnalyticsEvents.portfolioPnlViewed(
+                    timeframe: timeframe,
+                    realizedPnl: profitLossState.totalValue,
+                    unrealizedPnl: 0,
+                  ),
+                ),
+              );
+        }
+      }
     });
+  }
+
+  String _formatDuration(Duration duration) {
+    if (duration.inDays >= 365) return '${duration.inDays ~/ 365}y';
+    if (duration.inDays >= 30) return '${duration.inDays ~/ 30}M';
+    if (duration.inDays >= 1) return '${duration.inDays}d';
+    if (duration.inHours >= 1) return '${duration.inHours}h';
+    if (duration.inMinutes >= 1) return '${duration.inMinutes}m';
+    return '${duration.inSeconds}s';
   }
 
   @override


### PR DESCRIPTION
## Summary
- add E01-E06 analytics event data classes and factory methods
- log app lifecycle events via `_AnalyticsLifecycleHandler`
- fire onboarding started, wallet created/imported events from wallet manager
- track backup completion and skipped events in seed backup workflow

## Testing
- `flutter pub get --offline`
- `dart format lib/analytics/analytics_factory.dart lib/main.dart lib/views/wallets_manager/widgets/iguana_wallets_manager.dart lib/views/settings/widgets/security_settings/seed_settings/seed_confirmation/seed_confirmation.dart lib/views/settings/widgets/security_settings/seed_settings/seed_show.dart`
- `flutter analyze` *(fails: 528 issues found)*