### PR TITLE
fix(withdraw): auto-select source address

### DIFF
--- a/lib/bloc/withdraw_form/withdraw_form_bloc.dart
+++ b/lib/bloc/withdraw_form/withdraw_form_bloc.dart
@@ -6,6 +6,7 @@ import 'package:web_dex/bloc/withdraw_form/withdraw_form_bloc.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/mm2/mm2_api/rpc/base.dart';
 import 'package:web_dex/model/text_error.dart';
+import 'package:collection/collection.dart';
 
 export 'package:web_dex/bloc/withdraw_form/withdraw_form_event.dart';
 export 'package:web_dex/bloc/withdraw_form/withdraw_form_state.dart';
@@ -54,13 +55,19 @@ class WithdrawFormBloc extends Bloc<WithdrawFormEvent, WithdrawFormState> {
     try {
       final pubkeys = await state.asset.getPubkeys(_sdk);
       if (pubkeys.keys.isNotEmpty) {
+        final current = state.selectedSourceAddress;
+        final newSelection = current != null
+            ? pubkeys.keys.firstWhereOrNull(
+                  (key) => key.address == current.address,
+                ) ??
+                pubkeys.keys.first
+            : (pubkeys.keys.length == 1 ? pubkeys.keys.first : null);
+
         emit(
           state.copyWith(
             pubkeys: () => pubkeys,
             networkError: () => null,
-            selectedSourceAddress: state.selectedSourceAddress == null
-                ? null
-                : () => pubkeys.keys.firstOrNull,
+            selectedSourceAddress: () => newSelection,
           ),
         );
       } else {

--- a/lib/views/wallet/coin_details/withdraw_form/withdraw_form.dart
+++ b/lib/views/wallet/coin_details/withdraw_form/withdraw_form.dart
@@ -316,7 +316,8 @@ class WithdrawFormFillSection extends StatelessWidget {
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            if (state.asset.supportsMultipleAddresses) ...[
+            if (state.asset.supportsMultipleAddresses &&
+                (state.pubkeys?.keys.length ?? 0) > 1) ...[
               SourceAddressField(
                 asset: state.asset,
                 pubkeys: state.pubkeys,


### PR DESCRIPTION
## Summary
- auto-select the only available source address
- hide source address selector when there is a single address

## Testing
- `flutter pub get --offline --enforce-lockfile` *(fails: domain not in allowlist)*
- `flutter analyze` *(fails: domain not in allowlist)*
- `dart format -o none -l 120 lib/bloc/withdraw_form/withdraw_form_bloc.dart lib/views/wallet/coin_details/withdraw_form/withdraw_form.dart`

------
https://chatgpt.com/codex/tasks/task_e_68595b7161dc8326aa621cde5a111893