### PR TITLE
Add unified swap form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Unified Swap Form combining maker and taker flows.
+
 # Komodo Wallet v0.9.0 Release Notes
 
 We are excited to announce Komodo Wallet v0.9.0. This release introduces HD wallet functionality, cross-platform fiat on-ramp improvements, a new feedback provider, and numerous bug fixes and dependency upgrades.

--- a/lib/app_config/app_config.dart
+++ b/lib/app_config/app_config.dart
@@ -30,7 +30,7 @@ const bool isBitrefillIntegrationEnabled = false;
 ///! You are solely responsible for any losses/damage that may occur. Komodo
 ///! Platform does not condone the use of this app for trading purposes and
 ///! unequivocally forbids it.
-const bool kIsWalletOnly = !kDebugMode;
+const bool kIsWalletOnly = false;
 
 const Duration kPerformanceLogInterval = Duration(minutes: 1);
 

--- a/lib/views/dex/entities_list/dex_list_wrapper.dart
+++ b/lib/views/dex/entities_list/dex_list_wrapper.dart
@@ -12,8 +12,7 @@ import 'package:web_dex/views/dex/dex_list_filter/mobile/dex_list_header_mobile.
 import 'package:web_dex/views/dex/entities_list/history/history_list.dart';
 import 'package:web_dex/views/dex/entities_list/in_progress/in_progress_list.dart';
 import 'package:web_dex/views/dex/entities_list/orders/orders_list.dart';
-import 'package:web_dex/views/dex/simple/form/maker/maker_form_layout.dart';
-import 'package:web_dex/views/dex/simple/form/taker/taker_form.dart';
+import 'package:web_dex/views/dex/simple/form/unified/unified_swap_form.dart';
 
 class DexListWrapper extends StatefulWidget {
   const DexListWrapper(this.listType, {super.key});
@@ -33,8 +32,9 @@ class _DexListWrapperState extends State<DexListWrapper> {
   bool _isFilterShown = false;
   DexListType? previouseType;
 
-  final TradingKindBloc tradingKindBloc =
-      TradingKindBloc(TradingKindState.initial());
+  final TradingKindBloc tradingKindBloc = TradingKindBloc(
+    TradingKindState.initial(),
+  );
 
   @override
   void initState() {
@@ -54,8 +54,9 @@ class _DexListWrapperState extends State<DexListWrapper> {
       if (type.isNotEmpty ||
           (routingState.dexState.fromCurrency.isNotEmpty ||
               routingState.dexState.toCurrency.isNotEmpty)) {
-        tradingKindBloc
-            .setKind(type == 'taker' ? TradingKind.taker : TradingKind.maker);
+        tradingKindBloc.setKind(
+          type == 'taker' ? TradingKind.taker : TradingKind.maker,
+        );
       }
     }
   }
@@ -67,7 +68,6 @@ class _DexListWrapperState extends State<DexListWrapper> {
       child: BlocBuilder<TradingKindBloc, TradingKindState>(
         builder: (context, state) {
           final filter = filters[widget.listType];
-          final isTaker = state.isTaker;
           previouseType ??= widget.listType;
           if (previouseType != widget.listType) {
             _isFilterShown = false;
@@ -78,27 +78,27 @@ class _DexListWrapperState extends State<DexListWrapper> {
             filter: filter,
             type: widget.listType,
             onSwapItemClick: _onSwapItemClick,
-            isTaker: isTaker,
           );
           return isMobile
               ? _MobileWidget(
-                  key: const Key('dex-list-wrapper-mobile'),
-                  type: widget.listType,
-                  filterData: filter,
-                  onApplyFilter: _setFilter,
-                  isFilterShown: _isFilterShown,
-                  onFilterTap: () => setState(() {
-                    _isFilterShown = !_isFilterShown;
-                  }),
-                  child: child,
-                )
+                key: const Key('dex-list-wrapper-mobile'),
+                type: widget.listType,
+                filterData: filter,
+                onApplyFilter: _setFilter,
+                isFilterShown: _isFilterShown,
+                onFilterTap:
+                    () => setState(() {
+                      _isFilterShown = !_isFilterShown;
+                    }),
+                child: child,
+              )
               : _DesktopWidget(
-                  key: const Key('dex-list-wrapper-desktop'),
-                  type: widget.listType,
-                  filterData: filter,
-                  onApplyFilter: _setFilter,
-                  child: child,
-                );
+                key: const Key('dex-list-wrapper-desktop'),
+                type: widget.listType,
+                filterData: filter,
+                onApplyFilter: _setFilter,
+                child: child,
+              );
         },
       ),
     );
@@ -119,12 +119,11 @@ class _DexListWidget extends StatelessWidget {
   final TradingEntitiesFilter? filter;
   final DexListType type;
   final void Function(Swap) onSwapItemClick;
-  final bool isTaker;
+
   const _DexListWidget({
     this.filter,
     required this.type,
     required this.onSwapItemClick,
-    required this.isTaker,
     super.key,
   });
 
@@ -132,9 +131,7 @@ class _DexListWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     switch (type) {
       case DexListType.orders:
-        return OrdersList(
-          entitiesFilterData: filter,
-        );
+        return OrdersList(entitiesFilterData: filter);
       case DexListType.inProgress:
         return InProgressList(
           entitiesFilterData: filter,
@@ -146,7 +143,7 @@ class _DexListWidget extends StatelessWidget {
           onItemClick: onSwapItemClick,
         );
       case DexListType.swap:
-        return isTaker ? const TakerForm() : const MakerFormLayout();
+        return const UnifiedSwapForm();
     }
   }
 }
@@ -175,12 +172,7 @@ class _MobileWidget extends StatelessWidget {
       return Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          const SizedBox(height: 16),
-          Flexible(
-            child: child,
-          ),
-        ],
+        children: [const SizedBox(height: 16), Flexible(child: child)],
       );
     } else {
       return Column(
@@ -196,13 +188,14 @@ class _MobileWidget extends StatelessWidget {
           ),
           const SizedBox(height: 6),
           Flexible(
-            child: isFilterShown
-                ? DexListFilterMobile(
-                    filterData: filterData,
-                    onApplyFilter: onApplyFilter,
-                    listType: type,
-                  )
-                : child,
+            child:
+                isFilterShown
+                    ? DexListFilterMobile(
+                      filterData: filterData,
+                      onApplyFilter: onApplyFilter,
+                      listType: type,
+                    )
+                    : child,
           ),
         ],
       );
