### PR TITLE
Add portfolio and asset analytics events

### DIFF
--- a/lib/analytics/events/portfolio_events.dart
+++ b/lib/analytics/events/portfolio_events.dart
@@ -1,0 +1,292 @@
+import '../bloc/analytics/analytics_repo.dart';
+
+// E07: Portfolio overview opened
+// ------------------------------------------
+
+/// E07: Portfolio overview opened
+/// Measures when the portfolio overview is viewed. Business category: Portfolio.
+/// Provides insights on balance-check engagement.
+class PortfolioViewedEventData implements AnalyticsEventData {
+  const PortfolioViewedEventData({
+    required this.totalCoins,
+    required this.totalValueUsd,
+  });
+
+  final int totalCoins;
+  final double totalValueUsd;
+
+  @override
+  String get name => 'portfolio_viewed';
+
+  @override
+  JsonMap get parameters => {
+        'total_coins': totalCoins,
+        'total_value_usd': totalValueUsd,
+      };
+}
+
+/// E07: Portfolio overview opened
+class AnalyticsPortfolioViewedEvent extends AnalyticsSendDataEvent {
+  AnalyticsPortfolioViewedEvent({
+    required int totalCoins,
+    required double totalValueUsd,
+  }) : super(
+          PortfolioViewedEventData(
+            totalCoins: totalCoins,
+            totalValueUsd: totalValueUsd,
+          ),
+        );
+}
+
+// E08: Growth chart opened
+// ------------------------------------------
+
+/// E08: Growth chart opened
+/// Measures when a user opens the growth chart. Business category: Portfolio.
+/// Provides insights on long-term performance interest.
+class PortfolioGrowthViewedEventData implements AnalyticsEventData {
+  const PortfolioGrowthViewedEventData({
+    required this.period,
+    required this.growthPct,
+  });
+
+  final String period;
+  final double growthPct;
+
+  @override
+  String get name => 'portfolio_growth_viewed';
+
+  @override
+  JsonMap get parameters => {
+        'period': period,
+        'growth_pct': growthPct,
+      };
+}
+
+/// E08: Growth chart opened
+class AnalyticsPortfolioGrowthViewedEvent extends AnalyticsSendDataEvent {
+  AnalyticsPortfolioGrowthViewedEvent({
+    required String period,
+    required double growthPct,
+  }) : super(
+          PortfolioGrowthViewedEventData(
+            period: period,
+            growthPct: growthPct,
+          ),
+        );
+}
+
+// E09: P&L breakdown viewed
+// ------------------------------------------
+
+/// E09: P&L breakdown viewed
+/// Measures when a user views the P&L breakdown. Business category: Portfolio.
+/// Provides insights on trading insight demand and upsell cues.
+class PortfolioPnlViewedEventData implements AnalyticsEventData {
+  const PortfolioPnlViewedEventData({
+    required this.timeframe,
+    required this.realizedPnl,
+    required this.unrealizedPnl,
+  });
+
+  final String timeframe;
+  final double realizedPnl;
+  final double unrealizedPnl;
+
+  @override
+  String get name => 'portfolio_pnl_viewed';
+
+  @override
+  JsonMap get parameters => {
+        'timeframe': timeframe,
+        'realized_pnl': realizedPnl,
+        'unrealized_pnl': unrealizedPnl,
+      };
+}
+
+/// E09: P&L breakdown viewed
+class AnalyticsPortfolioPnlViewedEvent extends AnalyticsSendDataEvent {
+  AnalyticsPortfolioPnlViewedEvent({
+    required String timeframe,
+    required double realizedPnl,
+    required double unrealizedPnl,
+  }) : super(
+          PortfolioPnlViewedEventData(
+            timeframe: timeframe,
+            realizedPnl: realizedPnl,
+            unrealizedPnl: unrealizedPnl,
+          ),
+        );
+}
+
+// E10: Custom token added
+// ------------------------------------------
+
+/// E10: Custom token added
+/// Measures when a user adds a custom token. Business category: Asset Management.
+/// Provides insights on token diversity and network popularity.
+class AssetAddedEventData implements AnalyticsEventData {
+  const AssetAddedEventData({
+    required this.assetSymbol,
+    required this.assetNetwork,
+    required this.walletType,
+  });
+
+  final String assetSymbol;
+  final String assetNetwork;
+  final String walletType;
+
+  @override
+  String get name => 'add_asset';
+
+  @override
+  JsonMap get parameters => {
+        'asset_symbol': assetSymbol,
+        'asset_network': assetNetwork,
+        'wallet_type': walletType,
+      };
+}
+
+/// E10: Custom token added
+class AnalyticsAssetAddedEvent extends AnalyticsSendDataEvent {
+  AnalyticsAssetAddedEvent({
+    required String assetSymbol,
+    required String assetNetwork,
+    required String walletType,
+  }) : super(
+          AssetAddedEventData(
+            assetSymbol: assetSymbol,
+            assetNetwork: assetNetwork,
+            walletType: walletType,
+          ),
+        );
+}
+
+// E11: Asset detail viewed
+// ------------------------------------------
+
+/// E11: Asset detail viewed
+/// Measures when a user views the detailed information of an asset. Business category: Asset Management.
+/// Provides insights on asset popularity and research depth.
+class AssetViewedEventData implements AnalyticsEventData {
+  const AssetViewedEventData({
+    required this.assetSymbol,
+    required this.assetNetwork,
+    required this.walletType,
+  });
+
+  final String assetSymbol;
+  final String assetNetwork;
+  final String walletType;
+
+  @override
+  String get name => 'view_asset';
+
+  @override
+  JsonMap get parameters => {
+        'asset_symbol': assetSymbol,
+        'asset_network': assetNetwork,
+        'wallet_type': walletType,
+      };
+}
+
+/// E11: Asset detail viewed
+class AnalyticsAssetViewedEvent extends AnalyticsSendDataEvent {
+  AnalyticsAssetViewedEvent({
+    required String assetSymbol,
+    required String assetNetwork,
+    required String walletType,
+  }) : super(
+          AssetViewedEventData(
+            assetSymbol: assetSymbol,
+            assetNetwork: assetNetwork,
+            walletType: walletType,
+          ),
+        );
+}
+
+// E12: Existing asset toggled on / made visible
+// ------------------------------------------
+
+/// E12: Existing asset toggled on / made visible
+/// Measures when a user enables an existing asset. Business category: Asset Management.
+/// Provides insights on which assets users want on dashboard and feature adoption.
+class AssetEnabledEventData implements AnalyticsEventData {
+  const AssetEnabledEventData({
+    required this.assetSymbol,
+    required this.assetNetwork,
+    required this.walletType,
+  });
+
+  final String assetSymbol;
+  final String assetNetwork;
+  final String walletType;
+
+  @override
+  String get name => 'asset_enabled';
+
+  @override
+  JsonMap get parameters => {
+        'asset_symbol': assetSymbol,
+        'asset_network': assetNetwork,
+        'wallet_type': walletType,
+      };
+}
+
+/// E12: Existing asset toggled on / made visible
+class AnalyticsAssetEnabledEvent extends AnalyticsSendDataEvent {
+  AnalyticsAssetEnabledEvent({
+    required String assetSymbol,
+    required String assetNetwork,
+    required String walletType,
+  }) : super(
+          AssetEnabledEventData(
+            assetSymbol: assetSymbol,
+            assetNetwork: assetNetwork,
+            walletType: walletType,
+          ),
+        );
+}
+
+// E13: Token toggled off / hidden
+// ------------------------------------------
+
+/// E13: Token toggled off / hidden
+/// Measures when a user disables or hides a token. Business category: Asset Management.
+/// Provides insights on portfolio-cleanup behavior and waning asset interest.
+class AssetDisabledEventData implements AnalyticsEventData {
+  const AssetDisabledEventData({
+    required this.assetSymbol,
+    required this.assetNetwork,
+    required this.walletType,
+  });
+
+  final String assetSymbol;
+  final String assetNetwork;
+  final String walletType;
+
+  @override
+  String get name => 'asset_disabled';
+
+  @override
+  JsonMap get parameters => {
+        'asset_symbol': assetSymbol,
+        'asset_network': assetNetwork,
+        'wallet_type': walletType,
+      };
+}
+
+/// E13: Token toggled off / hidden
+class AnalyticsAssetDisabledEvent extends AnalyticsSendDataEvent {
+  AnalyticsAssetDisabledEvent({
+    required String assetSymbol,
+    required String assetNetwork,
+    required String walletType,
+  }) : super(
+          AssetDisabledEventData(
+            assetSymbol: assetSymbol,
+            assetNetwork: assetNetwork,
+            walletType: walletType,
+          ),
+        );
+}

