### PR TITLE
Update Flutter references and Docker JDK

### DIFF
--- a/.docker/android-sdk.dockerfile
+++ b/.docker/android-sdk.dockerfile
@@ -36,7 +36,7 @@ RUN set -o xtrace \
     && sudo chown -R $USER:$USER /opt \
     && cd /opt \
     && sudo apt-get update \
-    && sudo apt-get install -y jq openjdk-17-jdk nodejs npm \
+    && sudo apt-get install -y jq openjdk-21-jdk nodejs npm \
     wget zip unzip git openssh-client curl bc software-properties-common build-essential \
     ruby-full ruby-bundler libstdc++6 libpulse0 libglu1-mesa locales lcov libsqlite3-dev --no-install-recommends \
     # For Linux build

--- a/.github/actions/flutter-deps/action.yml
+++ b/.github/actions/flutter-deps/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: subosito/flutter-action@v2
       with:
         # NB! Keep up-to-date with the flutter version used for development
-        flutter-version: "3.32.0"
+        flutter-version: "3.32.2"
         channel: "stable"
 
     - name: Prepare build directory

--- a/.github/workflows/mobile-builds.yml
+++ b/.github/workflows/mobile-builds.yml
@@ -68,13 +68,6 @@ jobs:
           FEEDBACK_PRODUCTION_URL: ${{ secrets.FEEDBACK_PRODUCTION_URL }}
           FEEDBACK_TEST_URL: ${{ secrets.FEEDBACK_TEST_URL }}
 
-      # Flutter build with `--no-pub` flag fails on Android due to a
-      # known regression with the build system in 3.32.0.
-      # https://github.com/flutter/flutter/issues/169336
-      - name: Temporary workaround for Android build issue
-        if: ${{ matrix.platform == 'Android' }}
-        run: |
-          flutter build apk --config-only
 
       - name: Build for ${{ matrix.platform }}
         env:

--- a/.github/workflows/roll-sdk-packages.yml
+++ b/.github/workflows/roll-sdk-packages.yml
@@ -45,7 +45,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           # NB! Keep up-to-date with the flutter version used for development
-          flutter-version: "3.32.0"
+          flutter-version: "3.32.2"
           channel: "stable"
 
       - name: Determine configuration

--- a/app_theme/pubspec.lock
+++ b/app_theme/pubspec.lock
@@ -61,4 +61,4 @@ packages:
     version: "2.1.4"
 sdks:
   dart: ">=3.7.0-0 <4.0.0"
-  flutter: ">=3.29.2"
+  flutter: ">=3.32.2"

--- a/app_theme/pubspec.yaml
+++ b/app_theme/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
-  flutter: ^3.29.2
+  flutter: ^3.32.2
 
 dependencies:
   flutter:

--- a/packages/komodo_ui_kit/pubspec.lock
+++ b/packages/komodo_ui_kit/pubspec.lock
@@ -196,4 +196,4 @@ packages:
     version: "1.1.1"
 sdks:
   dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.29.2"
+  flutter: ">=3.32.2"

--- a/packages/komodo_ui_kit/pubspec.yaml
+++ b/packages/komodo_ui_kit/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
-  flutter: ^3.29.2
+  flutter: ^3.32.2
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   # the new formatting style may cause conflicts. This allows to run 3.7.0, but it will not
   # enforce the new formatting style until the mininum Dart version is updated.
   sdk: ">=3.6.0 <4.0.0"
-  flutter: ^3.32.0
+  flutter: ^3.32.2
 
 dependencies:
   ## ---- Flutter SDK


### PR DESCRIPTION
## Summary
- update Flutter SDK requirement to 3.32.2
- switch GitHub actions to Flutter 3.32.2
- keep Android SDK container on JDK 21
- remove obsolete build workaround from `mobile-builds` workflow

## Testing
- `fvm flutter pub get --offline --enforce-lockfile`
- `fvm flutter analyze`
- `fvm dart format .`

------
https://chatgpt.com/codex/tasks/task_e_6847eadbdf888331a91256097e70351b