### PR TITLE
Implement missing analytics event triggers

### DIFF
--- a/Fetching
+++ b/Fetching
@@ -1,3 +1,6 @@
 
 # Bloc and Commit Conventions
  documentation...
+
+# Bloc and Commit Conventions
+ documentation...

--- a/lib/analytics/analytics_factory.dart
+++ b/lib/analytics/analytics_factory.dart
@@ -211,4 +211,661 @@ class AnalyticsEvents {
       walletType: walletType,
     );
   }
+
+  /// Bridge initiated event
+  static BridgeInitiatedEvent bridgeInitiated({
+    required String fromChain,
+    required String toChain,
+    required String asset,
+  }) {
+    return BridgeInitiatedEvent(
+      fromChain: fromChain,
+      toChain: toChain,
+      asset: asset,
+    );
+  }
+
+  /// Bridge success event
+  static BridgeSuccessEvent bridgeSuccess({
+    required String fromChain,
+    required String toChain,
+    required String asset,
+    required double amount,
+  }) {
+    return BridgeSuccessEvent(
+      fromChain: fromChain,
+      toChain: toChain,
+      asset: asset,
+      amount: amount,
+    );
+  }
+
+  /// Bridge failure event
+  static BridgeFailureEvent bridgeFailure({
+    required String fromChain,
+    required String toChain,
+    required String failError,
+  }) {
+    return BridgeFailureEvent(
+      fromChain: fromChain,
+      toChain: toChain,
+      failError: failError,
+    );
+  }
+
+  /// NFT gallery opened event
+  static NftGalleryOpenedEvent nftGalleryOpened({
+    required int nftCount,
+    required int loadTimeMs,
+  }) {
+    return NftGalleryOpenedEvent(
+      nftCount: nftCount,
+      loadTimeMs: loadTimeMs,
+    );
+  }
+
+  /// NFT transfer initiated
+  static NftTransferInitiatedEvent nftTransferInitiated({
+    required String collectionName,
+    required String tokenId,
+    required String hdType,
+  }) {
+    return NftTransferInitiatedEvent(
+      collectionName: collectionName,
+      tokenId: tokenId,
+      hdType: hdType,
+    );
+  }
+
+  /// NFT transfer success
+  static NftTransferSuccessEvent nftTransferSuccess({
+    required String collectionName,
+    required String tokenId,
+    required double fee,
+    required String hdType,
+  }) {
+    return NftTransferSuccessEvent(
+      collectionName: collectionName,
+      tokenId: tokenId,
+      fee: fee,
+      hdType: hdType,
+    );
+  }
+
+  /// NFT transfer failure
+  static NftTransferFailureEvent nftTransferFailure({
+    required String collectionName,
+    required String failReason,
+    required String hdType,
+  }) {
+    return NftTransferFailureEvent(
+      collectionName: collectionName,
+      failReason: failReason,
+      hdType: hdType,
+    );
+  }
+
+  /// Marketbot setup started
+  static MarketbotSetupStartEvent marketbotSetupStart({
+    required String strategyType,
+    required int pairsCount,
+  }) {
+    return MarketbotSetupStartEvent(
+      strategyType: strategyType,
+      pairsCount: pairsCount,
+    );
+  }
+
+  /// Marketbot setup complete
+  static MarketbotSetupCompleteEvent marketbotSetupComplete({
+    required String strategyType,
+    required double baseCapital,
+  }) {
+    return MarketbotSetupCompleteEvent(
+      strategyType: strategyType,
+      baseCapital: baseCapital,
+    );
+  }
+
+  /// Marketbot trade executed
+  static MarketbotTradeExecutedEvent marketbotTradeExecuted({
+    required String pair,
+    required double tradeSize,
+    required double profitUsd,
+  }) {
+    return MarketbotTradeExecutedEvent(
+      pair: pair,
+      tradeSize: tradeSize,
+      profitUsd: profitUsd,
+    );
+  }
+
+  /// Marketbot error
+  static MarketbotErrorEvent marketbotError({
+    required String errorCode,
+    required String strategyType,
+  }) {
+    return MarketbotErrorEvent(
+      errorCode: errorCode,
+      strategyType: strategyType,
+    );
+  }
+
+  /// Reward claim initiated
+  static RewardClaimInitiatedEvent rewardClaimInitiated({
+    required String asset,
+    required double expectedRewardAmount,
+  }) {
+    return RewardClaimInitiatedEvent(
+      asset: asset,
+      expectedRewardAmount: expectedRewardAmount,
+    );
+  }
+
+  /// Reward claim success
+  static RewardClaimSuccessEvent rewardClaimSuccess({
+    required String asset,
+    required double rewardAmount,
+  }) {
+    return RewardClaimSuccessEvent(
+      asset: asset,
+      rewardAmount: rewardAmount,
+    );
+  }
+
+  /// Reward claim failure
+  static RewardClaimFailureEvent rewardClaimFailure({
+    required String asset,
+    required String failReason,
+  }) {
+    return RewardClaimFailureEvent(
+      asset: asset,
+      failReason: failReason,
+    );
+  }
+
+  /// DApp connected
+  static DappConnectEvent dappConnect({
+    required String dappName,
+    required String network,
+  }) {
+    return DappConnectEvent(
+      dappName: dappName,
+      network: network,
+    );
+  }
+
+  /// Settings change
+  static SettingsChangeEvent settingsChange({
+    required String settingName,
+    required String newValue,
+  }) {
+    return SettingsChangeEvent(
+      settingName: settingName,
+      newValue: newValue,
+    );
+  }
+
+  /// Error displayed
+  static ErrorDisplayedEvent errorDisplayed({
+    required String errorCode,
+    required String screenContext,
+  }) {
+    return ErrorDisplayedEvent(
+      errorCode: errorCode,
+      screenContext: screenContext,
+    );
+  }
+
+  /// App shared
+  static AppShareEvent appShare({
+    required String channel,
+  }) {
+    return AppShareEvent(channel: channel);
+  }
+
+  /// Scroll attempt outside content
+  static ScrollAttemptOutsideContentEvent scrollAttemptOutsideContent({
+    required String screenContext,
+    required double scrollDelta,
+  }) {
+    return ScrollAttemptOutsideContentEvent(
+      screenContext: screenContext,
+      scrollDelta: scrollDelta,
+    );
+  }
+
+  /// Searchbar input
+  static SearchbarInputEvent searchbarInput({
+    required int queryLength,
+    String? assetSymbol,
+  }) {
+    return SearchbarInputEvent(
+      queryLength: queryLength,
+      assetSymbol: assetSymbol,
+    );
+  }
+
+  /// Theme selected
+  static ThemeSelectedEvent themeSelected({
+    required String themeName,
+  }) {
+    return ThemeSelectedEvent(themeName: themeName);
+  }
+}
+
+class BridgeInitiatedEvent extends AnalyticsEventData {
+  BridgeInitiatedEvent({
+    required this.fromChain,
+    required this.toChain,
+    required this.asset,
+  });
+
+  @override
+  String get name => 'bridge_initiated';
+
+  final String fromChain;
+  final String toChain;
+  final String asset;
+
+  @override
+  JsonMap get parameters => {
+        'from_chain': fromChain,
+        'to_chain': toChain,
+        'asset': asset,
+      };
+}
+
+class BridgeSuccessEvent extends AnalyticsEventData {
+  BridgeSuccessEvent({
+    required this.fromChain,
+    required this.toChain,
+    required this.asset,
+    required this.amount,
+  });
+
+  @override
+  String get name => 'bridge_success';
+
+  final String fromChain;
+  final String toChain;
+  final String asset;
+  final double amount;
+
+  @override
+  JsonMap get parameters => {
+        'from_chain': fromChain,
+        'to_chain': toChain,
+        'asset': asset,
+        'amount': amount,
+      };
+}
+
+class BridgeFailureEvent extends AnalyticsEventData {
+  BridgeFailureEvent({
+    required this.fromChain,
+    required this.toChain,
+    required this.failError,
+  });
+
+  @override
+  String get name => 'bridge_failure';
+
+  final String fromChain;
+  final String toChain;
+  final String failError;
+
+  @override
+  JsonMap get parameters => {
+        'from_chain': fromChain,
+        'to_chain': toChain,
+        'fail_error': failError,
+      };
+}
+
+class NftGalleryOpenedEvent extends AnalyticsEventData {
+  NftGalleryOpenedEvent({
+    required this.nftCount,
+    required this.loadTimeMs,
+  });
+
+  @override
+  String get name => 'nft_gallery_opened';
+
+  final int nftCount;
+  final int loadTimeMs;
+
+  @override
+  JsonMap get parameters => {
+        'nft_count': nftCount,
+        'load_time_ms': loadTimeMs,
+      };
+}
+
+class NftTransferInitiatedEvent extends AnalyticsEventData {
+  NftTransferInitiatedEvent({
+    required this.collectionName,
+    required this.tokenId,
+    required this.hdType,
+  });
+
+  @override
+  String get name => 'nft_transfer_initiated';
+
+  final String collectionName;
+  final String tokenId;
+  final String hdType;
+
+  @override
+  JsonMap get parameters => {
+        'collection_name': collectionName,
+        'token_id': tokenId,
+        'hd_type': hdType,
+      };
+}
+
+class NftTransferSuccessEvent extends AnalyticsEventData {
+  NftTransferSuccessEvent({
+    required this.collectionName,
+    required this.tokenId,
+    required this.fee,
+    required this.hdType,
+  });
+
+  @override
+  String get name => 'nft_transfer_success';
+
+  final String collectionName;
+  final String tokenId;
+  final double fee;
+  final String hdType;
+
+  @override
+  JsonMap get parameters => {
+        'collection_name': collectionName,
+        'token_id': tokenId,
+        'fee': fee,
+        'hd_type': hdType,
+      };
+}
+
+class NftTransferFailureEvent extends AnalyticsEventData {
+  NftTransferFailureEvent({
+    required this.collectionName,
+    required this.failReason,
+    required this.hdType,
+  });
+
+  @override
+  String get name => 'nft_transfer_failure';
+
+  final String collectionName;
+  final String failReason;
+  final String hdType;
+
+  @override
+  JsonMap get parameters => {
+        'collection_name': collectionName,
+        'fail_reason': failReason,
+        'hd_type': hdType,
+      };
+}
+
+class MarketbotSetupStartEvent extends AnalyticsEventData {
+  MarketbotSetupStartEvent({
+    required this.strategyType,
+    required this.pairsCount,
+  });
+
+  @override
+  String get name => 'marketbot_setup_start';
+
+  final String strategyType;
+  final int pairsCount;
+
+  @override
+  JsonMap get parameters => {
+        'strategy_type': strategyType,
+        'pairs_count': pairsCount,
+      };
+}
+
+class MarketbotSetupCompleteEvent extends AnalyticsEventData {
+  MarketbotSetupCompleteEvent({
+    required this.strategyType,
+    required this.baseCapital,
+  });
+
+  @override
+  String get name => 'marketbot_setup_complete';
+
+  final String strategyType;
+  final double baseCapital;
+
+  @override
+  JsonMap get parameters => {
+        'strategy_type': strategyType,
+        'base_capital': baseCapital,
+      };
+}
+
+class MarketbotTradeExecutedEvent extends AnalyticsEventData {
+  MarketbotTradeExecutedEvent({
+    required this.pair,
+    required this.tradeSize,
+    required this.profitUsd,
+  });
+
+  @override
+  String get name => 'marketbot_trade_executed';
+
+  final String pair;
+  final double tradeSize;
+  final double profitUsd;
+
+  @override
+  JsonMap get parameters => {
+        'pair': pair,
+        'trade_size': tradeSize,
+        'profit_usd': profitUsd,
+      };
+}
+
+class MarketbotErrorEvent extends AnalyticsEventData {
+  MarketbotErrorEvent({
+    required this.errorCode,
+    required this.strategyType,
+  });
+
+  @override
+  String get name => 'marketbot_error';
+
+  final String errorCode;
+  final String strategyType;
+
+  @override
+  JsonMap get parameters => {
+        'error_code': errorCode,
+        'strategy_type': strategyType,
+      };
+}
+
+class RewardClaimInitiatedEvent extends AnalyticsEventData {
+  RewardClaimInitiatedEvent({
+    required this.asset,
+    required this.expectedRewardAmount,
+  });
+
+  @override
+  String get name => 'reward_claim_initiated';
+
+  final String asset;
+  final double expectedRewardAmount;
+
+  @override
+  JsonMap get parameters => {
+        'asset': asset,
+        'expected_reward_amount': expectedRewardAmount,
+      };
+}
+
+class RewardClaimSuccessEvent extends AnalyticsEventData {
+  RewardClaimSuccessEvent({
+    required this.asset,
+    required this.rewardAmount,
+  });
+
+  @override
+  String get name => 'reward_claim_success';
+
+  final String asset;
+  final double rewardAmount;
+
+  @override
+  JsonMap get parameters => {
+        'asset': asset,
+        'reward_amount': rewardAmount,
+      };
+}
+
+class RewardClaimFailureEvent extends AnalyticsEventData {
+  RewardClaimFailureEvent({
+    required this.asset,
+    required this.failReason,
+  });
+
+  @override
+  String get name => 'reward_claim_failure';
+
+  final String asset;
+  final String failReason;
+
+  @override
+  JsonMap get parameters => {
+        'asset': asset,
+        'fail_reason': failReason,
+      };
+}
+
+class DappConnectEvent extends AnalyticsEventData {
+  DappConnectEvent({
+    required this.dappName,
+    required this.network,
+  });
+
+  @override
+  String get name => 'dapp_connect';
+
+  final String dappName;
+  final String network;
+
+  @override
+  JsonMap get parameters => {
+        'dapp_name': dappName,
+        'network': network,
+      };
+}
+
+class SettingsChangeEvent extends AnalyticsEventData {
+  SettingsChangeEvent({
+    required this.settingName,
+    required this.newValue,
+  });
+
+  @override
+  String get name => 'settings_change';
+
+  final String settingName;
+  final String newValue;
+
+  @override
+  JsonMap get parameters => {
+        'setting_name': settingName,
+        'new_value': newValue,
+      };
+}
+
+class ErrorDisplayedEvent extends AnalyticsEventData {
+  ErrorDisplayedEvent({
+    required this.errorCode,
+    required this.screenContext,
+  });
+
+  @override
+  String get name => 'error_displayed';
+
+  final String errorCode;
+  final String screenContext;
+
+  @override
+  JsonMap get parameters => {
+        'error_code': errorCode,
+        'screen_context': screenContext,
+      };
+}
+
+class AppShareEvent extends AnalyticsEventData {
+  AppShareEvent({required this.channel});
+
+  @override
+  String get name => 'app_share';
+
+  final String channel;
+
+  @override
+  JsonMap get parameters => {
+        'channel': channel,
+      };
+}
+
+class ScrollAttemptOutsideContentEvent extends AnalyticsEventData {
+  ScrollAttemptOutsideContentEvent({
+    required this.screenContext,
+    required this.scrollDelta,
+  });
+
+  @override
+  String get name => 'scroll_attempt_outside_content';
+
+  final String screenContext;
+  final double scrollDelta;
+
+  @override
+  JsonMap get parameters => {
+        'screen_context': screenContext,
+        'scroll_delta': scrollDelta,
+      };
+}
+
+class SearchbarInputEvent extends AnalyticsEventData {
+  SearchbarInputEvent({
+    required this.queryLength,
+    this.assetSymbol,
+  });
+
+  @override
+  String get name => 'searchbar_input';
+
+  final int queryLength;
+  final String? assetSymbol;
+
+  @override
+  JsonMap get parameters => {
+        'query_length': queryLength,
+        if (assetSymbol != null) 'asset_symbol': assetSymbol!,
+      };
+}
+
+class ThemeSelectedEvent extends AnalyticsEventData {
+  ThemeSelectedEvent({required this.themeName});
+
+  @override
+  String get name => 'theme_selected';
+
+  final String themeName;
+
+  @override
+  JsonMap get parameters => {
+        'theme_name': themeName,
+      };
 }

