### PR TITLE
feat: add trading status guard

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -672,4 +672,6 @@
     "createNewAddress": "Create New Address",
     "searchAddresses": "Search addresses",
     "chart": "Chart"
+    "tradingDisabledTooltip": "Trading features are currently disabled",
+    "tradingDisabled": "Trading is currently unavailable",
 }

--- a/lib/app_config/app_config.dart
+++ b/lib/app_config/app_config.dart
@@ -30,7 +30,6 @@ const bool isBitrefillIntegrationEnabled = false;
 ///! You are solely responsible for any losses/damage that may occur. Komodo
 ///! Platform does not condone the use of this app for trading purposes and
 ///! unequivocally forbids it.
-const bool kIsWalletOnly = !kDebugMode;
 
 const Duration kPerformanceLogInterval = Duration(minutes: 1);
 

--- a/lib/bloc/app_bloc_root.dart
+++ b/lib/bloc/app_bloc_root.dart
@@ -45,6 +45,7 @@ import 'package:web_dex/bloc/settings/settings_bloc.dart';
 import 'package:web_dex/bloc/settings/settings_repository.dart';
 import 'package:web_dex/bloc/system_health/system_clock_repository.dart';
 import 'package:web_dex/bloc/system_health/system_health_bloc.dart';
+import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 import 'package:web_dex/bloc/taker_form/taker_bloc.dart';
 import 'package:web_dex/bloc/transaction_history/transaction_history_bloc.dart';
 import 'package:web_dex/bloc/transaction_history/transaction_history_repo.dart';
