### PR TITLE
Implement cross-chain analytics events

### DIFF
--- a/lib/analytics/events/cross_chain_events.dart
+++ b/lib/analytics/events/cross_chain_events.dart
@@ -1,0 +1,140 @@
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+import 'package:web_dex/bloc/analytics/analytics_event.dart';
+import 'package:web_dex/bloc/analytics/analytics_repo.dart';
+
+/// E20: Bridge transfer started
+/// Business category: Cross-Chain.
+class BridgeInitiatedEventData implements AnalyticsEventData {
+  const BridgeInitiatedEventData({
+    required this.fromChain,
+    required this.toChain,
+    required this.asset,
+    required this.walletType,
+  });
+
+  final String fromChain;
+  final String toChain;
+  final String asset;
+  final String walletType;
+
+  @override
+  String get name => 'bridge_initiated';
+
+  @override
+  JsonMap get parameters => {
+        'from_chain': fromChain,
+        'to_chain': toChain,
+        'asset': asset,
+        'wallet_type': walletType,
+      };
+}
+
+/// E20: Bridge transfer started
+class AnalyticsBridgeInitiatedEvent extends AnalyticsSendDataEvent {
+  AnalyticsBridgeInitiatedEvent({
+    required String fromChain,
+    required String toChain,
+    required String asset,
+    required String walletType,
+  }) : super(
+          BridgeInitiatedEventData(
+            fromChain: fromChain,
+            toChain: toChain,
+            asset: asset,
+            walletType: walletType,
+          ),
+        );
+}
+
+/// E21: Bridge completed
+/// Business category: Cross-Chain.
+class BridgeSucceededEventData implements AnalyticsEventData {
+  const BridgeSucceededEventData({
+    required this.fromChain,
+    required this.toChain,
+    required this.asset,
+    required this.amount,
+    required this.walletType,
+  });
+
+  final String fromChain;
+  final String toChain;
+  final String asset;
+  final double amount;
+  final String walletType;
+
+  @override
+  String get name => 'bridge_success';
+
+  @override
+  JsonMap get parameters => {
+        'from_chain': fromChain,
+        'to_chain': toChain,
+        'asset': asset,
+        'amount': amount,
+        'wallet_type': walletType,
+      };
+}
+
+/// E21: Bridge completed
+class AnalyticsBridgeSucceededEvent extends AnalyticsSendDataEvent {
+  AnalyticsBridgeSucceededEvent({
+    required String fromChain,
+    required String toChain,
+    required String asset,
+    required double amount,
+    required String walletType,
+  }) : super(
+          BridgeSucceededEventData(
+            fromChain: fromChain,
+            toChain: toChain,
+            asset: asset,
+            amount: amount,
+            walletType: walletType,
+          ),
+        );
+}
+
+/// E22: Bridge failed
+/// Business category: Cross-Chain.
+class BridgeFailedEventData implements AnalyticsEventData {
+  const BridgeFailedEventData({
+    required this.fromChain,
+    required this.toChain,
+    required this.failError,
+    required this.walletType,
+  });
+
+  final String fromChain;
+  final String toChain;
+  final String failError;
+  final String walletType;
+
+  @override
+  String get name => 'bridge_failure';
+
+  @override
+  JsonMap get parameters => {
+        'from_chain': fromChain,
+        'to_chain': toChain,
+        'fail_error': failError,
+        'wallet_type': walletType,
+      };
+}
+
+/// E22: Bridge failed
+class AnalyticsBridgeFailedEvent extends AnalyticsSendDataEvent {
+  AnalyticsBridgeFailedEvent({
+    required String fromChain,
+    required String toChain,
+    required String failError,
+    required String walletType,
+  }) : super(
+          BridgeFailedEventData(
+            fromChain: fromChain,
+            toChain: toChain,
+            failError: failError,
+            walletType: walletType,
+          ),
+        );
+}

--- a/lib/bloc/app_bloc_root.dart
+++ b/lib/bloc/app_bloc_root.dart
@@ -251,6 +251,7 @@ class AppBlocRoot extends StatelessWidget {
                 coinsRepository,
               ),
               coinsRepository: coinsRepository,
+              analyticsBloc: BlocProvider.of<AnalyticsBloc>(context),
             ),
           ),
           BlocProvider(

--- a/lib/views/wallet/coin_details/coin_details.dart
+++ b/lib/views/wallet/coin_details/coin_details.dart
@@ -4,6 +4,9 @@ import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_bloc.dart';
 import 'package:web_dex/bloc/transaction_history/transaction_history_bloc.dart';
 import 'package:web_dex/bloc/transaction_history/transaction_history_event.dart';
+import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
+import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
+import 'package:web_dex/analytics/events/portfolio_events.dart';
 import 'package:web_dex/model/coin.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_details_info/coin_details_info.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_page_type.dart';
@@ -37,6 +40,16 @@ class _CoinDetailsState extends State<CoinDetails> {
     _txHistoryBloc = context.read<TransactionHistoryBloc>();
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       _txHistoryBloc.add(TransactionHistorySubscribe(coin: widget.coin));
+      final walletType =
+          context.read<AuthBloc>().state.currentUser?.wallet.config.type.name ??
+              '';
+      context.read<AnalyticsBloc>().add(
+            AnalyticsAssetViewedEvent(
+              assetSymbol: widget.coin.abbr,
+              assetNetwork: widget.coin.protocolType,
+              walletType: walletType,
+            ),
+          );
     });
     super.initState();
   }


### PR DESCRIPTION
## Summary
- add new Cross-Chain analytics events
- trigger asset details viewed analytics
- inject analytics bloc into bridge bloc
- record bridge initiated, success and failure events

## Testing
- `flutter analyze`
