### PR TITLE
feat(login): HD wallet toggle state storage and remove toggle from wallet creation

### DIFF
--- a/lib/views/wallets_manager/widgets/hdwallet_mode_switch.dart
+++ b/lib/views/wallets_manager/widgets/hdwallet_mode_switch.dart
@@ -1,38 +1,51 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
+import 'package:app_theme/app_theme.dart';
 
 class HDWalletModeSwitch extends StatelessWidget {
   final bool value;
   final ValueChanged<bool> onChanged;
+  final bool highlight;
 
   const HDWalletModeSwitch({
     Key? key,
     required this.value,
     required this.onChanged,
+    this.highlight = false,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return SwitchListTile(
-      title: Row(
-        children: [
-          Text(LocaleKeys.hdWalletModeSwitchTitle.tr()),
-          const SizedBox(width: 8),
-          Tooltip(
-            message: LocaleKeys.hdWalletModeSwitchTooltip.tr(),
-            child: const Icon(Icons.info, size: 16),
-          ),
-        ],
-      ),
-      subtitle: Text(
-        LocaleKeys.hdWalletModeSwitchSubtitle.tr(),
-        style: const TextStyle(
-          fontSize: 12,
+    final warningColor = theme.custom.warningColor;
+    return Container(
+      decoration: highlight
+          ? BoxDecoration(
+              color: warningColor.withOpacity(0.1),
+              border: Border.all(color: warningColor),
+              borderRadius: BorderRadius.circular(8),
+            )
+          : null,
+      child: SwitchListTile(
+        title: Row(
+          children: [
+            Text(LocaleKeys.hdWalletModeSwitchTitle.tr()),
+            const SizedBox(width: 8),
+            Tooltip(
+              message: LocaleKeys.hdWalletModeSwitchTooltip.tr(),
+              child: const Icon(Icons.info, size: 16),
+            ),
+          ],
         ),
+        subtitle: Text(
+          LocaleKeys.hdWalletModeSwitchSubtitle.tr(),
+          style: const TextStyle(
+            fontSize: 12,
+          ),
+        ),
+        value: value,
+        onChanged: onChanged,
       ),
-      value: value,
-      onChanged: onChanged,
     );
   }
 }

--- a/lib/views/wallets_manager/widgets/wallet_creation.dart
+++ b/lib/views/wallets_manager/widgets/wallet_creation.dart
@@ -10,7 +10,6 @@ import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 
 import 'package:web_dex/shared/widgets/disclaimer/eula_tos_checkboxes.dart';
 import 'package:web_dex/views/wallets_manager/widgets/creation_password_fields.dart';
-import 'package:web_dex/views/wallets_manager/widgets/hdwallet_mode_switch.dart';
 
 class WalletCreation extends StatefulWidget {
   const WalletCreation({
@@ -39,7 +38,6 @@ class _WalletCreationState extends State<WalletCreation> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   bool _eulaAndTosChecked = false;
   bool _inProgress = false;
-  bool _isHdMode = true;
 
   @override
   Widget build(BuildContext context) {
@@ -111,13 +109,6 @@ class _WalletCreationState extends State<WalletCreation> {
             if (_isCreateButtonEnabled) _onCreate();
           },
         ),
-        const SizedBox(height: 16),
-        HDWalletModeSwitch(
-          value: _isHdMode,
-          onChanged: (value) {
-            setState(() => _isHdMode = value);
-          },
-        ),
       ],
     );
   }
@@ -147,7 +138,7 @@ class _WalletCreationState extends State<WalletCreation> {
       widget.onCreate(
         name: _nameController.text,
         password: _passwordController.text,
-        walletType: _isHdMode ? WalletType.hdwallet : WalletType.iguana,
+        walletType: WalletType.hdwallet,
       );
     });
   }

--- a/lib/views/wallets_manager/widgets/wallet_import_by_file.dart
+++ b/lib/views/wallets_manager/widgets/wallet_import_by_file.dart
@@ -128,6 +128,7 @@ class _WalletImportByFileState extends State<WalletImportByFile> {
               const SizedBox(height: 30),
               HDWalletModeSwitch(
                 value: _isHdMode,
+                highlight: true,
                 onChanged: (value) {
                   setState(() => _isHdMode = value);
                 },

--- a/lib/views/wallets_manager/widgets/wallet_login.dart
+++ b/lib/views/wallets_manager/widgets/wallet_login.dart
@@ -33,12 +33,13 @@ class WalletLogIn extends StatefulWidget {
 class _WalletLogInState extends State<WalletLogIn> {
   final _backKeyButton = GlobalKey();
   final TextEditingController _passwordController = TextEditingController();
-  bool _isHdMode = true;
+  late bool _isHdMode;
   KdfUser? _user;
 
   @override
   void initState() {
     super.initState();
+    _isHdMode = widget.wallet.config.type == WalletType.hdwallet;
     unawaited(_fetchKdfUser());
   }
 
@@ -118,6 +119,7 @@ class _WalletLogInState extends State<WalletLogIn> {
             if (_user != null && _user!.isBip39Seed == true)
               HDWalletModeSwitch(
                 value: _isHdMode,
+                highlight: true,
                 onChanged: (value) {
                   setState(() => _isHdMode = value);
                 },

--- a/lib/views/wallets_manager/widgets/wallet_simple_import.dart
+++ b/lib/views/wallets_manager/widgets/wallet_simple_import.dart
@@ -195,6 +195,7 @@ class _WalletImportWrapperState extends State<WalletSimpleImport> {
         const SizedBox(height: 16),
         HDWalletModeSwitch(
           value: _isHdMode,
+          highlight: true,
           onChanged: (value) {
             setState(() {
               _isHdMode = value;


### PR DESCRIPTION
## Summary
- highlight HD wallet toggle using a warning style
- remember HD mode selection per wallet on login
- force new wallets to use HD without toggle

## Testing
- `dart format lib/views/wallets_manager/widgets/hdwallet_mode_switch.dart lib/views/wallets_manager/widgets/wallet_creation.dart lib/views/wallets_manager/widgets/wallet_simple_import.dart lib/views/wallets_manager/widgets/wallet_import_by_file.dart lib/views/wallets_manager/widgets/wallet_login.dart`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_683d4bbbc6e88331a505a81cafdeadc8