### PR TITLE
Tag parent chains of tokens as native instead of using the token standard

### DIFF
--- a/lib/model/coin_utils.dart
+++ b/lib/model/coin_utils.dart
@@ -116,6 +116,8 @@ bool compareCoinByPhrase(Coin coin, String phrase) {
       compareAbbr.contains(lowerCasePhrase);
 }
 
+bool isNativeErcType(Coin coin) => coin.protocolType == coin.id.symbol.configSymbol;
+
 String getCoinTypeName(CoinType type) {
   switch (type) {
     case CoinType.erc20:

--- a/lib/shared/widgets/coin_item/coin_item_subtitle.dart
+++ b/lib/shared/widgets/coin_item/coin_item_subtitle.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:web_dex/model/coin.dart';
+import 'package:web_dex/model/coin_utils.dart';
 import 'package:web_dex/shared/widgets/coin_item/coin_amount.dart';
 import 'package:web_dex/shared/widgets/coin_item/coin_item_size.dart';
 import 'package:web_dex/shared/widgets/coin_item/coin_protocol_name.dart';
@@ -29,7 +30,9 @@ class CoinItemSubtitle extends StatelessWidget {
         : coin?.mode == CoinMode.segwit && text == null
             ? SegwitIcon(height: size.segwitIconSize)
             : CoinProtocolName(
-                text: text ?? coin?.typeNameWithTestnet,
+                text: text?.isEmpty == false 
+                ? text : isNativeErcType(coin!)
+                ? "Native" : coin?.typeNameWithTestnet,
                 upperCase: text == null,
                 size: size,
               );

--- a/lib/shared/widgets/coin_item/coin_item_subtitle.dart
+++ b/lib/shared/widgets/coin_item/coin_item_subtitle.dart
@@ -22,6 +22,7 @@ class CoinItemSubtitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final bool isNativeCoin = isNativeErcType(coin!);
     return amount != null
         ? CoinAmount(
             amount: amount!,
@@ -31,7 +32,7 @@ class CoinItemSubtitle extends StatelessWidget {
             ? SegwitIcon(height: size.segwitIconSize)
             : CoinProtocolName(
                 text: text?.isEmpty == false 
-                ? text : isNativeErcType(coin!)
+                ? text : isNativeCoin
                 ? "Native" : coin?.typeNameWithTestnet,
                 upperCase: text == null,
                 size: size,

--- a/lib/views/dex/simple/form/taker/coin_item/coin_group_protocol.dart
+++ b/lib/views/dex/simple/form/taker/coin_item/coin_group_protocol.dart
@@ -1,6 +1,7 @@
 import 'package:app_theme/app_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:web_dex/model/coin.dart';
+import 'package:web_dex/model/coin_utils.dart';
 import 'package:web_dex/shared/widgets/segwit_icon.dart';
 
 class CoinGroupProtocol extends StatelessWidget {
@@ -31,8 +32,9 @@ class _CoinProtocol extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final bool isNativeCoin = isNativeErcType(coin);
     return Text(
-      coin.typeNameWithTestnet.toUpperCase(),
+      isNativeCoin ? "NATIVE" : coin.typeNameWithTestnet.toUpperCase(),
       style: TextStyle(
         fontSize: 11,
         fontWeight: FontWeight.w700,


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/komodo-wallet/issues/2537

### Changes
Native chain coins (like ETH on Ethereum chain) will now be tagged as "NATIVE" instead of their token standard (like "ERC20", "PLG20")

The logic for this is implemented in the isNativeErcType function:
`bool isNativeErcType(Coin coin) => coin.protocolType == coin.id.symbol.configSymbol;`
Which was added as the existing `isErcType` did not appear to catch non-ETH parents.

### QA Test Plan
1. Native Chain Coins Display
- [ ] Log in to the wallet
- [ ] Verify ETH on Ethereum chain shows "NATIVE" instead of "ERC20"
- [ ] Verify MATIC on Polygon chain shows "NATIVE" instead of "PLG20"
- [ ] Verify BNB on BSC chain shows "NATIVE" instead of "BEP20"
- [ ] Verify AVAX on Avalanche chain shows "NATIVE" instead of "AVX20"
- [ ] Verify FTM on Fantom chain shows "NATIVE" instead of "FTM20"
2. Token Display
- [ ] Verify USDT on Ethereum still shows "ERC20"
- [ ] Verify USDC on Polygon still shows "PLG20"
- [ ] Verify BUSD on BSC still shows "BEP20"
- [ ] Verify 1INCH on Avalanche still shows "AVX20"
4. UI Consistency
- [ ] Check coin lists
- [ ] Check portfolio view
- [ ] Check dex view
- [ ] Check bridge view
- [ ] Verify the "NATIVE" label is consistently applied across all views
6. Regression Testing
- [ ] Verify all other coin-related functionality works as before
- [ ] Check that trading between native coins and tokens works

### Notes for Reviewers
This change is primarily cosmetic but important for UX clarity. It helps align with industry standards where native chain coins are distinguished from tokens. This change should make the wallet more intuitive for users by clearly distinguishing between native chain coins and tokens built on those chains.