--- a/lib/analytics/events/cross_chain_events.dart
+++ b/lib/analytics/events/cross_chain_events.dart
@@ -1,0 +1,119 @@
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+import 'package:web_dex/bloc/analytics/analytics_event.dart';
+import 'package:web_dex/bloc/analytics/analytics_repo.dart';
+
+/// E20: Bridge transfer started
+class BridgeInitiatedEventData implements AnalyticsEventData {
+  const BridgeInitiatedEventData({
+    required this.fromChain,
+    required this.toChain,
+    required this.asset,
+  });
+
+  final String fromChain;
+  final String toChain;
+  final String asset;
+
+  @override
+  String get name => 'bridge_initiated';
+
+  @override
+  JsonMap get parameters => {
+        'from_chain': fromChain,
+        'to_chain': toChain,
+        'asset': asset,
+      };
+}
+
+class AnalyticsBridgeInitiatedEvent extends AnalyticsSendDataEvent {
+  AnalyticsBridgeInitiatedEvent({
+    required String fromChain,
+    required String toChain,
+    required String asset,
+  }) : super(
+          BridgeInitiatedEventData(
+            fromChain: fromChain,
+            toChain: toChain,
+            asset: asset,
+          ),
+        );
+}
+
+/// E21: Bridge completed
+class BridgeSuccessEventData implements AnalyticsEventData {
+  const BridgeSuccessEventData({
+    required this.fromChain,
+    required this.toChain,
+    required this.asset,
+    required this.amount,
+  });
+
+  final String fromChain;
+  final String toChain;
+  final String asset;
+  final double amount;
+
+  @override
+  String get name => 'bridge_success';
+
+  @override
+  JsonMap get parameters => {
+        'from_chain': fromChain,
+        'to_chain': toChain,
+        'asset': asset,
+        'amount': amount,
+      };
+}
+
+class AnalyticsBridgeSuccessEvent extends AnalyticsSendDataEvent {
+  AnalyticsBridgeSuccessEvent({
+    required String fromChain,
+    required String toChain,
+    required String asset,
+    required double amount,
+  }) : super(
+          BridgeSuccessEventData(
+            fromChain: fromChain,
+            toChain: toChain,
+            asset: asset,
+            amount: amount,
+          ),
+        );
+}
+
+/// E22: Bridge failed
+class BridgeFailureEventData implements AnalyticsEventData {
+  const BridgeFailureEventData({
+    required this.fromChain,
+    required this.toChain,
+    required this.failError,
+  });
+
+  final String fromChain;
+  final String toChain;
+  final String failError;
+
+  @override
+  String get name => 'bridge_failure';
+
+  @override
+  JsonMap get parameters => {
+        'from_chain': fromChain,
+        'to_chain': toChain,
+        'fail_error': failError,
+      };
+}
+
+class AnalyticsBridgeFailureEvent extends AnalyticsSendDataEvent {
+  AnalyticsBridgeFailureEvent({
+    required String fromChain,
+    required String toChain,
+    required String failError,
+  }) : super(
+          BridgeFailureEventData(
+            fromChain: fromChain,
+            toChain: toChain,
+            failError: failError,
+          ),
+        );
+}