@@ -177,6 +178,7 @@ class AppBlocRoot extends StatelessWidget {
         RepositoryProvider(
           create: (_) => KmdRewardsBloc(coinsRepository, mm2Api),
         ),
+        RepositoryProvider(create: (_) => TradingStatusRepository()),
       ],
       child: MultiBlocProvider(
         providers: [
@@ -286,6 +288,12 @@ class AppBlocRoot extends StatelessWidget {
                 coinsRepository,
               ),
             ),
+          ),
+          BlocProvider<TradingStatusBloc>(
+            lazy: false,
+            create: (_) => TradingStatusBloc(
+              context.read<TradingStatusRepository>(),
+            )..add(TradingStatusCheckRequested()),
           ),
           BlocProvider<SystemHealthBloc>(
             create: (_) => SystemHealthBloc(SystemClockRepository(), mm2Api)

--- a/lib/bloc/trading_status/trading_status_bloc.dart
+++ b/lib/bloc/trading_status/trading_status_bloc.dart
@@ -1,0 +1,27 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'trading_status_repository.dart';
+
+part 'trading_status_event.dart';
+part 'trading_status_state.dart';
+
+class TradingStatusBloc extends Bloc<TradingStatusEvent, TradingStatusState> {
+  TradingStatusBloc(this._repository) : super(TradingStatusInitial()) {
+    on<TradingStatusCheckRequested>(_onCheckRequested);
+  }
+
+  final TradingStatusRepository _repository;
+
+  Future<void> _onCheckRequested(
+    TradingStatusCheckRequested event,
+    Emitter<TradingStatusState> emit,
+  ) async {
+    emit(TradingStatusLoadInProgress());
+    try {
+      final enabled = await _repository.isTradingEnabled();
+      emit(enabled ? TradingEnabled() : TradingDisabled());
+    } catch (_) {
+      emit(TradingStatusLoadFailure());
+    }
+  }
+}

--- a/lib/bloc/trading_status/trading_status_event.dart
+++ b/lib/bloc/trading_status/trading_status_event.dart
@@ -1,0 +1,8 @@
+part of 'trading_status_bloc.dart';
+
+abstract class TradingStatusEvent extends Equatable {
+  @override
+  List<Object?> get props => [];
+}
+
+class TradingStatusCheckRequested extends TradingStatusEvent {}

--- a/lib/bloc/trading_status/trading_status_repository.dart
+++ b/lib/bloc/trading_status/trading_status_repository.dart
@@ -1,0 +1,27 @@
+import 'dart:async';
+import 'package:http/http.dart' as http;
+
+class TradingStatusRepository {
+  TradingStatusRepository({http.Client? httpClient, Duration? timeout})
+      : _httpClient = httpClient ?? http.Client(),
+        _timeout = timeout ?? const Duration(seconds: 4);
+
+  final http.Client _httpClient;
+  final Duration _timeout;
+
+  Future<bool> isTradingEnabled() async {
+    try {
+      final uri =
+          Uri.parse('https://defi-stats.komodo.earth/api/v3/utils/bouncer');
+      final res = await _httpClient.get(uri).timeout(_timeout);
+      return res.statusCode == 200;
+    } catch (_) {
+      // Do not block trading features on network failure
+      return true;
+    }
+  }
+
+  void dispose() {
+    _httpClient.close();
+  }
+}

--- a/lib/bloc/trading_status/trading_status_state.dart
+++ b/lib/bloc/trading_status/trading_status_state.dart
@@ -1,0 +1,16 @@
+part of 'trading_status_bloc.dart';
+
+abstract class TradingStatusState extends Equatable {
+  @override
+  List<Object?> get props => [];
+}
+
+class TradingStatusInitial extends TradingStatusState {}
+
+class TradingStatusLoadInProgress extends TradingStatusState {}
+
+class TradingEnabled extends TradingStatusState {}
+
+class TradingDisabled extends TradingStatusState {}
+
+class TradingStatusLoadFailure extends TradingStatusState {}

--- a/lib/model/main_menu_value.dart
+++ b/lib/model/main_menu_value.dart
@@ -1,5 +1,5 @@
 import 'package:easy_localization/easy_localization.dart';
-import 'package:web_dex/app_config/app_config.dart';
+import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 
 enum MainMenuValue {
@@ -13,11 +13,10 @@ enum MainMenuValue {
   support,
   none;
 
-  static MainMenuValue defaultMenu() =>
-      kIsWalletOnly ? MainMenuValue.wallet : MainMenuValue.dex;
+  static MainMenuValue defaultMenu() => MainMenuValue.dex;
 
-  bool isEnabledInCurrentMode() {
-    return !(kIsWalletOnly && isDisabledWhenWalletOnly);
+  bool isEnabledInCurrentMode({required bool tradingEnabled}) {
+    return tradingEnabled || !isDisabledWhenWalletOnly;
   }
 
   // Getter to determine if the item is disabled if the wallet is in wallet-only mode

--- a/lib/router/navigators/page_content/page_content_router_delegate.dart
+++ b/lib/router/navigators/page_content/page_content_router_delegate.dart
@@ -19,15 +19,6 @@ class PageContentRouterDelegate extends RouterDelegate<AppRoutePath>
 
   @override
   Widget build(BuildContext context) {
-    // Redirect to the Wallet page if the selected menu is disabled in
-    // wallet-only mode and the wallet is in wallet-only mode.
-    if (routingState.selectedMenu.isDisabledWhenWalletOnly && kIsWalletOnly) {
-      return WalletPage(
-        coinAbbr: routingState.walletState.selectedCoin,
-        action: routingState.walletState.coinsManagerAction,
-      );
-    }
-
     switch (routingState.selectedMenu) {
       case MainMenuValue.fiat:
         return const FiatPage();

--- a/lib/router/parsers/root_route_parser.dart
+++ b/lib/router/parsers/root_route_parser.dart
@@ -40,8 +40,7 @@ class RootRouteInformationParser extends RouteInformationParser<AppRoutePath> {
   }
 
   BaseRouteParser _getRoutParser(Uri uri) {
-    final defaultRouteParser =
-        kIsWalletOnly ? _parsers[firstUriSegment.wallet]! : dexRouteParser;
+    final defaultRouteParser = dexRouteParser;
 
     if (uri.pathSegments.isEmpty) return defaultRouteParser;
     return _parsers[uri.pathSegments.first] ?? defaultRouteParser;

--- a/lib/shared/ui/clock_warning_banner.dart
+++ b/lib/shared/ui/clock_warning_banner.dart
@@ -1,8 +1,8 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:web_dex/app_config/app_config.dart';
 import 'package:web_dex/bloc/system_health/system_health_bloc.dart';
+import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 
 class ClockWarningBanner extends StatelessWidget {
@@ -12,9 +12,11 @@ class ClockWarningBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<SystemHealthBloc, SystemHealthState>(
       builder: (context, systemHealthState) {
+        final tradingEnabled =
+            context.watch<TradingStatusBloc>().state is TradingEnabled;
         if (systemHealthState is SystemHealthLoadSuccess &&
             !systemHealthState.isValid &&
-            !kIsWalletOnly) {
+            tradingEnabled) {
           return _buildWarningBanner();
         }
         return const SizedBox.shrink();

--- a/lib/shared/widgets/logout_popup.dart
+++ b/lib/shared/widgets/logout_popup.dart
@@ -1,7 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:web_dex/app_config/app_config.dart';
+import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_bloc.dart';
@@ -39,7 +39,7 @@ class LogOutPopup extends StatelessWidget {
               if (currentWallet?.config.type == WalletType.iguana ||
                   currentWallet?.config.type == WalletType.hdwallet)
                 SelectableText(
-                  kIsWalletOnly
+                  context.watch<TradingStatusBloc>().state is! TradingEnabled
                       ? LocaleKeys.logoutPopupDescriptionWalletOnly.tr()
                       : LocaleKeys.logoutPopupDescription.tr(),
                   style: const TextStyle(

--- a/lib/views/bridge/bridge_page.dart
+++ b/lib/views/bridge/bridge_page.dart
@@ -8,6 +8,8 @@ import 'package:web_dex/model/swap.dart';
 import 'package:web_dex/router/state/bridge_section_state.dart';
 import 'package:web_dex/router/state/routing_state.dart';
 import 'package:web_dex/shared/ui/clock_warning_banner.dart';
+import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
+import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/shared/utils/utils.dart';
 import 'package:web_dex/shared/widgets/hidden_without_wallet.dart';
 import 'package:web_dex/views/bridge/bridge_form.dart';
@@ -50,7 +52,20 @@ class _BridgePageState extends State<BridgePage> with TickerProviderStateMixin {
           });
         }
       },
-      child: _showSwap ? _buildTradingDetails() : _buildBridgePage(),
+      child: Builder(builder: (context) {
+        final tradingEnabled =
+            context.watch<TradingStatusBloc>().state is TradingEnabled;
+        final page = _showSwap ? _buildTradingDetails() : _buildBridgePage();
+        if (!tradingEnabled) {
+          return Stack(
+            children: [
+              AbsorbPointer(child: page),
+              Center(child: Text(LocaleKeys.tradingDisabled.tr())),
+            ],
+          );
+        }
+        return page;
+      }),
     );
   }
 

--- a/lib/views/common/main_menu/main_menu_bar_mobile.dart
+++ b/lib/views/common/main_menu/main_menu_bar_mobile.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
 import 'package:web_dex/bloc/settings/settings_bloc.dart';
 import 'package:web_dex/bloc/settings/settings_state.dart';
+import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 import 'package:web_dex/model/main_menu_value.dart';
 import 'package:web_dex/model/wallet.dart';
 import 'package:web_dex/router/state/routing_state.dart';
@@ -18,6 +19,8 @@ class MainMenuBarMobile extends StatelessWidget {
     return BlocBuilder<SettingsBloc, SettingsState>(
       builder: (context, state) {
         final bool isMMBotEnabled = state.mmBotSettings.isMMBotEnabled;
+        final bool tradingEnabled =
+            context.watch<TradingStatusBloc>().state is TradingEnabled;
         return DecoratedBox(
           decoration: BoxDecoration(
             color: theme.currentGlobal.cardColor,
@@ -45,21 +48,36 @@ class MainMenuBarMobile extends StatelessWidget {
                     enabled: currentWallet?.isHW != true,
                     isActive: selected == MainMenuValue.fiat,
                   ),
-                  MainMenuBarMobileItem(
-                    value: MainMenuValue.dex,
-                    enabled: currentWallet?.isHW != true,
-                    isActive: selected == MainMenuValue.dex,
+                  Tooltip(
+                    message: tradingEnabled
+                        ? ''
+                        : LocaleKeys.tradingDisabledTooltip.tr(),
+                    child: MainMenuBarMobileItem(
+                      value: MainMenuValue.dex,
+                      enabled: tradingEnabled && currentWallet?.isHW != true,
+                      isActive: selected == MainMenuValue.dex,
+                    ),
                   ),
-                  MainMenuBarMobileItem(
-                    value: MainMenuValue.bridge,
-                    enabled: currentWallet?.isHW != true,
-                    isActive: selected == MainMenuValue.bridge,
+                  Tooltip(
+                    message: tradingEnabled
+                        ? ''
+                        : LocaleKeys.tradingDisabledTooltip.tr(),
+                    child: MainMenuBarMobileItem(
+                      value: MainMenuValue.bridge,
+                      enabled: tradingEnabled && currentWallet?.isHW != true,
+                      isActive: selected == MainMenuValue.bridge,
+                    ),
                   ),
                   if (isMMBotEnabled)
-                    MainMenuBarMobileItem(
-                      enabled: currentWallet?.isHW != true,
-                      value: MainMenuValue.marketMakerBot,
-                      isActive: selected == MainMenuValue.marketMakerBot,
+                    Tooltip(
+                      message: tradingEnabled
+                          ? ''
+                          : LocaleKeys.tradingDisabledTooltip.tr(),
+                      child: MainMenuBarMobileItem(
+                        enabled: tradingEnabled && currentWallet?.isHW != true,
+                        value: MainMenuValue.marketMakerBot,
+                        isActive: selected == MainMenuValue.marketMakerBot,
+                      ),
                     ),
                   MainMenuBarMobileItem(
                     value: MainMenuValue.nft,
@@ -70,9 +88,7 @@ class MainMenuBarMobile extends StatelessWidget {
                     value: MainMenuValue.settings,
                     isActive: selected == MainMenuValue.settings,
                   ),
-                ]
-                    .where((element) => element.value.isEnabledInCurrentMode())
-                    .toList(),
+                ],
               ),
             ),
           ),

--- a/lib/views/common/main_menu/main_menu_desktop.dart
+++ b/lib/views/common/main_menu/main_menu_desktop.dart
@@ -3,7 +3,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
-import 'package:web_dex/app_config/app_config.dart';
+import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
 import 'package:web_dex/bloc/settings/settings_bloc.dart';
 import 'package:web_dex/bloc/settings/settings_event.dart';
@@ -34,6 +34,8 @@ class _MainMenuDesktopState extends State<MainMenuDesktop> {
             final bool isDarkTheme = settingsState.themeMode == ThemeMode.dark;
             final bool isMMBotEnabled =
                 settingsState.mmBotSettings.isMMBotEnabled;
+            final bool tradingEnabled =
+                context.watch<TradingStatusBloc>().state is TradingEnabled;
             final SettingsBloc settings = context.read<SettingsBloc>();
             final currentWallet = state.currentUser?.wallet;
             return Container(
@@ -63,28 +65,44 @@ class _MainMenuDesktopState extends State<MainMenuDesktop> {
                       onTap: onTapItem,
                       isSelected: _checkSelectedItem(MainMenuValue.fiat),
                     ),
-                    DesktopMenuDesktopItem(
-                      key: const Key('main-menu-dex'),
-                      enabled: currentWallet?.isHW != true,
-                      menu: MainMenuValue.dex,
-                      onTap: onTapItem,
-                      isSelected: _checkSelectedItem(MainMenuValue.dex),
+                    Tooltip(
+                      message: tradingEnabled
+                          ? ''
+                          : LocaleKeys.tradingDisabledTooltip.tr(),
+                      child: DesktopMenuDesktopItem(
+                        key: const Key('main-menu-dex'),
+                        enabled: tradingEnabled && currentWallet?.isHW != true,
+                        menu: MainMenuValue.dex,
+                        onTap: onTapItem,
+                        isSelected: _checkSelectedItem(MainMenuValue.dex),
+                      ),
                     ),
-                    DesktopMenuDesktopItem(
-                      key: const Key('main-menu-bridge'),
-                      enabled: currentWallet?.isHW != true,
-                      menu: MainMenuValue.bridge,
-                      onTap: onTapItem,
-                      isSelected: _checkSelectedItem(MainMenuValue.bridge),
+                    Tooltip(
+                      message: tradingEnabled
+                          ? ''
+                          : LocaleKeys.tradingDisabledTooltip.tr(),
+                      child: DesktopMenuDesktopItem(
+                        key: const Key('main-menu-bridge'),
+                        enabled: tradingEnabled && currentWallet?.isHW != true,
+                        menu: MainMenuValue.bridge,
+                        onTap: onTapItem,
+                        isSelected: _checkSelectedItem(MainMenuValue.bridge),
+                      ),
                     ),
                     if (isMMBotEnabled && isAuthenticated)
-                      DesktopMenuDesktopItem(
-                        key: const Key('main-menu-market-maker-bot'),
-                        enabled: currentWallet?.isHW != true,
-                        menu: MainMenuValue.marketMakerBot,
-                        onTap: onTapItem,
-                        isSelected:
-                            _checkSelectedItem(MainMenuValue.marketMakerBot),
+                      Tooltip(
+                        message: tradingEnabled
+                            ? ''
+                            : LocaleKeys.tradingDisabledTooltip.tr(),
+                        child: DesktopMenuDesktopItem(
+                          key: const Key('main-menu-market-maker-bot'),
+                          enabled:
+                              tradingEnabled && currentWallet?.isHW != true,
+                          menu: MainMenuValue.marketMakerBot,
+                          onTap: onTapItem,
+                          isSelected:
+                              _checkSelectedItem(MainMenuValue.marketMakerBot),
+                        ),
                       ),
                     DesktopMenuDesktopItem(
                         key: const Key('main-menu-nft'),
@@ -129,12 +147,7 @@ class _MainMenuDesktopState extends State<MainMenuDesktop> {
                       }),
                     ),
                     const SizedBox(height: 48),
-                  ]
-                      // Filter out disabled items
-                      .where((item) =>
-                          item is! DesktopMenuDesktopItem ||
-                          item.menu.isEnabledInCurrentMode())
-                      .toList(),
+                  ].toList(),
                 ),
               ),
             );

--- a/lib/views/dex/dex_page.dart
+++ b/lib/views/dex/dex_page.dart
@@ -1,7 +1,7 @@
 import 'package:app_theme/app_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:web_dex/app_config/app_config.dart';
+import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_repo.dart';
 import 'package:web_dex/bloc/dex_tab_bar/dex_tab_bar_bloc.dart';
@@ -14,6 +14,7 @@ import 'package:web_dex/router/state/routing_state.dart';
 import 'package:web_dex/services/orders_service/my_orders_service.dart';
 import 'package:web_dex/shared/ui/clock_warning_banner.dart';
 import 'package:web_dex/shared/widgets/hidden_without_wallet.dart';
+import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/views/common/pages/page_layout.dart';
 import 'package:web_dex/views/dex/dex_tab_bar.dart';
 import 'package:web_dex/views/dex/entities_list/dex_list_wrapper.dart';
@@ -43,15 +44,14 @@ class _DexPageState extends State<DexPage> {
 
   @override
   Widget build(BuildContext context) {
-    if (kIsWalletOnly) {
-      return const Placeholder(child: Text('You should not see this page'));
-    }
+    final tradingEnabled =
+        context.watch<TradingStatusBloc>().state is TradingEnabled;
     final tradingEntitiesBloc =
         RepositoryProvider.of<TradingEntitiesBloc>(context);
     final coinsRepository = RepositoryProvider.of<CoinsRepo>(context);
     final myOrdersService = RepositoryProvider.of<MyOrdersService>(context);
 
-    return MultiBlocProvider(
+    final pageContent = MultiBlocProvider(
       providers: [
         BlocProvider<DexTabBarBloc>(
           key: const Key('dex-page'),
@@ -70,6 +70,15 @@ class _DexPageState extends State<DexPage> {
           ? TradingDetails(uuid: routingState.dexState.uuid)
           : _DexContent(),
     );
+    if (!tradingEnabled) {
+      return Stack(
+        children: [
+          AbsorbPointer(child: pageContent),
+          Center(child: Text(LocaleKeys.tradingDisabled.tr())),
+        ],
+      );
+    }
+    return pageContent;
   }
 
   void _onRouteChange() {

--- a/lib/views/main_layout/main_layout.dart
+++ b/lib/views/main_layout/main_layout.dart
@@ -3,7 +3,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:web_dex/app_config/app_config.dart';
+import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
 import 'package:web_dex/blocs/update_bloc.dart';
 import 'package:web_dex/common/screen.dart';
@@ -33,7 +33,9 @@ class _MainLayoutState extends State<MainLayout> {
       await AlphaVersionWarningService().run();
       await updateBloc.init();
 
-      if (!kIsWalletOnly && !await _hasAgreedNoTrading()) {
+      final tradingEnabled =
+          context.read<TradingStatusBloc>().state is TradingEnabled;
+      if (tradingEnabled && !await _hasAgreedNoTrading()) {
         _showNoTradingWarning().ignore();
       }
     });

--- a/lib/views/market_maker_bot/market_maker_bot_page.dart
+++ b/lib/views/market_maker_bot/market_maker_bot_page.dart
@@ -11,6 +11,8 @@ import 'package:web_dex/bloc/market_maker_bot/market_maker_order_list/market_mak
 import 'package:web_dex/bloc/market_maker_bot/market_maker_trade_form/market_maker_trade_form_bloc.dart';
 import 'package:web_dex/bloc/settings/settings_repository.dart';
 import 'package:web_dex/blocs/trading_entities_bloc.dart';
+import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
+import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/authorize_mode.dart';
 import 'package:web_dex/router/state/routing_state.dart';
 import 'package:web_dex/services/orders_service/my_orders_service.dart';
@@ -52,7 +54,9 @@ class _MarketMakerBotPageState extends State<MarketMakerBotPage> {
       coinsRepository,
     );
 
-    return MultiBlocProvider(
+    final tradingEnabled =
+        context.watch<TradingStatusBloc>().state is TradingEnabled;
+    final pageContent = MultiBlocProvider(
       providers: [
         BlocProvider<DexTabBarBloc>(
           create: (BuildContext context) => DexTabBarBloc(
@@ -90,6 +94,15 @@ class _MarketMakerBotPageState extends State<MarketMakerBotPage> {
             : MarketMakerBotView(),
       ),
     );
+    if (!tradingEnabled) {
+      return Stack(
+        children: [
+          AbsorbPointer(child: pageContent),
+          Center(child: Text(LocaleKeys.tradingDisabled.tr())),
+        ],
+      );
+    }
+    return pageContent;
   }
 
   void _onRouteChange() {

--- a/lib/views/settings/widgets/general_settings/general_settings.dart
+++ b/lib/views/settings/widgets/general_settings/general_settings.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:web_dex/app_config/app_config.dart';
+import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/shared/widgets/hidden_with_wallet.dart';
 import 'package:web_dex/shared/widgets/hidden_without_wallet.dart';
@@ -31,7 +31,7 @@ class GeneralSettings extends StatelessWidget {
         const SizedBox(height: 25),
         const SettingsManageWeakPasswords(),
         const SizedBox(height: 25),
-        if (!kIsWalletOnly)
+        if (context.watch<TradingStatusBloc>().state is TradingEnabled)
           const HiddenWithoutWallet(
             child: SettingsManageTradingBot(),
           ),

--- a/lib/views/wallet/coin_details/coin_details_info/coin_details_common_buttons.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/coin_details_common_buttons.dart
@@ -4,7 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 import 'package:komodo_ui/komodo_ui.dart';
-import 'package:web_dex/app_config/app_config.dart';
+import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
 import 'package:web_dex/bloc/coin_addresses/bloc/coin_addresses_bloc.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
@@ -167,7 +167,8 @@ class CoinDetailsCommonButtonsDesktopLayout extends StatelessWidget {
             context: context,
           ),
         ),
-        if (!coin.walletOnly && !kIsWalletOnly)
+        if (!coin.walletOnly &&
+            context.watch<TradingStatusBloc>().state is TradingEnabled)
           Container(
             margin: const EdgeInsets.only(left: 21),
             constraints: const BoxConstraints(maxWidth: 120),

--- a/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
@@ -5,7 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
-import 'package:web_dex/app_config/app_config.dart';
+import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
 import 'package:web_dex/bloc/cex_market_data/portfolio_growth/portfolio_growth_bloc.dart';
 import 'package:web_dex/bloc/cex_market_data/profit_loss/profit_loss_bloc.dart';
@@ -267,9 +267,10 @@ class _DesktopCoinDetails extends StatelessWidget {
             child: CoinDetailsCommonButtons(
               isMobile: false,
               selectWidget: setPageType,
-              onClickSwapButton: MainMenuValue.dex.isEnabledInCurrentMode()
-                  ? null
-                  : () => _goToSwap(context, coin),
+              onClickSwapButton:
+                  context.watch<TradingStatusBloc>().state is TradingEnabled
+                      ? () => _goToSwap(context, coin)
+                      : null,
               coin: coin,
             ),
           ),
@@ -368,9 +369,10 @@ class _CoinDetailsInfoHeader extends StatelessWidget {
             child: CoinDetailsCommonButtons(
               isMobile: true,
               selectWidget: setPageType,
-              onClickSwapButton: MainMenuValue.dex.isEnabledInCurrentMode()
-                  ? () => _goToSwap(context, coin)
-                  : null,
+              onClickSwapButton:
+                  context.watch<TradingStatusBloc>().state is TradingEnabled
+                      ? () => _goToSwap(context, coin)
+                      : null,
               coin: coin,
             ),
           ),

--- a/lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart
+++ b/lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart
@@ -7,7 +7,7 @@ import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
 import 'package:komodo_ui/komodo_ui.dart';
-import 'package:web_dex/app_config/app_config.dart';
+import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_bloc.dart';
 import 'package:web_dex/model/coin.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
@@ -272,7 +272,8 @@ class _AddressRow extends StatelessWidget {
                 visualDensity: VisualDensity.compact,
               ),
             ),
-            if (isSwapAddress && !kIsWalletOnly) ...[
+            if (isSwapAddress &&
+                context.watch<TradingStatusBloc>().state is TradingEnabled) ...[
               const SizedBox(width: 8),
               const Chip(
                 label: Text(


### PR DESCRIPTION
## Summary
- add TradingStatusBloc for checking the bouncer endpoint
- remove kIsWalletOnly constant
- disable trading actions when bouncer forbids with tooltips
- always keep dex/bridge/MMBot pages and menu items visible
- overlay disabled pages when trading not allowed

## Testing
- `flutter analyze` *(fails: 573 issues)*

------
https://chatgpt.com/codex/tasks/task_e_684dee592bdc8326a35809e69685aa2a