### PR TITLE
Refactor analytics triggers to log events directly

### DIFF
--- a/lib/bloc/app_bloc_root.dart
+++ b/lib/bloc/app_bloc_root.dart
@@ -393,12 +393,12 @@ class _MyAppViewState extends State<_MyAppView> {
 
       final delay =
           DateTime.now().difference(_pageLoadStartTime).inMilliseconds;
-      context.read<AnalyticsBloc>().add(
-            AnalyticsSendDataEvent(PageInteractiveDelayEventData(
+      context.read<AnalyticsBloc>().logEvent(
+            PageInteractiveDelayEventData(
               pageName: 'app_root',
               interactiveDelayMs: delay,
               spinnerTimeMs: 200,
-            )),
+            ),
           );
     }
   }
@@ -438,12 +438,12 @@ class _MyAppViewState extends State<_MyAppView> {
 
       _currentPrecacheOperation!.complete();
 
-      context.read<AnalyticsBloc>().add(
-            AnalyticsSendDataEvent(CoinsDataUpdatedEventData(
+      context.read<AnalyticsBloc>().logEvent(
+            CoinsDataUpdatedEventData(
               updateSource: 'remote',
               updateDurationMs: stopwatch.elapsedMilliseconds,
               coinsCount: coins.length,
-            )),
+            ),
           );
     } catch (e) {
       log('Error precaching coin icons: $e');

--- a/lib/bloc/bridge_form/bridge_bloc.dart
+++ b/lib/bloc/bridge_form/bridge_bloc.dart
@@ -524,8 +524,8 @@ class BridgeBloc extends Bloc<BridgeEvent, BridgeState> {
       final buyCoin = _coinsRepository.getCoin(bestOrder.coin);
       final walletType =
           (await _kdfSdk.auth.currentUser)?.wallet.config.type.name ?? '';
-      _analyticsBloc.add(
-        AnalyticsBridgeInitiatedEvent(
+      _analyticsBloc.logEvent(
+        BridgeInitiatedEventData(
           fromChain: sellCoin.protocolType,
           toChain: buyCoin?.protocolType ?? '',
           asset: sellCoin.abbr,
@@ -550,8 +550,8 @@ class BridgeBloc extends Bloc<BridgeEvent, BridgeState> {
       final buyCoin = _coinsRepository.getCoin(state.bestOrder!.coin);
       final walletType =
           (await _kdfSdk.auth.currentUser)?.wallet.config.type.name ?? '';
-      _analyticsBloc.add(
-        AnalyticsBridgeSucceededEvent(
+      _analyticsBloc.logEvent(
+        BridgeSucceededEventData(
           fromChain: state.sellCoin!.protocolType,
           toChain: buyCoin?.protocolType ?? '',
           asset: state.sellCoin!.abbr,
@@ -564,8 +564,8 @@ class BridgeBloc extends Bloc<BridgeEvent, BridgeState> {
       final walletType =
           (await _kdfSdk.auth.currentUser)?.wallet.config.type.name ?? '';
       final error = response.error?.message ?? 'unknown';
-      _analyticsBloc.add(
-        AnalyticsBridgeFailedEvent(
+      _analyticsBloc.logEvent(
+        BridgeFailedEventData(
           fromChain: state.sellCoin!.protocolType,
           toChain: buyCoin?.protocolType ?? '',
           failError: error,

--- a/lib/bloc/coin_addresses/bloc/coin_addresses_bloc.dart
+++ b/lib/bloc/coin_addresses/bloc/coin_addresses_bloc.dart
@@ -38,12 +38,12 @@ class CoinAddressesBloc extends Bloc<CoinAddressesEvent, CoinAddressesState> {
         final derivation = (newKey as dynamic).derivationPath as String?;
         if (derivation != null) {
           final parsed = parseDerivationPath(derivation);
-          analyticsBloc.add(
-            AnalyticsSendDataEvent(HdAddressGeneratedEventData(
+          analyticsBloc.logEvent(
+            HdAddressGeneratedEventData(
               accountIndex: parsed.accountIndex,
               addressIndex: parsed.addressIndex,
               assetSymbol: assetId,
-            )),
+            ),
           );
         }
 

--- a/lib/bloc/coins_manager/coins_manager_bloc.dart
+++ b/lib/bloc/coins_manager/coins_manager_bloc.dart
@@ -135,8 +135,8 @@ class CoinsManagerBloc extends Bloc<CoinsManagerEvent, CoinsManagerState> {
 
       if (state.action == CoinsManagerAction.add) {
         _coinsRepo.deactivateCoinsSync([event.coin]);
-        _analyticsBloc.add(
-          AnalyticsAssetDisabledEvent(
+        _analyticsBloc.logEvent(
+          AssetDisabledEventData(
             assetSymbol: coin.abbr,
             assetNetwork: coin.protocolType,
             walletType:
@@ -145,8 +145,8 @@ class CoinsManagerBloc extends Bloc<CoinsManagerEvent, CoinsManagerState> {
         );
       } else {
         _coinsRepo.activateCoinsSync([event.coin]);
-        _analyticsBloc.add(
-          AnalyticsAssetEnabledEvent(
+        _analyticsBloc.logEvent(
+          AssetEnabledEventData(
             assetSymbol: coin.abbr,
             assetNetwork: coin.protocolType,
             walletType:
@@ -159,8 +159,8 @@ class CoinsManagerBloc extends Bloc<CoinsManagerEvent, CoinsManagerState> {
 
       if (state.action == CoinsManagerAction.add) {
         _coinsRepo.activateCoinsSync([event.coin]);
-        _analyticsBloc.add(
-          AnalyticsAssetEnabledEvent(
+        _analyticsBloc.logEvent(
+          AssetEnabledEventData(
             assetSymbol: coin.abbr,
             assetNetwork: coin.protocolType,
             walletType:
@@ -169,8 +169,8 @@ class CoinsManagerBloc extends Bloc<CoinsManagerEvent, CoinsManagerState> {
         );
       } else {
         _coinsRepo.deactivateCoinsSync([event.coin]);
-        _analyticsBloc.add(
-          AnalyticsAssetDisabledEvent(
+        _analyticsBloc.logEvent(
+          AssetDisabledEventData(
             assetSymbol: coin.abbr,
             assetNetwork: coin.protocolType,
             walletType:

--- a/lib/bloc/custom_token_import/bloc/custom_token_import_bloc.dart
+++ b/lib/bloc/custom_token_import/bloc/custom_token_import_bloc.dart
@@ -137,8 +137,8 @@ class CustomTokenImportBloc
 
       final walletType =
           (await sdk.auth.currentUser)?.wallet.config.type.name ?? '';
-      analyticsBloc.add(
-        AnalyticsAssetAddedEvent(
+      analyticsBloc.logEvent(
+        AssetAddedEventData(
           assetSymbol: state.coin!.id.id,
           assetNetwork: state.network.ticker,
           walletType: walletType,

--- a/lib/views/bridge/bridge_confirmation.dart
+++ b/lib/views/bridge/bridge_confirmation.dart
@@ -114,8 +114,8 @@ class _BridgeOrderConfirmationState extends State<BridgeConfirmation> {
     final buyCoin = RepositoryProvider.of<CoinsRepo>(context)
         .getCoin(state.bestOrder?.coin ?? '');
     if (sellCoin != null && buyCoin != null) {
-      context.read<AnalyticsBloc>().add(
-            AnalyticsBridgeInitiatedEvent(
+      context.read<AnalyticsBloc>().logEvent(
+            BridgeInitiatedEventData(
               fromChain: sellCoin.protocolType,
               toChain: buyCoin.protocolType,
               asset: sellCoin.abbr,

--- a/lib/views/dex/entity_details/trading_details.dart
+++ b/lib/views/dex/entity_details/trading_details.dart
@@ -146,8 +146,8 @@ class _TradingDetailsState extends State<TradingDetails> {
             break;
           }
         }
-        context.read<AnalyticsBloc>().add(
-              AnalyticsSwapSucceededEvent(
+        context.read<AnalyticsBloc>().logEvent(
+              SwapSucceededEventData(
                 fromAsset: fromAsset,
                 toAsset: toAsset,
                 amount: swapStatus.sellAmount.toDouble(),
@@ -172,8 +172,8 @@ class _TradingDetailsState extends State<TradingDetails> {
         }
       } else if (swapStatus.isFailed && !_loggedFailure) {
         _loggedFailure = true;
-        context.read<AnalyticsBloc>().add(
-              AnalyticsSwapFailedEvent(
+        context.read<AnalyticsBloc>().logEvent(
+              SwapFailedEventData(
                 fromAsset: fromAsset,
                 toAsset: toAsset,
                 failStage: swapStatus.status.name,

--- a/lib/views/dex/simple/confirm/maker_order_confirmation.dart
+++ b/lib/views/dex/simple/confirm/maker_order_confirmation.dart
@@ -312,8 +312,8 @@ class _MakerOrderConfirmationState extends State<MakerOrderConfirmation> {
     final buyCoin = makerFormBloc.buyCoin!.abbr;
     final networks =
         '${makerFormBloc.sellCoin!.protocolType},${makerFormBloc.buyCoin!.protocolType}';
-    context.read<AnalyticsBloc>().add(
-          AnalyticsSwapInitiatedEvent(
+    context.read<AnalyticsBloc>().logEvent(
+          SwapInitiatedEventData(
             fromAsset: sellCoin,
             toAsset: buyCoin,
             networks: networks,
@@ -334,8 +334,8 @@ class _MakerOrderConfirmationState extends State<MakerOrderConfirmation> {
     setState(() => _inProgress = false);
 
     if (error != null) {
-      context.read<AnalyticsBloc>().add(
-            AnalyticsSwapFailedEvent(
+      context.read<AnalyticsBloc>().logEvent(
+            SwapFailedEventData(
               fromAsset: sellCoin,
               toAsset: buyCoin,
               failStage: 'order_submission',
@@ -346,8 +346,8 @@ class _MakerOrderConfirmationState extends State<MakerOrderConfirmation> {
       return;
     }
 
-    context.read<AnalyticsBloc>().add(
-          AnalyticsSwapSucceededEvent(
+    context.read<AnalyticsBloc>().logEvent(
+          SwapSucceededEventData(
             fromAsset: sellCoin,
             toAsset: buyCoin,
             amount: makerFormBloc.sellAmount!.toDouble(),

--- a/lib/views/dex/simple/confirm/taker_order_confirmation.dart
+++ b/lib/views/dex/simple/confirm/taker_order_confirmation.dart
@@ -324,8 +324,8 @@ class _TakerOrderConfirmationState extends State<TakerOrderConfirmation> {
     final buyCoin = buyCoinObj?.abbr ?? takerBloc.state.selectedOrder!.coin;
     final networks =
         '${sellCoinObj.protocolType},${buyCoinObj?.protocolType ?? ''}';
-    context.read<AnalyticsBloc>().add(
-          AnalyticsSwapInitiatedEvent(
+    context.read<AnalyticsBloc>().logEvent(
+          SwapInitiatedEventData(
             fromAsset: sellCoin,
             toAsset: buyCoin,
             networks: networks,

--- a/lib/views/nfts/nft_page.dart
+++ b/lib/views/nfts/nft_page.dart
@@ -90,8 +90,8 @@ class _NFTPageViewState extends State<NFTPageView> {
         _loggedOpen = true;
         final count = state.nftCount.values
             .fold<int>(0, (sum, item) => sum + (item ?? 0));
-        context.read<AnalyticsBloc>().add(
-              AnalyticsNftGalleryOpenedEvent(
+        context.read<AnalyticsBloc>().logEvent(
+              NftGalleryOpenedEventData(
                 nftCount: count,
                 loadTimeMs: _loadStopwatch.elapsedMilliseconds,
               ),

--- a/lib/views/wallet/coin_details/coin_details.dart
+++ b/lib/views/wallet/coin_details/coin_details.dart
@@ -44,8 +44,8 @@ class _CoinDetailsState extends State<CoinDetails> {
       final walletType =
           context.read<AuthBloc>().state.currentUser?.wallet.config.type.name ??
               '';
-      context.read<AnalyticsBloc>().add(
-            AnalyticsAssetViewedEvent(
+      context.read<AnalyticsBloc>().logEvent(
+            AssetViewedEventData(
               assetSymbol: widget.coin.abbr,
               assetNetwork: widget.coin.protocolType,
               walletType: walletType,

--- a/lib/views/wallet/coin_details/coin_details_info/charts/animated_portfolio_charts.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/charts/animated_portfolio_charts.dart
@@ -53,8 +53,8 @@ class _AnimatedPortfolioChartsState extends State<AnimatedPortfolioCharts> {
         final growthState = context.read<PortfolioGrowthBloc>().state;
         if (growthState is PortfolioGrowthChartLoadSuccess) {
           final period = _formatDuration(growthState.selectedPeriod);
-          context.read<AnalyticsBloc>().add(
-                AnalyticsPortfolioGrowthViewedEvent(
+          context.read<AnalyticsBloc>().logEvent(
+                PortfolioGrowthViewedEventData(
                   period: period,
                   growthPct: growthState.percentageIncrease,
                 ),
@@ -64,8 +64,8 @@ class _AnimatedPortfolioChartsState extends State<AnimatedPortfolioCharts> {
         final profitLossState = context.read<ProfitLossBloc>().state;
         if (profitLossState is PortfolioProfitLossChartLoadSuccess) {
           final timeframe = _formatDuration(profitLossState.selectedPeriod);
-          context.read<AnalyticsBloc>().add(
-                AnalyticsPortfolioPnlViewedEvent(
+          context.read<AnalyticsBloc>().logEvent(
+                PortfolioPnlViewedEventData(
                   timeframe: timeframe,
                   realizedPnl: profitLossState.totalValue,
                   unrealizedPnl: 0,

--- a/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
@@ -416,8 +416,8 @@ class _CoinDetailsMarketMetricsTabBarState
           final growthState = context.read<PortfolioGrowthBloc>().state;
           if (growthState is PortfolioGrowthChartLoadSuccess) {
             final period = _formatDuration(growthState.selectedPeriod);
-            context.read<AnalyticsBloc>().add(
-                  AnalyticsPortfolioGrowthViewedEvent(
+            context.read<AnalyticsBloc>().logEvent(
+                  PortfolioGrowthViewedEventData(
                     period: period,
                     growthPct: growthState.percentageIncrease,
                   ),
@@ -427,8 +427,8 @@ class _CoinDetailsMarketMetricsTabBarState
           final profitLossState = context.read<ProfitLossBloc>().state;
           if (profitLossState is PortfolioProfitLossChartLoadSuccess) {
             final timeframe = _formatDuration(profitLossState.selectedPeriod);
-            context.read<AnalyticsBloc>().add(
-                  AnalyticsPortfolioPnlViewedEvent(
+            context.read<AnalyticsBloc>().logEvent(
+                  PortfolioPnlViewedEventData(
                     timeframe: timeframe,
                     realizedPnl: profitLossState.totalValue,
                     unrealizedPnl: 0,

--- a/lib/views/wallet/coin_details/rewards/kmd_rewards_info.dart
+++ b/lib/views/wallet/coin_details/rewards/kmd_rewards_info.dart
@@ -417,8 +417,8 @@ class _KmdRewardsInfoState extends State<KmdRewardsInfo> {
       _successMessage = '';
     });
 
-    context.read<AnalyticsBloc>().add(
-          AnalyticsRewardClaimInitiatedEvent(
+    context.read<AnalyticsBloc>().logEvent(
+          RewardClaimInitiatedEventData(
             asset: widget.coin.abbr,
             expectedRewardAmount: _totalReward ?? 0,
           ),
@@ -434,8 +434,8 @@ class _KmdRewardsInfoState extends State<KmdRewardsInfo> {
         _isClaiming = false;
         _errorMessage = error.message;
       });
-      context.read<AnalyticsBloc>().add(
-            AnalyticsRewardClaimFailureEvent(
+      context.read<AnalyticsBloc>().logEvent(
+            RewardClaimFailureEventData(
               asset: widget.coin.abbr,
               failReason: error.message,
             ),
@@ -455,8 +455,8 @@ class _KmdRewardsInfoState extends State<KmdRewardsInfo> {
     setState(() {
       _isClaiming = false;
     });
-    context.read<AnalyticsBloc>().add(
-          AnalyticsRewardClaimSuccessEvent(
+    context.read<AnalyticsBloc>().logEvent(
+          RewardClaimSuccessEventData(
             asset: widget.coin.abbr,
             rewardAmount: double.tryParse(response.result!) ?? 0,
           ),

--- a/lib/views/wallet/coin_details/withdraw_form/withdraw_form.dart
+++ b/lib/views/wallet/coin_details/withdraw_form/withdraw_form.dart
@@ -66,8 +66,8 @@ class _WithdrawFormState extends State<WithdrawForm> {
               final authBloc = context.read<AuthBloc>();
               final walletType =
                   authBloc.state.currentUser?.wallet.config.type.name ?? '';
-              context.read<AnalyticsBloc>().add(
-                    AnalyticsSendSucceededEvent(
+              context.read<AnalyticsBloc>().logEvent(
+                    SendSucceededEventData(
                       assetSymbol: state.asset.id.id,
                       network: state.asset.id.subClass.name,
                       amount: double.tryParse(state.amount) ?? 0.0,
@@ -85,8 +85,8 @@ class _WithdrawFormState extends State<WithdrawForm> {
               final walletType =
                   authBloc.state.currentUser?.wallet.config.type.name ?? '';
               final reason = state.transactionError?.message ?? 'unknown';
-              context.read<AnalyticsBloc>().add(
-                    AnalyticsSendFailedEvent(
+              context.read<AnalyticsBloc>().logEvent(
+                    SendFailedEventData(
                       assetSymbol: state.asset.id.id,
                       network: state.asset.protocol.subClass.name,
                       failReason: reason,
@@ -420,8 +420,8 @@ class WithdrawFormFillSection extends StatelessWidget {
                       final walletType =
                           authBloc.state.currentUser?.wallet.config.type.name ??
                               '';
-                      context.read<AnalyticsBloc>().add(
-                            AnalyticsSendInitiatedEvent(
+                      context.read<AnalyticsBloc>().logEvent(
+                            SendInitiatedEventData(
                               assetSymbol: state.asset.id.id,
                               network: state.asset.protocol.subClass.name,
                               amount: double.tryParse(state.amount) ?? 0.0,

--- a/lib/views/wallet/wallet_page/wallet_main/wallet_main.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/wallet_main.dart
@@ -290,11 +290,11 @@ class _WalletMainState extends State<WalletMain>
     if (_scrollController.offset >= half) {
       _walletHalfLogged = true;
       final coinsCount = context.read<CoinsBloc>().state.walletCoins.length;
-      context.read<AnalyticsBloc>().add(
-            AnalyticsSendDataEvent(WalletListHalfViewportReachedEventData(
+      context.read<AnalyticsBloc>().logEvent(
+            WalletListHalfViewportReachedEventData(
               timeToHalfMs: _walletListStopwatch.elapsedMilliseconds,
               walletSize: coinsCount,
-            )),
+            ),
           );
     }
   }

--- a/lib/views/wallet/wallet_page/wallet_main/wallet_overview.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/wallet_overview.dart
@@ -42,8 +42,8 @@ class _WalletOverviewState extends State<WalletOverview> {
             : null;
 
         if (!_logged && stateWithData != null) {
-          context.read<AnalyticsBloc>().add(
-                AnalyticsPortfolioViewedEvent(
+          context.read<AnalyticsBloc>().logEvent(
+                PortfolioViewedEventData(
                   totalCoins: assetCount,
                   totalValueUsd: stateWithData.totalValue.value,
                 ),

--- a/lib/views/wallets_manager/widgets/hardware_wallets_manager.dart
+++ b/lib/views/wallets_manager/widgets/hardware_wallets_manager.dart
@@ -90,11 +90,9 @@ class _HardwareWalletsManagerViewState
           AuthModeChanged(mode: AuthorizeMode.logIn, currentUser: kdfUser),
         );
     context.read<CoinsBloc>().add(CoinsSessionStarted(kdfUser));
-    context.read<AnalyticsBloc>().add(
-          AnalyticsSendDataEvent(
-            walletsManagerEventsFactory.createEvent(
-                widget.eventType, WalletsManagerEventMethod.hardware),
-          ),
+    context.read<AnalyticsBloc>().logEvent(
+          walletsManagerEventsFactory.createEvent(
+              widget.eventType, WalletsManagerEventMethod.hardware),
         );
 
     routingState.selectedMenu = MainMenuValue.wallet;

--- a/lib/views/wallets_manager/widgets/iguana_wallets_manager.dart
+++ b/lib/views/wallets_manager/widgets/iguana_wallets_manager.dart
@@ -82,8 +82,8 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
                         final method = newAction == WalletsManagerAction.create
                             ? 'create'
                             : 'import';
-                        context.read<AnalyticsBloc>().add(
-                              AnalyticsOnboardingStartedEvent(
+                        context.read<AnalyticsBloc>().logEvent(
+                              OnboardingStartedEventData(
                                 method: method,
                                 referralSource: widget.eventType.name,
                               ),
@@ -242,7 +242,7 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
       widget.eventType,
       WalletsManagerEventMethod.loginExisting,
     );
-    analyticsBloc.add(AnalyticsSendDataEvent(analyticsEvent));
+    analyticsBloc.logEvent(analyticsEvent);
 
     context
         .read<AuthBloc>()


### PR DESCRIPTION
## Summary
- use `logEvent` helper for sending analytics data
- update various widgets and blocs to call `logEvent` with event data

## Testing
- `dart format lib/bloc/app_bloc_root.dart lib/bloc/bridge_form/bridge_bloc.dart lib/bloc/coin_addresses/bloc/coin_addresses_bloc.dart lib/bloc/coins_manager/coins_manager_bloc.dart lib/bloc/custom_token_import/bloc/custom_token_import_bloc.dart lib/views/bridge/bridge_confirmation.dart lib/views/dex/entity_details/trading_details.dart lib/views/dex/simple/confirm/maker_order_confirmation.dart lib/views/dex/simple/confirm/taker_order_confirmation.dart lib/views/nfts/nft_page.dart lib/views/wallet/coin_details/coin_details.dart lib/views/wallet/coin_details/coin_details_info/charts/animated_portfolio_charts.dart lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart lib/views/wallet/coin_details/rewards/kmd_rewards_info.dart lib/views/wallet/coin_details/withdraw_form/withdraw_form.dart lib/views/wallet/wallet_page/wallet_main/wallet_main.dart lib/views/wallet/wallet_page/wallet_main/wallet_overview.dart lib/views/wallets_manager/widgets/hardware_wallets_manager.dart lib/views/wallets_manager/widgets/iguana_wallets_manager.dart`
- `flutter analyze`