--- a/lib/analytics/events/market_bot_events.dart
+++ b/lib/analytics/events/market_bot_events.dart
@@ -1,0 +1,136 @@
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+import 'package:web_dex/bloc/analytics/analytics_event.dart';
+import 'package:web_dex/bloc/analytics/analytics_repo.dart';
+
+/// E27: Bot config wizard opened
+class MarketbotSetupStartedEventData implements AnalyticsEventData {
+  const MarketbotSetupStartedEventData({
+    required this.strategyType,
+    required this.pairsCount,
+  });
+
+  final String strategyType;
+  final int pairsCount;
+
+  @override
+  String get name => 'marketbot_setup_start';
+
+  @override
+  JsonMap get parameters => {
+        'strategy_type': strategyType,
+        'pairs_count': pairsCount,
+      };
+}
+
+class AnalyticsMarketbotSetupStartedEvent extends AnalyticsSendDataEvent {
+  AnalyticsMarketbotSetupStartedEvent({
+    required String strategyType,
+    required int pairsCount,
+  }) : super(
+          MarketbotSetupStartedEventData(
+            strategyType: strategyType,
+            pairsCount: pairsCount,
+          ),
+        );
+}
+
+/// E28: Bot configured & saved
+class MarketbotSetupCompleteEventData implements AnalyticsEventData {
+  const MarketbotSetupCompleteEventData({
+    required this.strategyType,
+    required this.baseCapital,
+  });
+
+  final String strategyType;
+  final double baseCapital;
+
+  @override
+  String get name => 'marketbot_setup_complete';
+
+  @override
+  JsonMap get parameters => {
+        'strategy_type': strategyType,
+        'base_capital': baseCapital,
+      };
+}
+
+class AnalyticsMarketbotSetupCompleteEvent extends AnalyticsSendDataEvent {
+  AnalyticsMarketbotSetupCompleteEvent({
+    required String strategyType,
+    required double baseCapital,
+  }) : super(
+          MarketbotSetupCompleteEventData(
+            strategyType: strategyType,
+            baseCapital: baseCapital,
+          ),
+        );
+}
+
+/// E29: Bot placed a trade
+class MarketbotTradeExecutedEventData implements AnalyticsEventData {
+  const MarketbotTradeExecutedEventData({
+    required this.pair,
+    required this.tradeSize,
+    required this.profitUsd,
+  });
+
+  final String pair;
+  final double tradeSize;
+  final double profitUsd;
+
+  @override
+  String get name => 'marketbot_trade_executed';
+
+  @override
+  JsonMap get parameters => {
+        'pair': pair,
+        'trade_size': tradeSize,
+        'profit_usd': profitUsd,
+      };
+}
+
+class AnalyticsMarketbotTradeExecutedEvent extends AnalyticsSendDataEvent {
+  AnalyticsMarketbotTradeExecutedEvent({
+    required String pair,
+    required double tradeSize,
+    required double profitUsd,
+  }) : super(
+          MarketbotTradeExecutedEventData(
+            pair: pair,
+            tradeSize: tradeSize,
+            profitUsd: profitUsd,
+          ),
+        );
+}
+
+/// E30: Bot error encountered
+class MarketbotErrorEventData implements AnalyticsEventData {
+  const MarketbotErrorEventData({
+    required this.errorCode,
+    required this.strategyType,
+  });
+
+  final String errorCode;
+  final String strategyType;
+
+  @override
+  String get name => 'marketbot_error';
+
+  @override
+  JsonMap get parameters => {
+        'error_code': errorCode,
+        'strategy_type': strategyType,
+      };
+}
+
+class AnalyticsMarketbotErrorEvent extends AnalyticsSendDataEvent {
+  AnalyticsMarketbotErrorEvent({
+    required String errorCode,
+    required String strategyType,
+  }) : super(
+          MarketbotErrorEventData(
+            errorCode: errorCode,
+            strategyType: strategyType,
+          ),
+        );
+}

