### PR TITLE
fix(transactions): show sender address in transaction list

### DIFF
--- a/lib/views/wallet/coin_details/transactions/transaction_list_item.dart
+++ b/lib/views/wallet/coin_details/transactions/transaction_list_item.dart
@@ -263,17 +263,17 @@ class _TransactionListRowState extends State<TransactionListRow> {
   }
 
   Widget _buildAddress() {
-    final myAddress = widget.transaction.isIncoming
-        ? widget.transaction.to.first
-        : widget.transaction.from.first;
+    final address = widget.transaction.isIncoming
+        ? widget.transaction.from.first
+        : widget.transaction.to.first;
 
     return Row(
       children: [
         const SizedBox(width: 8),
-        AddressIcon(address: myAddress),
+        AddressIcon(address: address),
         const SizedBox(width: 8),
-        AddressText(address: myAddress),
-        AddressCopyButton(address: myAddress),
+        AddressText(address: address),
+        AddressCopyButton(address: address),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- ensure send transactions display the recipient address

## Testing
- `flutter pub get --offline`
- `dart format lib/views/wallet/coin_details/transactions/transaction_list_item.dart`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_683dbada69c88331a6c0ff5885035885