### PR TITLE
fix(fiat-onramp): breaking Ramp API change

### DIFF
--- a/lib/bloc/fiat/ramp/ramp_fiat_provider.dart
+++ b/lib/bloc/fiat/ramp/ramp_fiat_provider.dart
@@ -309,7 +309,7 @@ class RampFiatProvider extends BaseFiatProvider {
       'userAddress': walletAddress,
       'finalUrl': returnUrlOnSuccess,
       'defaultFlow': 'ONRAMP',
-      'enabledFlows': '[ONRAMP]',
+      'enabledFlows': 'ONRAMP',
       'fiatCurrency': source,
       'fiatValue': sourceAmount,
       'defaultAsset': getFullCoinCode(target),


### PR DESCRIPTION
Align the Ramp `enabledFlows` configuration parameter with the format expected and defined in their [documentation](https://docs.ramp.network/configuration#enabledflows).

Although incorrect, the Ramp v1 API previously accepted (or ignored) the URL encoded string of a JavaScript array `['ONRAMP']` -> `%5B%27ONRAMP%27%5D`. A recent change to their form/API appears to have tightened up their validation, and the URL-encoded array is no longer accepted. 

Ramp was last tested between 07-15 May 2025 (#2608 , #2570), so this change likely occurred sometime afterwards. I couldn't locate changelogs or issues in their repositories relating to this issue.  