--- a/lib/analytics/events/misc_events.dart
+++ b/lib/analytics/events/misc_events.dart
@@ -1,0 +1,207 @@
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+import 'package:web_dex/bloc/analytics/analytics_event.dart';
+import 'package:web_dex/bloc/analytics/analytics_repo.dart';
+
+/// E34: External DApp connection
+class DappConnectEventData implements AnalyticsEventData {
+  const DappConnectEventData({
+    required this.dappName,
+    required this.network,
+  });
+
+  final String dappName;
+  final String network;
+
+  @override
+  String get name => 'dapp_connect';
+
+  @override
+  JsonMap get parameters => {
+        'dapp_name': dappName,
+        'network': network,
+      };
+}
+
+class AnalyticsDappConnectEvent extends AnalyticsSendDataEvent {
+  AnalyticsDappConnectEvent({
+    required String dappName,
+    required String network,
+  }) : super(
+          DappConnectEventData(
+            dappName: dappName,
+            network: network,
+          ),
+        );
+}
+
+/// E35: Setting toggled
+class SettingsChangeEventData implements AnalyticsEventData {
+  const SettingsChangeEventData({
+    required this.settingName,
+    required this.newValue,
+  });
+
+  final String settingName;
+  final String newValue;
+
+  @override
+  String get name => 'settings_change';
+
+  @override
+  JsonMap get parameters => {
+        'setting_name': settingName,
+        'new_value': newValue,
+      };
+}
+
+class AnalyticsSettingsChangeEvent extends AnalyticsSendDataEvent {
+  AnalyticsSettingsChangeEvent({
+    required String settingName,
+    required String newValue,
+  }) : super(
+          SettingsChangeEventData(
+            settingName: settingName,
+            newValue: newValue,
+          ),
+        );
+}
+
+/// E36: Error dialog shown
+class ErrorDisplayedEventData implements AnalyticsEventData {
+  const ErrorDisplayedEventData({
+    required this.errorCode,
+    required this.screenContext,
+  });
+
+  final String errorCode;
+  final String screenContext;
+
+  @override
+  String get name => 'error_displayed';
+
+  @override
+  JsonMap get parameters => {
+        'error_code': errorCode,
+        'screen_context': screenContext,
+      };
+}
+
+class AnalyticsErrorDisplayedEvent extends AnalyticsSendDataEvent {
+  AnalyticsErrorDisplayedEvent({
+    required String errorCode,
+    required String screenContext,
+  }) : super(
+          ErrorDisplayedEventData(
+            errorCode: errorCode,
+            screenContext: screenContext,
+          ),
+        );
+}
+
+/// E37: App / referral shared
+class AppShareEventData implements AnalyticsEventData {
+  const AppShareEventData({required this.channel});
+
+  final String channel;
+
+  @override
+  String get name => 'app_share';
+
+  @override
+  JsonMap get parameters => {
+        'channel': channel,
+      };
+}
+
+class AnalyticsAppShareEvent extends AnalyticsSendDataEvent {
+  AnalyticsAppShareEvent({required String channel})
+      : super(
+          AppShareEventData(channel: channel),
+        );
+}
+
+/// E40: User scroll attempt outside content
+class ScrollAttemptOutsideContentEventData implements AnalyticsEventData {
+  const ScrollAttemptOutsideContentEventData({
+    required this.screenContext,
+    required this.scrollDelta,
+  });
+
+  final String screenContext;
+  final double scrollDelta;
+
+  @override
+  String get name => 'scroll_attempt_outside_content';
+
+  @override
+  JsonMap get parameters => {
+        'screen_context': screenContext,
+        'scroll_delta': scrollDelta,
+      };
+}
+
+class AnalyticsScrollAttemptOutsideContentEvent extends AnalyticsSendDataEvent {
+  AnalyticsScrollAttemptOutsideContentEvent({
+    required String screenContext,
+    required double scrollDelta,
+  }) : super(
+          ScrollAttemptOutsideContentEventData(
+            screenContext: screenContext,
+            scrollDelta: scrollDelta,
+          ),
+        );
+}
+
+/// E42: Searchbar input submitted
+class SearchbarInputEventData implements AnalyticsEventData {
+  const SearchbarInputEventData({
+    required this.queryLength,
+    this.assetSymbol,
+  });
+
+  final int queryLength;
+  final String? assetSymbol;
+
+  @override
+  String get name => 'searchbar_input';
+
+  @override
+  JsonMap get parameters => {
+        'query_length': queryLength,
+        if (assetSymbol != null) 'asset_symbol': assetSymbol!,
+      };
+}
+
+class AnalyticsSearchbarInputEvent extends AnalyticsSendDataEvent {
+  AnalyticsSearchbarInputEvent({
+    required int queryLength,
+    String? assetSymbol,
+  }) : super(
+          SearchbarInputEventData(
+            queryLength: queryLength,
+            assetSymbol: assetSymbol,
+          ),
+        );
+}
+
+/// E43: Theme selected
+class ThemeSelectedEventData implements AnalyticsEventData {
+  const ThemeSelectedEventData({required this.themeName});
+
+  final String themeName;
+
+  @override
+  String get name => 'theme_selected';
+
+  @override
+  JsonMap get parameters => {
+        'theme_name': themeName,
+      };
+}
+
+class AnalyticsThemeSelectedEvent extends AnalyticsSendDataEvent {
+  AnalyticsThemeSelectedEvent({required String themeName})
+      : super(
+          ThemeSelectedEventData(themeName: themeName),
+        );
+}

