### PR TITLE
feat: manage trading status via bloc

### DIFF
--- a/lib/app_config/app_config.dart
+++ b/lib/app_config/app_config.dart
@@ -16,7 +16,8 @@ const String assetsPath = 'assets';
 const String coinsAssetsPath = 'packages/komodo_defi_framework/assets';
 
 final Uri discordSupportChannelUrl = Uri.parse(
-    'https://discord.com/channels/412898016371015680/429676282196787200');
+  'https://discord.com/channels/412898016371015680/429676282196787200',
+);
 final Uri discordInviteUrl = Uri.parse('https://komodoplatform.com/discord');
 
 // Temporary feature flag to allow merging of the PR
@@ -30,7 +31,11 @@ const bool isBitrefillIntegrationEnabled = false;
 ///! You are solely responsible for any losses/damage that may occur. Komodo
 ///! Platform does not condone the use of this app for trading purposes and
 ///! unequivocally forbids it.
-const bool kIsWalletOnly = !kDebugMode;
+bool kIsWalletOnly = !kDebugMode;
+
+void updateWalletOnly(bool value) {
+  kIsWalletOnly = value;
+}
 
 const Duration kPerformanceLogInterval = Duration(minutes: 1);
 
@@ -138,23 +143,19 @@ const List<String> appWalletOnlyAssetList = [
 /// Coins that are enabled by default on restore from seed or registration.
 /// This will not affect existing wallets.
 List<String> get enabledByDefaultCoins => [
-      'BTC-segwit',
-      'KMD',
-      'LTC-segwit',
-      'ETH',
-      'MATIC',
-      'BNB',
-      'AVAX',
-      'FTM',
-      if (kDebugMode) 'DOC',
-      if (kDebugMode) 'MARTY',
-    ];
+  'BTC-segwit',
+  'KMD',
+  'LTC-segwit',
+  'ETH',
+  'MATIC',
+  'BNB',
+  'AVAX',
+  'FTM',
+  if (kDebugMode) 'DOC',
+  if (kDebugMode) 'MARTY',
+];
 
-List<String> get enabledByDefaultTrezorCoins => [
-      'BTC',
-      'KMD',
-      'LTC',
-    ];
+List<String> get enabledByDefaultTrezorCoins => ['BTC', 'KMD', 'LTC'];
 
 List<String> get coinsWithFaucet => ['RICK', 'MORTY', 'DOC', 'MARTY'];
 

--- a/lib/bloc/trading_bouncer/trading_bouncer_bloc.dart
+++ b/lib/bloc/trading_bouncer/trading_bouncer_bloc.dart
@@ -1,0 +1,25 @@
+import 'package:bloc/bloc.dart';
+import 'package:web_dex/services/trading_bouncer/trading_bouncer_service.dart';
+
+part 'trading_bouncer_event.dart';
+part 'trading_bouncer_state.dart';
+
+class TradingBouncerBloc
+    extends Bloc<TradingBouncerEvent, TradingBouncerState> {
+  TradingBouncerBloc({required TradingBouncerService service})
+    : _service = service,
+      super(TradingBouncerState.initial()) {
+    on<TradingBouncerCheckRequested>(_onCheckRequested);
+    add(const TradingBouncerCheckRequested());
+  }
+
+  final TradingBouncerService _service;
+
+  Future<void> _onCheckRequested(
+    TradingBouncerCheckRequested event,
+    Emitter<TradingBouncerState> emit,
+  ) async {
+    final walletOnly = await _service.checkTradingStatus();
+    emit(state.copyWith(walletOnly: walletOnly));
+  }
+}

