### PR TITLE
Implement missing analytics events

### DIFF
--- a/lib/analytics/events/security_events.dart
+++ b/lib/analytics/events/security_events.dart
@@ -1,0 +1,76 @@
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+import 'package:web_dex/bloc/analytics/analytics_event.dart';
+import 'package:web_dex/bloc/analytics/analytics_repo.dart';
+
+/// E05: Seed backup finished
+/// Business category: Security.
+class BackupCompletedEventData implements AnalyticsEventData {
+  const BackupCompletedEventData({
+    required this.backupTime,
+    required this.method,
+    required this.walletType,
+  });
+
+  final int backupTime;
+  final String method;
+  final String walletType;
+
+  @override
+  String get name => 'backup_complete';
+
+  @override
+  JsonMap get parameters => {
+        'backup_time': backupTime,
+        'method': method,
+        'wallet_type': walletType,
+      };
+}
+
+/// E05: Seed backup finished
+class AnalyticsBackupCompletedEvent extends AnalyticsSendDataEvent {
+  AnalyticsBackupCompletedEvent({
+    required int backupTime,
+    required String method,
+    required String walletType,
+  }) : super(
+          BackupCompletedEventData(
+            backupTime: backupTime,
+            method: method,
+            walletType: walletType,
+          ),
+        );
+}
+
+/// E06: Backup skipped / postponed
+/// Business category: Security.
+class BackupSkippedEventData implements AnalyticsEventData {
+  const BackupSkippedEventData({
+    required this.stageSkipped,
+    required this.walletType,
+  });
+
+  final String stageSkipped;
+  final String walletType;
+
+  @override
+  String get name => 'backup_skipped';
+
+  @override
+  JsonMap get parameters => {
+        'stage_skipped': stageSkipped,
+        'wallet_type': walletType,
+      };
+}
+
+/// E06: Backup skipped / postponed
+class AnalyticsBackupSkippedEvent extends AnalyticsSendDataEvent {
+  AnalyticsBackupSkippedEvent({
+    required String stageSkipped,
+    required String walletType,
+  }) : super(
+          BackupSkippedEventData(
+            stageSkipped: stageSkipped,
+            walletType: walletType,
+          ),
+        );
+}

--- a/lib/analytics/events/user_acquisition_events.dart
+++ b/lib/analytics/events/user_acquisition_events.dart
@@ -1,0 +1,111 @@
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+import 'package:web_dex/bloc/analytics/analytics_event.dart';
+import 'package:web_dex/bloc/analytics/analytics_repo.dart';
+
+/// E02: Wallet setup flow begins
+/// Measures when the onboarding flow starts.
+/// Business category: User Acquisition.
+class OnboardingStartedEventData implements AnalyticsEventData {
+  const OnboardingStartedEventData({
+    required this.method,
+    this.referralSource,
+  });
+
+  final String method;
+  final String? referralSource;
+
+  @override
+  String get name => 'onboarding_start';
+
+  @override
+  JsonMap get parameters => {
+        'method': method,
+        if (referralSource != null) 'referral_source': referralSource!,
+      };
+}
+
+/// E02: Wallet setup flow begins
+class AnalyticsOnboardingStartedEvent extends AnalyticsSendDataEvent {
+  AnalyticsOnboardingStartedEvent({
+    required String method,
+    String? referralSource,
+  }) : super(
+          OnboardingStartedEventData(
+            method: method,
+            referralSource: referralSource,
+          ),
+        );
+}
+
+/// E03: New wallet generated
+/// Business category: User Acquisition.
+class WalletCreatedEventData implements AnalyticsEventData {
+  const WalletCreatedEventData({
+    required this.source,
+    required this.walletType,
+  });
+
+  final String source;
+  final String walletType;
+
+  @override
+  String get name => 'wallet_created';
+
+  @override
+  JsonMap get parameters => {
+        'source': source,
+        'wallet_type': walletType,
+      };
+}
+
+/// E03: New wallet generated
+class AnalyticsWalletCreatedEvent extends AnalyticsSendDataEvent {
+  AnalyticsWalletCreatedEvent({
+    required String source,
+    required String walletType,
+  }) : super(
+          WalletCreatedEventData(
+            source: source,
+            walletType: walletType,
+          ),
+        );
+}
+
+/// E04: Existing wallet imported
+/// Business category: User Acquisition.
+class WalletImportedEventData implements AnalyticsEventData {
+  const WalletImportedEventData({
+    required this.source,
+    required this.importType,
+    required this.walletType,
+  });
+
+  final String source;
+  final String importType;
+  final String walletType;
+
+  @override
+  String get name => 'wallet_imported';
+
+  @override
+  JsonMap get parameters => {
+        'source': source,
+        'import_type': importType,
+        'wallet_type': walletType,
+      };
+}
+
+/// E04: Existing wallet imported
+class AnalyticsWalletImportedEvent extends AnalyticsSendDataEvent {
+  AnalyticsWalletImportedEvent({
+    required String source,
+    required String importType,
+    required String walletType,
+  }) : super(
+          WalletImportedEventData(
+            source: source,
+            importType: importType,
+            walletType: walletType,
+          ),
+        );
+}