--- a/lib/analytics/events/nft_events.dart
+++ b/lib/analytics/events/nft_events.dart
@@ -1,0 +1,151 @@
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+import 'package:web_dex/bloc/analytics/analytics_event.dart';
+import 'package:web_dex/bloc/analytics/analytics_repo.dart';
+
+/// E23: NFT gallery opened
+class NftGalleryOpenedEventData implements AnalyticsEventData {
+  const NftGalleryOpenedEventData({
+    required this.nftCount,
+    required this.loadTimeMs,
+  });
+
+  final int nftCount;
+  final int loadTimeMs;
+
+  @override
+  String get name => 'nft_gallery_opened';
+
+  @override
+  JsonMap get parameters => {
+        'nft_count': nftCount,
+        'load_time_ms': loadTimeMs,
+      };
+}
+
+class AnalyticsNftGalleryOpenedEvent extends AnalyticsSendDataEvent {
+  AnalyticsNftGalleryOpenedEvent({
+    required int nftCount,
+    required int loadTimeMs,
+  }) : super(
+          NftGalleryOpenedEventData(
+            nftCount: nftCount,
+            loadTimeMs: loadTimeMs,
+          ),
+        );
+}
+
+/// E24: NFT send flow started
+class NftTransferInitiatedEventData implements AnalyticsEventData {
+  const NftTransferInitiatedEventData({
+    required this.collectionName,
+    required this.tokenId,
+    required this.hdType,
+  });
+
+  final String collectionName;
+  final String tokenId;
+  final String hdType;
+
+  @override
+  String get name => 'nft_transfer_initiated';
+
+  @override
+  JsonMap get parameters => {
+        'collection_name': collectionName,
+        'token_id': tokenId,
+        'hd_type': hdType,
+      };
+}
+
+class AnalyticsNftTransferInitiatedEvent extends AnalyticsSendDataEvent {
+  AnalyticsNftTransferInitiatedEvent({
+    required String collectionName,
+    required String tokenId,
+    required String hdType,
+  }) : super(
+          NftTransferInitiatedEventData(
+            collectionName: collectionName,
+            tokenId: tokenId,
+            hdType: hdType,
+          ),
+        );
+}
+
+/// E25: NFT sent successfully
+class NftTransferSuccessEventData implements AnalyticsEventData {
+  const NftTransferSuccessEventData({
+    required this.collectionName,
+    required this.tokenId,
+    required this.fee,
+    required this.hdType,
+  });
+
+  final String collectionName;
+  final String tokenId;
+  final double fee;
+  final String hdType;
+
+  @override
+  String get name => 'nft_transfer_success';
+
+  @override
+  JsonMap get parameters => {
+        'collection_name': collectionName,
+        'token_id': tokenId,
+        'fee': fee,
+        'hd_type': hdType,
+      };
+}
+
+class AnalyticsNftTransferSuccessEvent extends AnalyticsSendDataEvent {
+  AnalyticsNftTransferSuccessEvent({
+    required String collectionName,
+    required String tokenId,
+    required double fee,
+    required String hdType,
+  }) : super(
+          NftTransferSuccessEventData(
+            collectionName: collectionName,
+            tokenId: tokenId,
+            fee: fee,
+            hdType: hdType,
+          ),
+        );
+}
+
+/// E26: NFT send failed
+class NftTransferFailureEventData implements AnalyticsEventData {
+  const NftTransferFailureEventData({
+    required this.collectionName,
+    required this.failReason,
+    required this.hdType,
+  });
+
+  final String collectionName;
+  final String failReason;
+  final String hdType;
+
+  @override
+  String get name => 'nft_transfer_failure';
+
+  @override
+  JsonMap get parameters => {
+        'collection_name': collectionName,
+        'fail_reason': failReason,
+        'hd_type': hdType,
+      };
+}
+
+class AnalyticsNftTransferFailureEvent extends AnalyticsSendDataEvent {
+  AnalyticsNftTransferFailureEvent({
+    required String collectionName,
+    required String failReason,
+    required String hdType,
+  }) : super(
+          NftTransferFailureEventData(
+            collectionName: collectionName,
+            failReason: failReason,
+            hdType: hdType,
+          ),
+        );
+}

