### PR TITLE
Update docs for VS Code and web port usage

### DIFF
--- a/docs/BUILD_RUN_APP.md
+++ b/docs/BUILD_RUN_APP.md
@@ -59,6 +59,13 @@ Running on web-server (useful for testing/debugging in different browsers):
 flutter run -d web-server --web-port=8080
 ```
 
+The `--web-port` flag forces Flutter to use the same port each time you run the
+application locally. Keeping the port static ensures your browser reuses the
+same origin so that cache, cookies and any persisted wallet data remain
+available across runs. Without specifying a port, Flutter chooses a random one
+which clears local data on every launch, making it harder to test upgrades or
+identify wallet loading issues.
+
 ## Desktop
 
 #### macOS desktop

--- a/docs/MANUAL_TESTING_DEBUGGING.md
+++ b/docs/MANUAL_TESTING_DEBUGGING.md
@@ -140,6 +140,13 @@ Look for entries starting with or containing "Runner" or "Komodo"
 
 Replace `$HOME` with your home directory if there are any issues with the path.
 
+The repository already contains a `.vscode/launch.json` with several predefined
+configurations. Each uses the `--web-port` argument so the development server
+runs on the same port every time (55353 by default). A static port allows the
+browser to keep its cache and local storage between runs, preventing local
+wallet data from being wiped and helping to catch issues that might break wallet
+loading.
+
 ```json
 {
     "version": "0.2.0",
@@ -251,3 +258,16 @@ Replace `$HOME` with your home directory if there are any issues with the path.
   }
 }
 ```
+
+### tasks.json
+
+`tasks.json` defines tasks for running unit and integration tests directly from
+VS Code. They match the commands used in CI so you can quickly verify changes
+within the editor.
+
+### Recommended extensions
+
+When opening the repository, VS Code will prompt you to install the extensions
+listed in `.vscode/extensions.json`. These include Flutter, Dart, Remote
+Containers and Bloc helpers to align your environment with the project
+standards.

--- a/docs/PROJECT_SETUP.md
+++ b/docs/PROJECT_SETUP.md
@@ -15,6 +15,8 @@ Komodo Wallet is a cross-platform application, meaning it can be built for multi
     - [VS Code](https://code.visualstudio.com/)
       - install and enable `Dart` and `Flutter` extensions
       - enable `Dart: Use recommended settings` via the Command Pallette
+      - VS Code will suggest installing additional recommended extensions from
+        `.vscode/extensions.json` when you open the project
     - [Android Studio](https://developer.android.com/studio) - Ladybug | 2024.2.2
       - install and enable `Dart` and `Flutter` plugins
       - SDK Manager -> SDK Tools:


### PR DESCRIPTION
## Summary
- document benefits of specifying `--web-port` when running the app
- update VS Code docs: mention launch.json static port, tasks and extensions
- note recommended VS Code extensions in project setup

## Testing
- `fvm flutter test test_units/main.dart` *(fails: Got socket error trying to find package vm_service at https://pub.dev)*

------
https://chatgpt.com/codex/tasks/task_e_683d60c99ab88331be91e9b4fa315c64