### PR TITLE
Add analytics callbacks for send and swap events

### DIFF
--- a/lib/analytics/events/transaction_events.dart
+++ b/lib/analytics/events/transaction_events.dart
@@ -1,0 +1,282 @@
+import '../../bloc/analytics/analytics_repo.dart';
+
+// E14: Send flow started
+// ------------------------------------------
+
+/// E14: Send flow started
+/// Measures when a user initiates a send transaction. Business category: Transactions.
+/// Provides insights on transaction funnel start and popular send assets.
+class SendInitiatedEventData implements AnalyticsEventData {
+  const SendInitiatedEventData({
+    required this.assetSymbol,
+    required this.network,
+    required this.amount,
+    required this.walletType,
+  });
+
+  final String assetSymbol;
+  final String network;
+  final double amount;
+  final String walletType;
+
+  @override
+  String get name => 'send_initiated';
+
+  @override
+  JsonMap get parameters => {
+        'asset_symbol': assetSymbol,
+        'network': network,
+        'amount': amount,
+        'wallet_type': walletType,
+      };
+}
+
+/// E14: Send flow started
+class AnalyticsSendInitiatedEvent extends AnalyticsSendDataEvent {
+  AnalyticsSendInitiatedEvent({
+    required String assetSymbol,
+    required String network,
+    required double amount,
+    required String walletType,
+  }) : super(SendInitiatedEventData(
+          assetSymbol: assetSymbol,
+          network: network,
+          amount: amount,
+          walletType: walletType,
+        ));
+}
+
+// E15: On-chain send completed
+// ------------------------------------------
+
+/// E15: On-chain send completed
+/// Measures when an on-chain send transaction is completed successfully. Business category: Transactions.
+/// Provides insights on successful sends, volume, and average size.
+class SendSucceededEventData implements AnalyticsEventData {
+  const SendSucceededEventData({
+    required this.assetSymbol,
+    required this.network,
+    required this.amount,
+    required this.walletType,
+  });
+
+  final String assetSymbol;
+  final String network;
+  final double amount;
+  final String walletType;
+
+  @override
+  String get name => 'send_success';
+
+  @override
+  JsonMap get parameters => {
+        'asset_symbol': assetSymbol,
+        'network': network,
+        'amount': amount,
+        'wallet_type': walletType,
+      };
+}
+
+/// E15: On-chain send completed
+class AnalyticsSendSucceededEvent extends AnalyticsSendDataEvent {
+  AnalyticsSendSucceededEvent({
+    required String assetSymbol,
+    required String network,
+    required double amount,
+    required String walletType,
+  }) : super(SendSucceededEventData(
+          assetSymbol: assetSymbol,
+          network: network,
+          amount: amount,
+          walletType: walletType,
+        ));
+}
+
+// E16: Send failed / cancelled
+// ------------------------------------------
+
+/// E16: Send failed / cancelled
+/// Measures when a send transaction fails or is cancelled. Business category: Transactions.
+/// Provides insights on error hotspots and UX/network issues.
+class SendFailedEventData implements AnalyticsEventData {
+  const SendFailedEventData({
+    required this.assetSymbol,
+    required this.network,
+    required this.failReason,
+    required this.walletType,
+  });
+
+  final String assetSymbol;
+  final String network;
+  final String failReason;
+  final String walletType;
+
+  @override
+  String get name => 'send_failure';
+
+  @override
+  JsonMap get parameters => {
+        'asset_symbol': assetSymbol,
+        'network': network,
+        'fail_reason': failReason,
+        'wallet_type': walletType,
+      };
+}
+
+/// E16: Send failed / cancelled
+class AnalyticsSendFailedEvent extends AnalyticsSendDataEvent {
+  AnalyticsSendFailedEvent({
+    required String assetSymbol,
+    required String network,
+    required String failReason,
+    required String walletType,
+  }) : super(SendFailedEventData(
+          assetSymbol: assetSymbol,
+          network: network,
+          failReason: failReason,
+          walletType: walletType,
+        ));
+}
+
+// E17: Swap order submitted
+// ------------------------------------------
+
+/// E17: Swap order submitted
+/// Measures when a swap order is submitted. Business category: Trading (DEX).
+/// Provides insights on DEX funnel start and pair demand.
+class SwapInitiatedEventData implements AnalyticsEventData {
+  const SwapInitiatedEventData({
+    required this.fromAsset,
+    required this.toAsset,
+    required this.networks,
+    required this.walletType,
+  });
+
+  final String fromAsset;
+  final String toAsset;
+  final String networks;
+  final String walletType;
+
+  @override
+  String get name => 'swap_initiated';
+
+  @override
+  JsonMap get parameters => {
+        'from_asset': fromAsset,
+        'to_asset': toAsset,
+        'networks': networks,
+        'wallet_type': walletType,
+      };
+}
+
+/// E17: Swap order submitted
+class AnalyticsSwapInitiatedEvent extends AnalyticsSendDataEvent {
+  AnalyticsSwapInitiatedEvent({
+    required String fromAsset,
+    required String toAsset,
+    required String networks,
+    required String walletType,
+  }) : super(SwapInitiatedEventData(
+          fromAsset: fromAsset,
+          toAsset: toAsset,
+          networks: networks,
+          walletType: walletType,
+        ));
+}
+
+// E18: Atomic swap succeeded
+// ------------------------------------------
+
+/// E18: Atomic swap succeeded
+/// Measures when an atomic swap is completed successfully. Business category: Trading (DEX).
+/// Provides insights on trading volume and fee revenue.
+class SwapSucceededEventData implements AnalyticsEventData {
+  const SwapSucceededEventData({
+    required this.fromAsset,
+    required this.toAsset,
+    required this.amount,
+    required this.fee,
+    required this.walletType,
+  });
+
+  final String fromAsset;
+  final String toAsset;
+  final double amount;
+  final double fee;
+  final String walletType;
+
+  @override
+  String get name => 'swap_success';
+
+  @override
+  JsonMap get parameters => {
+        'from_asset': fromAsset,
+        'to_asset': toAsset,
+        'amount': amount,
+        'fee': fee,
+        'wallet_type': walletType,
+      };
+}
+
+/// E18: Atomic swap succeeded
+class AnalyticsSwapSucceededEvent extends AnalyticsSendDataEvent {
+  AnalyticsSwapSucceededEvent({
+    required String fromAsset,
+    required String toAsset,
+    required double amount,
+    required double fee,
+    required String walletType,
+  }) : super(SwapSucceededEventData(
+          fromAsset: fromAsset,
+          toAsset: toAsset,
+          amount: amount,
+          fee: fee,
+          walletType: walletType,
+        ));
+}
+
+// E19: Swap failed
+// ------------------------------------------
+
+/// E19: Swap failed
+/// Measures when an atomic swap fails. Business category: Trading (DEX).
+/// Provides insights on liquidity gaps and technical/UX blockers.
+class SwapFailedEventData implements AnalyticsEventData {
+  const SwapFailedEventData({
+    required this.fromAsset,
+    required this.toAsset,
+    required this.failStage,
+    required this.walletType,
+  });
+
+  final String fromAsset;
+  final String toAsset;
+  final String failStage;
+  final String walletType;
+
+  @override
+  String get name => 'swap_failure';
+
+  @override
+  JsonMap get parameters => {
+        'from_asset': fromAsset,
+        'to_asset': toAsset,
+        'fail_stage': failStage,
+        'wallet_type': walletType,
+      };
+}
+
+/// E19: Swap failed
+class AnalyticsSwapFailedEvent extends AnalyticsSendDataEvent {
+  AnalyticsSwapFailedEvent({
+    required String fromAsset,
+    required String toAsset,
+    required String failStage,
+    required String walletType,
+  }) : super(SwapFailedEventData(
+          fromAsset: fromAsset,
+          toAsset: toAsset,
+          failStage: failStage,
+          walletType: walletType,
+        ));
+}

