### PR TITLE
feat: set wallet page as default landing view

### DIFF
--- a/lib/model/main_menu_value.dart
+++ b/lib/model/main_menu_value.dart
@@ -13,7 +13,7 @@ enum MainMenuValue {
   support,
   none;
 
-  static MainMenuValue defaultMenu() => MainMenuValue.dex;
+  static MainMenuValue defaultMenu() => MainMenuValue.wallet;
 
   bool isEnabledInCurrentMode({required bool tradingEnabled}) {
     return tradingEnabled || !isDisabledWhenWalletOnly;


### PR DESCRIPTION
## Summary
- set wallet as the default landing page in the main menu

## Testing
- `flutter analyze --no-pub` *(fails: version solving failed)*
- `dart format -o none lib/model/main_menu_value.dart`

------
https://chatgpt.com/codex/tasks/task_e_685181ee93c483268a4b16b36b7ff677