--- a/lib/analytics/events/user_engagement_events.dart
+++ b/lib/analytics/events/user_engagement_events.dart
@@ -1,0 +1,38 @@
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+import 'package:web_dex/bloc/analytics/analytics_event.dart';
+import 'package:web_dex/bloc/analytics/analytics_repo.dart';
+
+/// E01: App launched / foregrounded
+/// Measures when the application is opened or returns to foreground.
+/// Business category: User Engagement.
+class AppOpenedEventData implements AnalyticsEventData {
+  const AppOpenedEventData({
+    required this.platform,
+    required this.appVersion,
+  });
+
+  final String platform;
+  final String appVersion;
+
+  @override
+  String get name => 'app_open';
+
+  @override
+  JsonMap get parameters => {
+        'platform': platform,
+        'app_version': appVersion,
+      };
+}
+
+/// E01: App launched / foregrounded
+class AnalyticsAppOpenedEvent extends AnalyticsSendDataEvent {
+  AnalyticsAppOpenedEvent({
+    required String platform,
+    required String appVersion,
+  }) : super(
+          AppOpenedEventData(
+            platform: platform,
+            appVersion: appVersion,
+          ),
+        );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,7 @@ import 'package:web_dex/app_config/app_config.dart';
 import 'package:web_dex/app_config/package_information.dart';
 import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
 import 'package:web_dex/bloc/analytics/analytics_event.dart';
-import 'package:web_dex/analytics/analytics_factory.dart';
+import 'package:web_dex/analytics/events/user_engagement_events.dart';
 import 'package:web_dex/services/platform_info/plaftorm_info.dart';
 import 'package:web_dex/bloc/app_bloc_observer.dart';
 import 'package:web_dex/bloc/app_bloc_root.dart' deferred as app_bloc_root;
@@ -229,11 +229,9 @@ class _AnalyticsLifecycleHandlerState extends State<_AnalyticsLifecycleHandler>
     final platform = PlatformInfo.getInstance().platform;
     final appVersion = packageInformation.packageVersion ?? 'unknown';
     analyticsBloc.add(
-      AnalyticsSendDataEvent(
-        AnalyticsEvents.appOpened(
-          platform: platform,
-          appVersion: appVersion,
-        ),
+      AnalyticsAppOpenedEvent(
+        platform: platform,
+        appVersion: appVersion,
       ),
     );
   }

--- a/lib/views/settings/widgets/security_settings/seed_settings/seed_confirmation/seed_confirmation.dart
+++ b/lib/views/settings/widgets/security_settings/seed_settings/seed_confirmation/seed_confirmation.dart
@@ -7,7 +7,7 @@ import 'package:web_dex/bloc/security_settings/security_settings_event.dart';
 import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
 import 'package:web_dex/bloc/analytics/analytics_event.dart';
-import 'package:web_dex/analytics/analytics_factory.dart';
+import 'package:web_dex/analytics/events/security_events.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/text_error.dart';
 import 'package:web_dex/model/wallet.dart';
@@ -56,19 +56,17 @@ class _SeedConfirmationState extends State<SeedConfirmation> {
                 child: SeedBackButton(
                   () {
                     context.read<AnalyticsBloc>().add(
-                          AnalyticsSendDataEvent(
-                            AnalyticsEvents.backupSkipped(
-                              stageSkipped: 'seed_confirm',
-                              walletType: context
-                                      .read<AuthBloc>()
-                                      .state
-                                      .currentUser
-                                      ?.wallet
-                                      .config
-                                      .type
-                                      .name ??
-                                  '',
-                            ),
+                          AnalyticsBackupSkippedEvent(
+                            stageSkipped: 'seed_confirm',
+                            walletType: context
+                                    .read<AuthBloc>()
+                                    .state
+                                    .currentUser
+                                    ?.wallet
+                                    .config
+                                    .type
+                                    .name ??
+                                '',
                           ),
                         );
                     context
@@ -141,12 +139,10 @@ class _SeedConfirmationState extends State<SeedConfirmation> {
           context.read<AuthBloc>().state.currentUser?.wallet.config.type.name ??
               '';
       context.read<AnalyticsBloc>().add(
-            AnalyticsSendDataEvent(
-              AnalyticsEvents.backupCompleted(
-                backupTime: 0,
-                method: 'manual',
-                walletType: walletType,
-              ),
+            AnalyticsBackupCompletedEvent(
+              backupTime: 0,
+              method: 'manual',
+              walletType: walletType,
             ),
           );
       return;

--- a/lib/views/settings/widgets/security_settings/seed_settings/seed_show.dart
+++ b/lib/views/settings/widgets/security_settings/seed_settings/seed_show.dart
@@ -10,7 +10,7 @@ import 'package:web_dex/bloc/security_settings/security_settings_state.dart';
 import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
 import 'package:web_dex/bloc/analytics/analytics_event.dart';
-import 'package:web_dex/analytics/analytics_factory.dart';
+import 'package:web_dex/analytics/events/security_events.dart';
 import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/coin.dart';
@@ -47,19 +47,17 @@ class SeedShow extends StatelessWidget {
                 padding: const EdgeInsets.only(bottom: 16.0),
                 child: SeedBackButton(() {
                   context.read<AnalyticsBloc>().add(
-                        AnalyticsSendDataEvent(
-                          AnalyticsEvents.backupSkipped(
-                            stageSkipped: 'seed_show',
-                            walletType: context
-                                    .read<AuthBloc>()
-                                    .state
-                                    .currentUser
-                                    ?.wallet
-                                    .config
-                                    .type
-                                    .name ??
-                                '',
-                          ),
+                        AnalyticsBackupSkippedEvent(
+                          stageSkipped: 'seed_show',
+                          walletType: context
+                                  .read<AuthBloc>()
+                                  .state
+                                  .currentUser
+                                  ?.wallet
+                                  .config
+                                  .type
+                                  .name ??
+                              '',
                         ),
                       );
                   context.read<SecuritySettingsBloc>().add(const ResetEvent());

--- a/lib/views/wallets_manager/widgets/iguana_wallets_manager.dart
+++ b/lib/views/wallets_manager/widgets/iguana_wallets_manager.dart
@@ -2,7 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
-import 'package:web_dex/analytics/analytics_factory.dart';
+import 'package:web_dex/analytics/events/user_acquisition_events.dart';
 import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
 import 'package:web_dex/bloc/analytics/analytics_event.dart';
 import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
@@ -83,11 +83,9 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
                             ? 'create'
                             : 'import';
                         context.read<AnalyticsBloc>().add(
-                              AnalyticsSendDataEvent(
-                                AnalyticsEvents.onboardingStarted(
-                                  method: method,
-                                  referralSource: widget.eventType.name,
-                                ),
+                              AnalyticsOnboardingStartedEvent(
+                                method: method,
+                                referralSource: widget.eventType.name,
                               ),
                             );
                       },
@@ -268,21 +266,17 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
       final walletType = currentWallet.config.type.name;
       if (action == WalletsManagerAction.create) {
         analyticsBloc.add(
-          AnalyticsSendDataEvent(
-            AnalyticsEvents.walletCreated(
-              source: source,
-              walletType: walletType,
-            ),
+          AnalyticsWalletCreatedEvent(
+            source: source,
+            walletType: walletType,
           ),
         );
       } else if (action == WalletsManagerAction.import) {
         analyticsBloc.add(
-          AnalyticsSendDataEvent(
-            AnalyticsEvents.walletImported(
-              source: source,
-              importType: 'seed_phrase',
-              walletType: walletType,
-            ),
+          AnalyticsWalletImportedEvent(
+            source: source,
+            importType: 'seed_phrase',
+            walletType: walletType,
           ),
         );
       }


### PR DESCRIPTION
## Summary
- add new analytics event classes for app startup and onboarding flow
- add security-related event classes
- update event usage to use the new classes

## Testing
- `flutter pub get --offline --enforce-lockfile`
- `dart format .`
- `flutter analyze` *(fails: 524 issues found)*