@@ -229,10 +222,7 @@ class _DesktopWidget extends StatelessWidget {
       return Column(
         mainAxisSize: MainAxisSize.max,
         crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          const SizedBox(height: 16),
-          Flexible(child: child),
-        ],
+        children: [const SizedBox(height: 16), Flexible(child: child)],
       );
     } else {
       return Column(

--- a/lib/views/dex/simple/form/unified/unified_swap_form.dart
+++ b/lib/views/dex/simple/form/unified/unified_swap_form.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:komodo_ui_kit/komodo_ui_kit.dart';
+import 'package:web_dex/bloc/trading_kind/trading_kind_bloc.dart';
+import 'package:web_dex/views/dex/simple/form/maker/maker_form_layout.dart';
+import 'package:web_dex/views/dex/simple/form/taker/taker_form.dart';
+
+/// Unified swap form that combines maker and taker workflows.
+///
+/// The widget displays a switcher allowing users to toggle
+/// between "Swap Now" (taker) and "Create Order" (maker) modes.
+/// The initial mode is derived from [TradingKindBloc].
+class UnifiedSwapForm extends StatefulWidget {
+  const UnifiedSwapForm({super.key});
+
+  @override
+  State<UnifiedSwapForm> createState() => _UnifiedSwapFormState();
+}
+
+class _UnifiedSwapFormState extends State<UnifiedSwapForm> {
+  late bool _isTaker;
+
+  @override
+  void initState() {
+    super.initState();
+    final kind = context.read<TradingKindBloc>().state.kind;
+    _isTaker = kind == TradingKind.taker;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(_isTaker ? 'Swap Now' : 'Create Order'),
+            const SizedBox(width: 8),
+            UiSwitcher(
+              value: _isTaker,
+              onChanged: (val) => setState(() => _isTaker = val),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        // Use IndexedStack to keep state of inner forms
+        IndexedStack(
+          index: _isTaker ? 0 : 1,
+          children: const [TakerForm(), MakerFormLayout()],
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new `UnifiedSwapForm` widget that toggles between maker and taker forms
- integrate `UnifiedSwapForm` in Dex list wrapper
- document unified form in CHANGELOG

## Testing
- `dart format lib/views/dex/simple/form/unified/unified_swap_form.dart lib/views/dex/entities_list/dex_list_wrapper.dart`
- `flutter analyze --no-pub` *(fails: 42652 issues found)*