--- a/lib/analytics/events/reward_events.dart
+++ b/lib/analytics/events/reward_events.dart
@@ -1,0 +1,99 @@
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+import 'package:web_dex/bloc/analytics/analytics_event.dart';
+import 'package:web_dex/bloc/analytics/analytics_repo.dart';
+
+/// E31: KMD reward claim started
+class RewardClaimInitiatedEventData implements AnalyticsEventData {
+  const RewardClaimInitiatedEventData({
+    required this.asset,
+    required this.expectedRewardAmount,
+  });
+
+  final String asset;
+  final double expectedRewardAmount;
+
+  @override
+  String get name => 'reward_claim_initiated';
+
+  @override
+  JsonMap get parameters => {
+        'asset': asset,
+        'expected_reward_amount': expectedRewardAmount,
+      };
+}
+
+class AnalyticsRewardClaimInitiatedEvent extends AnalyticsSendDataEvent {
+  AnalyticsRewardClaimInitiatedEvent({
+    required String asset,
+    required double expectedRewardAmount,
+  }) : super(
+          RewardClaimInitiatedEventData(
+            asset: asset,
+            expectedRewardAmount: expectedRewardAmount,
+          ),
+        );
+}
+
+/// E32: KMD reward claim succeeded
+class RewardClaimSuccessEventData implements AnalyticsEventData {
+  const RewardClaimSuccessEventData({
+    required this.asset,
+    required this.rewardAmount,
+  });
+
+  final String asset;
+  final double rewardAmount;
+
+  @override
+  String get name => 'reward_claim_success';
+
+  @override
+  JsonMap get parameters => {
+        'asset': asset,
+        'reward_amount': rewardAmount,
+      };
+}
+
+class AnalyticsRewardClaimSuccessEvent extends AnalyticsSendDataEvent {
+  AnalyticsRewardClaimSuccessEvent({
+    required String asset,
+    required double rewardAmount,
+  }) : super(
+          RewardClaimSuccessEventData(
+            asset: asset,
+            rewardAmount: rewardAmount,
+          ),
+        );
+}
+
+/// E33: Reward claim failed
+class RewardClaimFailureEventData implements AnalyticsEventData {
+  const RewardClaimFailureEventData({
+    required this.asset,
+    required this.failReason,
+  });
+
+  final String asset;
+  final String failReason;
+
+  @override
+  String get name => 'reward_claim_failure';
+
+  @override
+  JsonMap get parameters => {
+        'asset': asset,
+        'fail_reason': failReason,
+      };
+}
+
+class AnalyticsRewardClaimFailureEvent extends AnalyticsSendDataEvent {
+  AnalyticsRewardClaimFailureEvent({
+    required String asset,
+    required String failReason,
+  }) : super(
+          RewardClaimFailureEventData(
+            asset: asset,
+            failReason: failReason,
+          ),
+        );
+}

