### PR TITLE
fix(auth): restore session on app start

### DIFF
--- a/lib/bloc/auth_bloc/auth_bloc.dart
+++ b/lib/bloc/auth_bloc/auth_bloc.dart
@@ -30,6 +30,7 @@ class AuthBloc extends Bloc<AuthBlocEvent, AuthBlocState> {
     on<AuthRestoreRequested>(_onRestore);
     on<AuthSeedBackupConfirmed>(_onSeedBackupConfirmed);
     on<AuthWalletDownloadRequested>(_onWalletDownloadRequested);
+    on<AuthSessionRestoreRequested>(_onRestoreSession);
   }
 
   final KomodoDefiSdk _kdfSdk;
@@ -37,6 +38,17 @@ class AuthBloc extends Bloc<AuthBlocEvent, AuthBlocState> {
   final SettingsRepository _settingsRepository;
   StreamSubscription<KdfUser?>? _authChangesSubscription;
   final _log = Logger('AuthBloc');
+
+  Future<void> _onRestoreSession(
+    AuthSessionRestoreRequested event,
+    Emitter<AuthBlocState> emit,
+  ) async {
+    final currentUser = await _kdfSdk.auth.currentUser;
+    if (currentUser != null) {
+      emit(AuthBlocState.loggedIn(currentUser));
+    }
+    _listenToAuthStateChanges();
+  }
 
   @override
   Future<void> close() async {

--- a/lib/bloc/auth_bloc/auth_bloc_event.dart
+++ b/lib/bloc/auth_bloc/auth_bloc_event.dart
@@ -53,3 +53,7 @@ class AuthWalletDownloadRequested extends AuthBlocEvent {
   const AuthWalletDownloadRequested({required this.password});
   final String password;
 }
+
+class AuthSessionRestoreRequested extends AuthBlocEvent {
+  const AuthSessionRestoreRequested();
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -155,8 +155,11 @@ class MyApp extends StatelessWidget {
     return MultiBlocProvider(
       providers: [
         BlocProvider<AuthBloc>(
-          create: (_) =>
-              AuthBloc(komodoDefiSdk, walletsRepository, SettingsRepository()),
+          create: (_) => AuthBloc(
+            komodoDefiSdk,
+            walletsRepository,
+            SettingsRepository(),
+          )..add(const AuthSessionRestoreRequested()),
         ),
       ],
       child: BetterFeedback(


### PR DESCRIPTION
## Summary
- restore persisted auth session via event handler
- trigger session restoration when the AuthBloc provider is created

## Testing
- `flutter pub get --enforce-lockfile`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_68495852c7a883268faf4cd6fc09f370