--- a/lib/views/wallet/coin_details/withdraw_form/withdraw_form.dart
+++ b/lib/views/wallet/coin_details/withdraw_form/withdraw_form.dart
@@ -7,6 +7,10 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 import 'package:komodo_ui/komodo_ui.dart';
+import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
+import 'package:web_dex/bloc/analytics/analytics_event.dart';
+import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
+import 'package:web_dex/analytics/events/transaction_events.dart';
 import 'package:web_dex/bloc/withdraw_form/withdraw_form_bloc.dart';
 import 'package:web_dex/mm2/mm2_api/rpc/base.dart';
 import 'package:web_dex/model/text_error.dart';
@@ -53,10 +57,45 @@ class _WithdrawFormState extends State<WithdrawForm> {
   Widget build(BuildContext context) {
     return BlocProvider.value(
       value: _formBloc,
-      child: BlocListener<WithdrawFormBloc, WithdrawFormState>(
-        listenWhen: (prev, curr) =>
-            prev.step != curr.step && curr.step == WithdrawFormStep.success,
-        listener: (_, __) => widget.onSuccess(),
+      child: MultiBlocListener(
+        listeners: [
+          BlocListener<WithdrawFormBloc, WithdrawFormState>(
+            listenWhen: (prev, curr) =>
+                prev.step != curr.step && curr.step == WithdrawFormStep.success,
+            listener: (context, state) {
+              final authBloc = context.read<AuthBloc>();
+              final walletType =
+                  authBloc.state.currentUser?.wallet.config.type.name ?? '';
+              context.read<AnalyticsBloc>().add(
+                    AnalyticsSendSucceededEvent(
+                      assetSymbol: state.asset.id.id,
+                      network: state.asset.protocolType,
+                      amount: double.tryParse(state.amount) ?? 0.0,
+                      walletType: walletType,
+                    ),
+                  );
+              widget.onSuccess();
+            },
+          ),
+          BlocListener<WithdrawFormBloc, WithdrawFormState>(
+            listenWhen: (prev, curr) =>
+                prev.step != curr.step && curr.step == WithdrawFormStep.failed,
+            listener: (context, state) {
+              final authBloc = context.read<AuthBloc>();
+              final walletType =
+                  authBloc.state.currentUser?.wallet.config.type.name ?? '';
+              final reason = state.transactionError?.message ?? 'unknown';
+              context.read<AnalyticsBloc>().add(
+                    AnalyticsSendFailedEvent(
+                      assetSymbol: state.asset.id.id,
+                      network: state.asset.protocolType,
+                      failReason: reason,
+                      walletType: walletType,
+                    ),
+                  );
+            },
+          ),
+        ],
         child: WithdrawFormContent(
           onBackButtonPressed: widget.onBackButtonPressed,
         ),
@@ -377,6 +416,18 @@ class WithdrawFormFillSection extends StatelessWidget {
               onPressed: state.isSending || state.hasValidationErrors
                   ? null
                   : () {
+                      final authBloc = context.read<AuthBloc>();
+                      final walletType =
+                          authBloc.state.currentUser?.wallet.config.type.name ??
+                              '';
+                      context.read<AnalyticsBloc>().add(
+                            AnalyticsSendInitiatedEvent(
+                              assetSymbol: state.asset.id.id,
+                              network: state.asset.protocolType,
+                              amount: double.tryParse(state.amount) ?? 0.0,
+                              walletType: walletType,
+                            ),
+                          );
                       context
                           .read<WithdrawFormBloc>()
                           .add(const WithdrawFormPreviewSubmitted());


### PR DESCRIPTION
## Summary
- implement transaction analytics events
- log send initiated, success and failure
- log swap initiated in maker and taker confirmations
- track swap success/failure in trading details

## Testing
- `flutter analyze`