--- a/lib/bloc/trading_bouncer/trading_bouncer_event.dart
+++ b/lib/bloc/trading_bouncer/trading_bouncer_event.dart
@@ -1,0 +1,12 @@
+import 'package:equatable/equatable.dart';
+
+abstract class TradingBouncerEvent extends Equatable {
+  const TradingBouncerEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class TradingBouncerCheckRequested extends TradingBouncerEvent {
+  const TradingBouncerCheckRequested();
+}

--- a/lib/bloc/trading_bouncer/trading_bouncer_state.dart
+++ b/lib/bloc/trading_bouncer/trading_bouncer_state.dart
@@ -1,0 +1,19 @@
+import 'package:equatable/equatable.dart';
+import 'package:web_dex/app_config/app_config.dart';
+
+class TradingBouncerState extends Equatable {
+  const TradingBouncerState({required this.walletOnly});
+
+  factory TradingBouncerState.initial() {
+    return TradingBouncerState(walletOnly: kIsWalletOnly);
+  }
+
+  final bool walletOnly;
+
+  @override
+  List<Object?> get props => [walletOnly];
+
+  TradingBouncerState copyWith({bool? walletOnly}) {
+    return TradingBouncerState(walletOnly: walletOnly ?? this.walletOnly);
+  }
+}

--- a/lib/services/initializer/app_bootstrapper.dart
+++ b/lib/services/initializer/app_bootstrapper.dart
@@ -23,7 +23,9 @@ final class AppBootstrapper {
     timer.reset();
 
     await _warmUpInitializers().awaitAll();
-    log('AppBootstrapper: Warm-up initializers completed in ${timer.elapsedMilliseconds}ms');
+    log(
+      'AppBootstrapper: Warm-up initializers completed in ${timer.elapsedMilliseconds}ms',
+    );
     timer.stop();
 
     _isInitialized = true;
@@ -46,9 +48,11 @@ final class AppBootstrapper {
       CexMarketData.ensureInitialized(),
       PlatformTuner.setWindowTitleAndSize(),
       _initializeSettings(),
-      _initHive(isWeb: kIsWeb || kIsWasm, appFolder: appFolder).then(
-        (_) => sparklineRepository.init(),
-      ),
+      tradingBouncerService.checkTradingStatus().then((_) {}),
+      _initHive(
+        isWeb: kIsWeb || kIsWasm,
+        appFolder: appFolder,
+      ).then((_) => sparklineRepository.init()),
     ];
   }
 

--- a/lib/services/trading_bouncer/trading_bouncer_service.dart
+++ b/lib/services/trading_bouncer/trading_bouncer_service.dart
@@ -1,0 +1,24 @@
+import 'package:http/http.dart' as http;
+import 'package:web_dex/app_config/app_config.dart';
+import 'package:web_dex/shared/constants.dart';
+
+/// Service responsible for toggling trading features based on server status.
+class TradingBouncerService {
+  const TradingBouncerService();
+
+  /// Queries the status endpoint and updates [kIsWalletOnly].
+  /// Returns `true` when trading should be disabled.
+  Future<bool> checkTradingStatus() async {
+    try {
+      final res = await http.get(Uri.parse(tradingBouncerEndpoint));
+      final walletOnly = res.statusCode != 200;
+      updateWalletOnly(walletOnly);
+      return walletOnly;
+    } catch (_) {
+      updateWalletOnly(true);
+      return true;
+    }
+  }
+}
+
+const TradingBouncerService tradingBouncerService = TradingBouncerService();

--- a/lib/shared/constants.dart
+++ b/lib/shared/constants.dart
@@ -38,9 +38,14 @@ final Uri pricesUrlV3 = Uri.parse(
   'https://defi-stats.komodo.earth/api/v3/prices/tickers_v2?expire_at=60',
 );
 
+const String tradingBouncerEndpoint =
+    'https://defi-stats.komodo.earth/api/v3/utils/bouncer';
+
 const int millisecondsIn24H = 86400000;
 
-const bool isTestMode =
-    bool.fromEnvironment('testing_mode', defaultValue: false);
+const bool isTestMode = bool.fromEnvironment(
+  'testing_mode',
+  defaultValue: false,
+);
 const String moralisProxyUrl = 'https://moralis-proxy.komodo.earth';
 const String nftAntiSpamUrl = 'https://nft.antispam.dragonhound.info';


### PR DESCRIPTION
## Summary
- add TradingBouncerBloc for runtime trading control
- return boolean flag from TradingBouncerService
- initialize trading status bloc in AppBlocRoot
- handle trading check during bootstrapper

## Testing
- `dart format lib/bloc/trading_bouncer/trading_bouncer_bloc.dart lib/bloc/trading_bouncer/trading_bouncer_event.dart lib/bloc/trading_bouncer/trading_bouncer_state.dart lib/services/trading_bouncer/trading_bouncer_service.dart lib/bloc/app_bloc_root.dart lib/services/initializer/app_bootstrapper.dart`
- `flutter analyze` *(fails: resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684c4e02a1b48326bf971bf971d298b2