--- a/lib/views/dex/entity_details/trading_details.dart
+++ b/lib/views/dex/entity_details/trading_details.dart
@@ -7,6 +7,8 @@ import 'package:web_dex/bloc/dex_repository.dart';
 import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
 import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
 import 'package:web_dex/analytics/events/transaction_events.dart';
+import 'package:web_dex/analytics/events/cross_chain_events.dart';
+import 'package:web_dex/bloc/coins_bloc/coins_repo.dart';
 import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/model/swap.dart';
 import 'package:web_dex/model/text_error.dart';
@@ -153,6 +155,21 @@ class _TradingDetailsState extends State<TradingDetails> {
                 walletType: walletType ?? 'unknown',
               ),
             );
+
+        final coinsRepo = RepositoryProvider.of<CoinsRepo>(context);
+        if (swapStatus.isTheSameTicker) {
+          final fromChain =
+              coinsRepo.getCoin(fromAsset)?.protocolType ?? 'unknown';
+          final toChain = coinsRepo.getCoin(toAsset)?.protocolType ?? 'unknown';
+          context.read<AnalyticsBloc>().add(
+                AnalyticsBridgeSuccessEvent(
+                  fromChain: fromChain,
+                  toChain: toChain,
+                  asset: fromAsset,
+                  amount: swapStatus.sellAmount.toDouble(),
+                ),
+              );
+        }
       } else if (swapStatus.isFailed && !_loggedFailure) {
         _loggedFailure = true;
         context.read<AnalyticsBloc>().add(
@@ -163,6 +180,20 @@ class _TradingDetailsState extends State<TradingDetails> {
                 walletType: walletType ?? 'unknown',
               ),
             );
+
+        final coinsRepo = RepositoryProvider.of<CoinsRepo>(context);
+        if (swapStatus.isTheSameTicker) {
+          final fromChain =
+              coinsRepo.getCoin(fromAsset)?.protocolType ?? 'unknown';
+          final toChain = coinsRepo.getCoin(toAsset)?.protocolType ?? 'unknown';
+          context.read<AnalyticsBloc>().add(
+                AnalyticsBridgeFailureEvent(
+                  fromChain: fromChain,
+                  toChain: toChain,
+                  failError: swapStatus.status.name,
+                ),
+              );
+        }
       }
     }
   }

--- a/lib/views/nfts/nft_page.dart
+++ b/lib/views/nfts/nft_page.dart
@@ -4,6 +4,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_repo.dart';
 import 'package:web_dex/bloc/nft_transactions/nft_txn_repository.dart';
 import 'package:web_dex/bloc/nfts/nft_main_bloc.dart';
+import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
+import 'package:web_dex/analytics/events/nft_events.dart';
 import 'package:web_dex/bloc/settings/settings_bloc.dart';
 import 'package:web_dex/bloc/settings/settings_state.dart';
 import 'package:web_dex/common/screen.dart';