--- a/lib/bloc/app_bloc_root.dart
+++ b/lib/bloc/app_bloc_root.dart
@@ -299,6 +299,7 @@ class AppBlocRoot extends StatelessWidget {
             create: (context) => CoinsManagerBloc(
               coinsRepo: coinsRepository,
               sdk: komodoDefiSdk,
+              analyticsBloc: context.read<AnalyticsBloc>(),
             ),
           ),
           BlocProvider<FaucetBloc>(

--- a/lib/bloc/coins_manager/coins_manager_bloc.dart
+++ b/lib/bloc/coins_manager/coins_manager_bloc.dart
@@ -5,6 +5,8 @@ import 'package:flutter_bloc/flutter_bloc.dart' show Bloc, Emitter;
 import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
 import 'package:web_dex/app_config/app_config.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_repo.dart';
+import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
+import 'package:web_dex/analytics/events/portfolio_events.dart';
 import 'package:web_dex/model/coin.dart';
 import 'package:web_dex/model/coin_type.dart';
 import 'package:web_dex/model/coin_utils.dart';
@@ -19,8 +21,10 @@ class CoinsManagerBloc extends Bloc<CoinsManagerEvent, CoinsManagerState> {
   CoinsManagerBloc({
     required CoinsRepo coinsRepo,
     required KomodoDefiSdk sdk,
+    required AnalyticsBloc analyticsBloc,
   })  : _coinsRepo = coinsRepo,
         _sdk = sdk,
+        _analyticsBloc = analyticsBloc,
         super(CoinsManagerState.initial(coins: [])) {
     on<CoinsManagerCoinsUpdate>(_onCoinsUpdate);
     on<CoinsManagerCoinsListReset>(_onCoinsListReset);
@@ -34,6 +38,7 @@ class CoinsManagerBloc extends Bloc<CoinsManagerEvent, CoinsManagerState> {
 
   final CoinsRepo _coinsRepo;
   final KomodoDefiSdk _sdk;
+  final AnalyticsBloc _analyticsBloc;
 
   List<Coin> mergeCoinLists(List<Coin> originalList, List<Coin> newList) {
     final Map<String, Coin> coinMap = {};
@@ -119,10 +124,10 @@ class CoinsManagerBloc extends Bloc<CoinsManagerEvent, CoinsManagerState> {
     await switchingFuture;
   }
 
-  void _onCoinSelect(
+  Future<void> _onCoinSelect(
     CoinsManagerCoinSelect event,
     Emitter<CoinsManagerState> emit,
-  ) {
+  ) async {
     final coin = event.coin;
     final List<Coin> selectedCoins = List.from(state.selectedCoins);
     if (selectedCoins.contains(coin)) {
@@ -130,16 +135,48 @@ class CoinsManagerBloc extends Bloc<CoinsManagerEvent, CoinsManagerState> {
 
       if (state.action == CoinsManagerAction.add) {
         _coinsRepo.deactivateCoinsSync([event.coin]);
+        _analyticsBloc.add(
+          AnalyticsAssetDisabledEvent(
+            assetSymbol: coin.abbr,
+            assetNetwork: coin.protocolType,
+            walletType:
+                (await _sdk.auth.currentUser)?.wallet.config.type.name ?? '',
+          ),
+        );
       } else {
         _coinsRepo.activateCoinsSync([event.coin]);
+        _analyticsBloc.add(
+          AnalyticsAssetEnabledEvent(
+            assetSymbol: coin.abbr,
+            assetNetwork: coin.protocolType,
+            walletType:
+                (await _sdk.auth.currentUser)?.wallet.config.type.name ?? '',
+          ),
+        );
       }
     } else {
       selectedCoins.add(coin);
 
       if (state.action == CoinsManagerAction.add) {
         _coinsRepo.activateCoinsSync([event.coin]);
+        _analyticsBloc.add(
+          AnalyticsAssetEnabledEvent(
+            assetSymbol: coin.abbr,
+            assetNetwork: coin.protocolType,
+            walletType:
+                (await _sdk.auth.currentUser)?.wallet.config.type.name ?? '',
+          ),
+        );
       } else {
         _coinsRepo.deactivateCoinsSync([event.coin]);
+        _analyticsBloc.add(
+          AnalyticsAssetDisabledEvent(
+            assetSymbol: coin.abbr,
+            assetNetwork: coin.protocolType,
+            walletType:
+                (await _sdk.auth.currentUser)?.wallet.config.type.name ?? '',
+          ),
+        );
       }
     }
     emit(state.copyWith(selectedCoins: selectedCoins));

--- a/lib/bloc/custom_token_import/bloc/custom_token_import_bloc.dart
+++ b/lib/bloc/custom_token_import/bloc/custom_token_import_bloc.dart
@@ -6,6 +6,9 @@ import 'package:web_dex/bloc/coins_bloc/coins_repo.dart';
 import 'package:web_dex/bloc/custom_token_import/bloc/custom_token_import_event.dart';
 import 'package:web_dex/bloc/custom_token_import/bloc/custom_token_import_state.dart';
 import 'package:web_dex/bloc/custom_token_import/data/custom_token_import_repository.dart';
+import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
+import 'package:web_dex/analytics/events/portfolio_events.dart';
+import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
 import 'package:web_dex/model/coin_type.dart';
 import 'package:web_dex/shared/utils/utils.dart';
 
@@ -13,9 +16,15 @@ class CustomTokenImportBloc
     extends Bloc<CustomTokenImportEvent, CustomTokenImportState> {
   final ICustomTokenImportRepository repository;
   final CoinsRepo _coinsRepo;
+  final KomodoDefiSdk sdk;
+  final AnalyticsBloc analyticsBloc;
 
-  CustomTokenImportBloc(this.repository, this._coinsRepo)
-      : super(CustomTokenImportState.defaults()) {
+  CustomTokenImportBloc(
+    this.repository,
+    this._coinsRepo,
+    this.sdk,
+    this.analyticsBloc,
+  ) : super(CustomTokenImportState.defaults()) {
     on<UpdateNetworkEvent>(_onUpdateAsset);
     on<UpdateAddressEvent>(_onUpdateAddress);
     on<SubmitImportCustomTokenEvent>(_onSubmitImportCustomToken);
@@ -124,6 +133,16 @@ class CustomTokenImportBloc
 
     try {
       await repository.importCustomToken(state.coin!);
+
+      final walletType =
+          (await sdk.auth.currentUser)?.wallet.config.type.name ?? '';
+      analyticsBloc.add(
+        AnalyticsAssetAddedEvent(
+          assetSymbol: state.coin!.id.id,
+          assetNetwork: state.network.ticker,
+          walletType: walletType,
+        ),
+      );
 
       emit(
         state.copyWith(

--- a/lib/views/custom_token_import/custom_token_import_button.dart
+++ b/lib/views/custom_token_import/custom_token_import_button.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_repo.dart';
+import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
 import 'package:web_dex/bloc/custom_token_import/bloc/custom_token_import_bloc.dart';
 import 'package:web_dex/bloc/custom_token_import/bloc/custom_token_import_event.dart';
 import 'package:web_dex/bloc/custom_token_import/data/custom_token_import_repository.dart';
@@ -26,6 +27,8 @@ class CustomTokenImportButton extends StatelessWidget {
               create: (context) => CustomTokenImportBloc(
                 KdfCustomTokenImportRepository(kdfSdk, coinsRepo),
                 coinsRepo,
+                kdfSdk,
+                context.read<AnalyticsBloc>(),
               )..add(const ResetFormStatusEvent()),
               child: const CustomTokenImportDialog(),
             );

--- a/lib/views/wallet/coin_details/coin_details_info/charts/animated_portfolio_charts.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/charts/animated_portfolio_charts.dart
@@ -5,7 +5,7 @@ import 'package:web_dex/bloc/cex_market_data/portfolio_growth/portfolio_growth_b
 import 'package:web_dex/bloc/cex_market_data/profit_loss/profit_loss_bloc.dart';
 import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
 import 'package:web_dex/bloc/analytics/analytics_event.dart';
-import 'package:web_dex/analytics/analytics_factory.dart';
+import 'package:web_dex/analytics/events/portfolio_events.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/coin.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_details_info/charts/portfolio_growth_chart.dart';
@@ -48,20 +48,30 @@ class _AnimatedPortfolioChartsState extends State<AnimatedPortfolioCharts> {
       });
     }
 
-    if (widget.tabController.index == 1 &&
-        !widget.tabController.indexIsChanging) {
-      final profitLossState = context.read<ProfitLossBloc>().state;
-      if (profitLossState is PortfolioProfitLossChartLoadSuccess) {
-        final timeframe = _formatDuration(profitLossState.selectedPeriod);
-        context.read<AnalyticsBloc>().add(
-              AnalyticsSendDataEvent(
-                AnalyticsEvents.portfolioPnlViewed(
+    if (!widget.tabController.indexIsChanging) {
+      if (widget.tabController.index == 0) {
+        final growthState = context.read<PortfolioGrowthBloc>().state;
+        if (growthState is PortfolioGrowthChartLoadSuccess) {
+          final period = _formatDuration(growthState.selectedPeriod);
+          context.read<AnalyticsBloc>().add(
+                AnalyticsPortfolioGrowthViewedEvent(
+                  period: period,
+                  growthPct: growthState.percentageIncrease,
+                ),
+              );
+        }
+      } else if (widget.tabController.index == 1) {
+        final profitLossState = context.read<ProfitLossBloc>().state;
+        if (profitLossState is PortfolioProfitLossChartLoadSuccess) {
+          final timeframe = _formatDuration(profitLossState.selectedPeriod);
+          context.read<AnalyticsBloc>().add(
+                AnalyticsPortfolioPnlViewedEvent(
                   timeframe: timeframe,
                   realizedPnl: profitLossState.totalValue,
                   unrealizedPnl: 0,
                 ),
-              ),
-            );
+              );
+        }
       }
     }
   }

--- a/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
@@ -11,7 +11,7 @@ import 'package:web_dex/bloc/cex_market_data/portfolio_growth/portfolio_growth_b
 import 'package:web_dex/bloc/cex_market_data/profit_loss/profit_loss_bloc.dart';
 import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
 import 'package:web_dex/bloc/analytics/analytics_event.dart';
-import 'package:web_dex/analytics/analytics_factory.dart';
+import 'package:web_dex/analytics/events/portfolio_events.dart';
 import 'package:web_dex/bloc/coin_addresses/bloc/coin_addresses_bloc.dart';
 import 'package:web_dex/bloc/coin_addresses/bloc/coin_addresses_event.dart';
 import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
@@ -411,19 +411,30 @@ class _CoinDetailsMarketMetricsTabBarState
         });
       }
 
-      if (_tabController!.index == 1 && !_tabController!.indexIsChanging) {
-        final profitLossState = context.read<ProfitLossBloc>().state;
-        if (profitLossState is PortfolioProfitLossChartLoadSuccess) {
-          final timeframe = _formatDuration(profitLossState.selectedPeriod);
-          context.read<AnalyticsBloc>().add(
-                AnalyticsSendDataEvent(
-                  AnalyticsEvents.portfolioPnlViewed(
+      if (!_tabController!.indexIsChanging) {
+        if (_tabController!.index == 0) {
+          final growthState = context.read<PortfolioGrowthBloc>().state;
+          if (growthState is PortfolioGrowthChartLoadSuccess) {
+            final period = _formatDuration(growthState.selectedPeriod);
+            context.read<AnalyticsBloc>().add(
+                  AnalyticsPortfolioGrowthViewedEvent(
+                    period: period,
+                    growthPct: growthState.percentageIncrease,
+                  ),
+                );
+          }
+        } else if (_tabController!.index == 1) {
+          final profitLossState = context.read<ProfitLossBloc>().state;
+          if (profitLossState is PortfolioProfitLossChartLoadSuccess) {
+            final timeframe = _formatDuration(profitLossState.selectedPeriod);
+            context.read<AnalyticsBloc>().add(
+                  AnalyticsPortfolioPnlViewedEvent(
                     timeframe: timeframe,
                     realizedPnl: profitLossState.totalValue,
                     unrealizedPnl: 0,
                   ),
-                ),
-              );
+                );
+          }
         }
       }
     });

--- a/lib/views/wallet/wallet_page/wallet_main/wallet_overview.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/wallet_overview.dart
@@ -5,10 +5,12 @@ import 'package:komodo_ui/komodo_ui.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 import 'package:web_dex/bloc/assets_overview/bloc/asset_overview_bloc.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_bloc.dart';
+import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
+import 'package:web_dex/analytics/events/portfolio_events.dart';
 import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 
-class WalletOverview extends StatelessWidget {
+class WalletOverview extends StatefulWidget {
   const WalletOverview({
     super.key,
     this.onPortfolioGrowthPressed,
@@ -17,6 +19,13 @@ class WalletOverview extends StatelessWidget {
 
   final VoidCallback? onPortfolioGrowthPressed;
   final VoidCallback? onPortfolioProfitLossPressed;
+
+  @override
+  State<WalletOverview> createState() => _WalletOverviewState();
+}
+
+class _WalletOverviewState extends State<WalletOverview> {
+  bool _logged = false;
 
   @override
   Widget build(BuildContext context) {
@@ -32,6 +41,16 @@ class WalletOverview extends StatelessWidget {
                 as PortfolioAssetsOverviewLoadSuccess
             : null;
 
+        if (!_logged && stateWithData != null) {
+          context.read<AnalyticsBloc>().add(
+                AnalyticsPortfolioViewedEvent(
+                  totalCoins: assetCount,
+                  totalValueUsd: stateWithData.totalValue.value,
+                ),
+              );
+          _logged = true;
+        }
+
         return Wrap(
           runSpacing: 16,
           children: [
@@ -42,7 +61,7 @@ class WalletOverview extends StatelessWidget {
                 caption: Text(LocaleKeys.allTimeInvestment.tr()),
                 value: stateWithData?.totalInvestment.value ?? 0,
                 actionIcon: const Icon(CustomIcons.fiatIconCircle),
-                onPressed: onPortfolioGrowthPressed,
+                onPressed: widget.onPortfolioGrowthPressed,
                 footer: Container(
                   height: 28,
                   decoration: BoxDecoration(
@@ -73,7 +92,7 @@ class WalletOverview extends StatelessWidget {
                   percentage: stateWithData?.profitIncreasePercentage ?? 0,
                 ),
                 actionIcon: const Icon(Icons.trending_up),
-                onPressed: onPortfolioProfitLossPressed,
+                onPressed: widget.onPortfolioProfitLossPressed,
               ),
             ),
           ],


### PR DESCRIPTION
## Summary
- add portfolio-related analytics event classes
- log portfolio and asset events in relevant widgets and blocs
- send analytics when toggling asset visibility and importing custom tokens

## Testing
- `flutter analyze`
- `dart format`