### PR TITLE
Restore logged in user on app resume

### DIFF
--- a/lib/analytics/widgets/analytics_lifecycle_handler.dart
+++ b/lib/analytics/widgets/analytics_lifecycle_handler.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get_it/get_it.dart';
 import 'package:web_dex/app_config/package_information.dart';
 import 'package:web_dex/bloc/analytics/analytics_repo.dart';
 import 'package:web_dex/analytics/events/user_engagement_events.dart';
 import 'package:web_dex/services/platform_info/plaftorm_info.dart';
 import 'package:web_dex/shared/utils/utils.dart';
+import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
 
 /// A widget that handles analytics lifecycle events like app opened/resumed.
 ///
@@ -53,6 +55,7 @@ class _AnalyticsLifecycleHandlerState extends State<AnalyticsLifecycleHandler>
     // Schedule the initial app opened event to be logged after the first frame
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _logAppOpenedEvent();
+      _checkAuthStatus();
     });
   }
 
@@ -69,6 +72,7 @@ class _AnalyticsLifecycleHandlerState extends State<AnalyticsLifecycleHandler>
     // Log app opened event when app is resumed (but not on initial open)
     if (state == AppLifecycleState.resumed && _hasLoggedInitialOpen) {
       _logAppOpenedEvent();
+      _checkAuthStatus();
     }
   }
 
@@ -97,6 +101,14 @@ class _AnalyticsLifecycleHandlerState extends State<AnalyticsLifecycleHandler>
 
       // If this is the initial attempt and failed, we'll try again on next resume
       // Flutter's lifecycle management will handle subsequent attempts naturally
+    }
+  }
+
+  void _checkAuthStatus() {
+    try {
+      context.read<AuthBloc>().add(const AuthCurrentUserRequested());
+    } catch (e) {
+      log('AnalyticsLifecycleHandler: Failed to check auth status - $e');
     }
   }
 

--- a/lib/bloc/auth_bloc/auth_bloc.dart
+++ b/lib/bloc/auth_bloc/auth_bloc.dart
@@ -30,6 +30,7 @@ class AuthBloc extends Bloc<AuthBlocEvent, AuthBlocState> {
     on<AuthRestoreRequested>(_onRestore);
     on<AuthSeedBackupConfirmed>(_onSeedBackupConfirmed);
     on<AuthWalletDownloadRequested>(_onWalletDownloadRequested);
+    on<AuthCurrentUserRequested>(_onCurrentUserRequested);
   }
 
   final KomodoDefiSdk _kdfSdk;
@@ -289,6 +290,17 @@ class AuthBloc extends Bloc<AuthBlocEvent, AuthBlocState> {
       );
     } catch (e, s) {
       _log.shout('Failed to download wallet data', e, s);
+    }
+  }
+
+  Future<void> _onCurrentUserRequested(
+    AuthCurrentUserRequested event,
+    Emitter<AuthBlocState> emit,
+  ) async {
+    final currentUser = await _kdfSdk.auth.currentUser;
+    if (currentUser != null) {
+      emit(AuthBlocState.loggedIn(currentUser));
+      _listenToAuthStateChanges();
     }
   }
 

--- a/lib/bloc/auth_bloc/auth_bloc_event.dart
+++ b/lib/bloc/auth_bloc/auth_bloc_event.dart
@@ -53,3 +53,8 @@ class AuthWalletDownloadRequested extends AuthBlocEvent {
   const AuthWalletDownloadRequested({required this.password});
   final String password;
 }
+
+/// Event emitted to check if an existing user is already signed in.
+class AuthCurrentUserRequested extends AuthBlocEvent {
+  const AuthCurrentUserRequested();
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -155,8 +155,12 @@ class MyApp extends StatelessWidget {
     return MultiBlocProvider(
       providers: [
         BlocProvider<AuthBloc>(
-          create: (_) =>
-              AuthBloc(komodoDefiSdk, walletsRepository, SettingsRepository()),
+          create: (_) {
+            final bloc = AuthBloc(
+                komodoDefiSdk, walletsRepository, SettingsRepository());
+            bloc.add(const AuthCurrentUserRequested());
+            return bloc;
+          },
         ),
       ],
       child: BetterFeedback(


### PR DESCRIPTION
## Summary
- check for an existing signed in user when the app starts or resumes
- emit the current user in `AuthBloc` if already logged in
- start the auth check when the app provider is created and on app lifecycle events

## Testing
- `fvm flutter pub get --enforce-lockfile`
- `timeout 40s fvm flutter analyze` *(fails with many lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6847edccbb3083319b3ab61697119ae2