@@ -62,9 +64,12 @@ class NFTPageView extends StatefulWidget {
 
 class _NFTPageViewState extends State<NFTPageView> {
   late NftMainBloc _nftMainBloc;
+  late final Stopwatch _loadStopwatch;
+  bool _loggedOpen = false;
   @override
   void initState() {
     _nftMainBloc = context.read<NftMainBloc>();
+    _loadStopwatch = Stopwatch()..start();
     _nftMainBloc.add(const NftMainChainUpdateRequested());
     _nftMainBloc.add(const NftMainUpdateNftsStarted());
     super.initState();
@@ -78,27 +83,42 @@ class _NFTPageViewState extends State<NFTPageView> {
 
   @override
   Widget build(BuildContext context) {
-    return PageLayout(
-      header: null,
-      content: Expanded(
-        child: Container(
-          margin: isMobile ? const EdgeInsets.only(top: 14) : null,
-          child: Builder(builder: (context) {
-            switch (widget.pageState) {
-              case NFTSelectedState.details:
-              case NFTSelectedState.send:
-                return NftDetailsPage(
-                  uuid: widget.uuid,
-                  isSend: widget.pageState == NFTSelectedState.send,
-                );
-              case NFTSelectedState.receive:
-                return const NftReceivePage();
-              case NFTSelectedState.transactions:
-                return const NftListOfTransactionsPage();
-              case NFTSelectedState.none:
-                return const NftMain();
-            }
-          }),
+    return BlocListener<NftMainBloc, NftMainState>(
+      listenWhen: (prev, curr) =>
+          !_loggedOpen && curr.isInitialized && !prev.isInitialized,
+      listener: (context, state) {
+        _loggedOpen = true;
+        final count = state.nftCount.values
+            .fold<int>(0, (sum, item) => sum + (item ?? 0));
+        context.read<AnalyticsBloc>().add(
+              AnalyticsNftGalleryOpenedEvent(
+                nftCount: count,
+                loadTimeMs: _loadStopwatch.elapsedMilliseconds,
+              ),
+            );
+      },
+      child: PageLayout(
+        header: null,
+        content: Expanded(
+          child: Container(
+            margin: isMobile ? const EdgeInsets.only(top: 14) : null,
+            child: Builder(builder: (context) {
+              switch (widget.pageState) {
+                case NFTSelectedState.details:
+                case NFTSelectedState.send:
+                  return NftDetailsPage(
+                    uuid: widget.uuid,
+                    isSend: widget.pageState == NFTSelectedState.send,
+                  );
+                case NFTSelectedState.receive:
+                  return const NftReceivePage();
+                case NFTSelectedState.transactions:
+                  return const NftListOfTransactionsPage();
+                case NFTSelectedState.none:
+                  return const NftMain();
+              }
+            }),
+          ),
         ),
       ),
     );

--- a/lib/views/wallet/coin_details/rewards/kmd_rewards_info.dart
+++ b/lib/views/wallet/coin_details/rewards/kmd_rewards_info.dart
@@ -13,6 +13,8 @@ import 'package:web_dex/mm2/mm2_api/rpc/base.dart';
 import 'package:web_dex/mm2/mm2_api/rpc/bloc_response.dart';
 import 'package:web_dex/mm2/mm2_api/rpc/kmd_rewards_info/kmd_reward_item.dart';
 import 'package:web_dex/model/coin.dart';
+import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
+import 'package:web_dex/analytics/events/reward_events.dart';
 import 'package:web_dex/shared/utils/formatters.dart';
 import 'package:web_dex/shared/utils/utils.dart';
 import 'package:web_dex/views/common/page_header/page_header.dart';
@@ -415,6 +417,13 @@ class _KmdRewardsInfoState extends State<KmdRewardsInfo> {
       _successMessage = '';
     });
 
+    context.read<AnalyticsBloc>().add(
+          AnalyticsRewardClaimInitiatedEvent(
+            asset: widget.coin.abbr,
+            expectedRewardAmount: _totalReward ?? 0,
+          ),
+        );
+
     final coinsRepository = RepositoryProvider.of<CoinsRepo>(context);
     final kmdRewardsBloc = RepositoryProvider.of<KmdRewardsBloc>(context);
     final BlocResponse<String, BaseError> response =
@@ -425,6 +434,12 @@ class _KmdRewardsInfoState extends State<KmdRewardsInfo> {
         _isClaiming = false;
         _errorMessage = error.message;
       });
+      context.read<AnalyticsBloc>().add(
+            AnalyticsRewardClaimFailureEvent(
+              asset: widget.coin.abbr,
+              failReason: error.message,
+            ),
+          );
       return;
     }
 
@@ -440,6 +455,12 @@ class _KmdRewardsInfoState extends State<KmdRewardsInfo> {
     setState(() {
       _isClaiming = false;
     });
+    context.read<AnalyticsBloc>().add(
+          AnalyticsRewardClaimSuccessEvent(
+            asset: widget.coin.abbr,
+            rewardAmount: double.tryParse(response.result!) ?? 0,
+          ),
+        );
     widget.onSuccess(reward, formattedUsdPrice);
   }
 


### PR DESCRIPTION
## Summary
- log bridge initiation in BridgeConfirmation
- emit bridge success/failure events from TradingDetails
- track NFT gallery load timing
- fire reward claim analytics for KMD rewards

## Testing
- `flutter pub get --offline`
- `dart format lib/views/bridge/bridge_confirmation.dart lib/views/dex/entity_details/trading_details.dart lib/views/nfts/nft_page.dart lib/views/wallet/coin_details/rewards/kmd_rewards_info.dart lib/analytics/analytics_factory.dart lib/analytics/events/*.dart`
- `flutter analyze` *(fails: 531 issues found)*