### PR TITLE
fix: display auth errors on wallet restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ venv/
 # FVM Version Cache
 .fvm/
 /macos/build
+AGENTS_1.md

--- a/lib/views/wallets_manager/widgets/iguana_wallets_manager.dart
+++ b/lib/views/wallets_manager/widgets/iguana_wallets_manager.dart
@@ -50,6 +50,28 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
         if (state.mode == AuthorizeMode.logIn) {
           _onLogIn();
         }
+
+        if (state.isError) {
+          setState(() => _isLoading = false);
+
+          final theme = Theme.of(context);
+          final message =
+              state.authError?.message ?? LocaleKeys.somethingWrong.tr();
+
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                message,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: theme.colorScheme.onErrorContainer,
+                ),
+              ),
+              backgroundColor: theme.colorScheme.errorContainer,
+            ),
+          );
+        } else if (!state.isLoading) {
+          setState(() => _isLoading = false);
+        }
       },
       child: Builder(
         builder: (context) {
@@ -61,15 +83,16 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
                 children: [
                   WalletsList(
                     walletType: WalletType.iguana,
-                    onWalletClick: (
-                      Wallet wallet,
-                      WalletsManagerExistWalletAction existWalletAction,
-                    ) {
-                      setState(() {
-                        _selectedWallet = wallet;
-                        _existWalletAction = existWalletAction;
-                      });
-                    },
+                    onWalletClick:
+                        (
+                          Wallet wallet,
+                          WalletsManagerExistWalletAction existWalletAction,
+                        ) {
+                          setState(() {
+                            _selectedWallet = wallet;
+                            _existWalletAction = existWalletAction;
+                          });
+                        },
                   ),
                   Padding(
                     padding: const EdgeInsets.only(top: 15.0),
@@ -83,11 +106,11 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
                             ? 'create'
                             : 'import';
                         context.read<AnalyticsBloc>().logEvent(
-                              OnboardingStartedEventData(
-                                method: method,
-                                referralSource: widget.eventType.name,
-                              ),
-                            );
+                          OnboardingStartedEventData(
+                            method: method,
+                            referralSource: widget.eventType.name,
+                          ),
+                        );
                       },
                     ),
                   ),
@@ -117,10 +140,7 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
         _existWalletAction != WalletsManagerExistWalletAction.none) {
       switch (_existWalletAction) {
         case WalletsManagerExistWalletAction.delete:
-          return WalletDeleting(
-            wallet: selectedWallet,
-            close: _cancel,
-          );
+          return WalletDeleting(wallet: selectedWallet, close: _cancel);
         case WalletsManagerExistWalletAction.logIn:
         case WalletsManagerExistWalletAction.none:
           return WalletLogIn(
@@ -208,8 +228,8 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
     );
 
     context.read<AuthBloc>().add(
-          AuthRegisterRequested(wallet: newWallet, password: password),
-        );
+      AuthRegisterRequested(wallet: newWallet, password: password),
+    );
   }
 
   void _importWallet({
@@ -220,16 +240,18 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
     setState(() {
       _isLoading = true;
     });
-    final Wallet newWallet =
-        Wallet.fromConfig(name: name, config: walletConfig);
+    final Wallet newWallet = Wallet.fromConfig(
+      name: name,
+      config: walletConfig,
+    );
 
     context.read<AuthBloc>().add(
-          AuthRestoreRequested(
-            wallet: newWallet,
-            password: password,
-            seed: walletConfig.seedPhrase,
-          ),
-        );
+      AuthRestoreRequested(
+        wallet: newWallet,
+        password: password,
+        seed: walletConfig.seedPhrase,
+      ),
+    );
   }
 
   Future<void> _logInToWallet(String password, Wallet wallet) async {
@@ -244,9 +266,9 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
     );
     analyticsBloc.logEvent(analyticsEvent);
 
-    context
-        .read<AuthBloc>()
-        .add(AuthSignInRequested(wallet: wallet, password: password));
+    context.read<AuthBloc>().add(
+      AuthSignInRequested(wallet: wallet, password: password),
+    );
 
     if (mounted) {
       setState(() {
@@ -266,10 +288,7 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
       final walletType = currentWallet.config.type.name;
       if (action == WalletsManagerAction.create) {
         analyticsBloc.add(
-          AnalyticsWalletCreatedEvent(
-            source: source,
-            walletType: walletType,
-          ),
+          AnalyticsWalletCreatedEvent(source: source, walletType: walletType),
         );
       } else if (action == WalletsManagerAction.import) {
         analyticsBloc.add(

--- a/lib/views/wallets_manager/widgets/wallet_creation.dart
+++ b/lib/views/wallets_manager/widgets/wallet_creation.dart
@@ -25,7 +25,8 @@ class WalletCreation extends StatefulWidget {
     required String name,
     required String password,
     WalletType? walletType,
-  }) onCreate;
+  })
+  onCreate;
   final void Function() onCancel;
 
   @override
@@ -34,8 +35,9 @@ class WalletCreation extends StatefulWidget {
 
 class _WalletCreationState extends State<WalletCreation> {
   final TextEditingController _nameController = TextEditingController(text: '');
-  final TextEditingController _passwordController =
-      TextEditingController(text: '');
+  final TextEditingController _passwordController = TextEditingController(
+    text: '',
+  );
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   bool _eulaAndTosChecked = false;
   bool _inProgress = false;
@@ -43,49 +45,75 @@ class _WalletCreationState extends State<WalletCreation> {
 
   @override
   Widget build(BuildContext context) {
-    return Form(
-      key: _formKey,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            widget.action == WalletsManagerAction.create
-                ? LocaleKeys.walletCreationTitle.tr()
-                : LocaleKeys.walletImportTitle.tr(),
-            style:
-                Theme.of(context).textTheme.titleLarge?.copyWith(fontSize: 18),
-          ),
-          const SizedBox(height: 24),
-          _buildFields(),
-          const SizedBox(height: 22),
-          EulaTosCheckboxes(
-            key: const Key('create-wallet-eula-checks'),
-            isChecked: _eulaAndTosChecked,
-            onCheck: (isChecked) {
-              setState(() {
-                _eulaAndTosChecked = isChecked;
-              });
-            },
-          ),
-          const SizedBox(height: 32),
-          UiPrimaryButton(
-            key: const Key('confirm-password-button'),
-            height: 50,
-            text: _inProgress
-                ? '${LocaleKeys.pleaseWait.tr()}...'
-                : LocaleKeys.create.tr(),
-            textStyle: const TextStyle(
-              fontSize: 14,
-              fontWeight: FontWeight.w700,
+    return BlocListener<AuthBloc, AuthBlocState>(
+      listener: (context, state) {
+        if (!state.isLoading) {
+          setState(() => _inProgress = false);
+        }
+
+        if (state.isError) {
+          final theme = Theme.of(context);
+          final message =
+              state.authError?.message ?? LocaleKeys.somethingWrong.tr();
+
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                message,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: theme.colorScheme.onErrorContainer,
+                ),
+              ),
+              backgroundColor: theme.colorScheme.errorContainer,
             ),
-            onPressed: _isCreateButtonEnabled ? _onCreate : null,
-          ),
-          const SizedBox(height: 20),
-          UiUnderlineTextButton(
-            onPressed: widget.onCancel,
-            text: LocaleKeys.cancel.tr(),
-          ),
-        ],
+          );
+        }
+      },
+      child: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              widget.action == WalletsManagerAction.create
+                  ? LocaleKeys.walletCreationTitle.tr()
+                  : LocaleKeys.walletImportTitle.tr(),
+              style: Theme.of(
+                context,
+              ).textTheme.titleLarge?.copyWith(fontSize: 18),
+            ),
+            const SizedBox(height: 24),
+            _buildFields(),
+            const SizedBox(height: 22),
+            EulaTosCheckboxes(
+              key: const Key('create-wallet-eula-checks'),
+              isChecked: _eulaAndTosChecked,
+              onCheck: (isChecked) {
+                setState(() {
+                  _eulaAndTosChecked = isChecked;
+                });
+              },
+            ),
+            const SizedBox(height: 32),
+            UiPrimaryButton(
+              key: const Key('confirm-password-button'),
+              height: 50,
+              text: _inProgress
+                  ? '${LocaleKeys.pleaseWait.tr()}...'
+                  : LocaleKeys.create.tr(),
+              textStyle: const TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w700,
+              ),
+              onPressed: _isCreateButtonEnabled ? _onCreate : null,
+            ),
+            const SizedBox(height: 20),
+            UiUnderlineTextButton(
+              onPressed: widget.onCancel,
+              text: LocaleKeys.cancel.tr(),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/views/wallets_manager/widgets/wallet_simple_import.dart
+++ b/lib/views/wallets_manager/widgets/wallet_simple_import.dart
@@ -30,28 +30,27 @@ class WalletSimpleImport extends StatefulWidget {
     required String name,
     required String password,
     required WalletConfig walletConfig,
-  }) onImport;
+  })
+  onImport;
 
   final void Function() onCancel;
 
   final void Function({required String fileName, required String fileData})
-      onUploadFiles;
+  onUploadFiles;
 
   @override
   State<WalletSimpleImport> createState() => _WalletImportWrapperState();
 }
 
-enum WalletSimpleImportSteps {
-  nameAndSeed,
-  password,
-}
+enum WalletSimpleImportSteps { nameAndSeed, password }
 
 class _WalletImportWrapperState extends State<WalletSimpleImport> {
   WalletSimpleImportSteps _step = WalletSimpleImportSteps.nameAndSeed;
   final TextEditingController _nameController = TextEditingController(text: '');
   final TextEditingController _seedController = TextEditingController(text: '');
-  final TextEditingController _passwordController =
-      TextEditingController(text: '');
+  final TextEditingController _passwordController = TextEditingController(
+    text: '',
+  );
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   bool _isSeedHidden = true;
   bool _eulaAndTosChecked = false;
@@ -67,50 +66,76 @@ class _WalletImportWrapperState extends State<WalletSimpleImport> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        SelectableText(
-          _step == WalletSimpleImportSteps.nameAndSeed
-              ? LocaleKeys.walletImportTitle.tr()
-              : LocaleKeys.walletImportCreatePasswordTitle
-                  .tr(args: [_nameController.text]),
-          style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                fontSize: 20,
-              ),
-          textAlign: TextAlign.center,
-        ),
-        const SizedBox(height: 20),
-        Form(
-          key: _formKey,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              _buildFields(),
-              const SizedBox(height: 20),
-              UiPrimaryButton(
-                key: const Key('confirm-seed-button'),
-                text: _inProgress
-                    ? '${LocaleKeys.pleaseWait.tr()}...'
-                    : LocaleKeys.import.tr(),
-                height: 50,
-                textStyle: const TextStyle(
-                  fontSize: 14,
-                  fontWeight: FontWeight.w700,
+    return BlocListener<AuthBloc, AuthBlocState>(
+      listener: (context, state) {
+        if (!state.isLoading) {
+          setState(() => _inProgress = false);
+        }
+
+        if (state.isError) {
+          final theme = Theme.of(context);
+          final message =
+              state.authError?.message ?? LocaleKeys.somethingWrong.tr();
+
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                message,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: theme.colorScheme.onErrorContainer,
                 ),
-                onPressed: _isButtonEnabled ? _onImport : null,
               ),
-              const SizedBox(height: 20),
-              UiUnderlineTextButton(
-                onPressed: _onCancel,
-                text: _step == WalletSimpleImportSteps.nameAndSeed
-                    ? LocaleKeys.cancel.tr()
-                    : LocaleKeys.back.tr(),
-              ),
-            ],
+              backgroundColor: theme.colorScheme.errorContainer,
+            ),
+          );
+        }
+      },
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SelectableText(
+            _step == WalletSimpleImportSteps.nameAndSeed
+                ? LocaleKeys.walletImportTitle.tr()
+                : LocaleKeys.walletImportCreatePasswordTitle.tr(
+                    args: [_nameController.text],
+                  ),
+            style: Theme.of(
+              context,
+            ).textTheme.titleLarge?.copyWith(fontSize: 20),
+            textAlign: TextAlign.center,
           ),
-        ),
-      ],
+          const SizedBox(height: 20),
+          Form(
+            key: _formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                _buildFields(),
+                const SizedBox(height: 20),
+                UiPrimaryButton(
+                  key: const Key('confirm-seed-button'),
+                  text: _inProgress
+                      ? '${LocaleKeys.pleaseWait.tr()}...'
+                      : LocaleKeys.import.tr(),
+                  height: 50,
+                  textStyle: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                  ),
+                  onPressed: _isButtonEnabled ? _onImport : null,
+                ),
+                const SizedBox(height: 20),
+                UiUnderlineTextButton(
+                  onPressed: _onCancel,
+                  text: _step == WalletSimpleImportSteps.nameAndSeed
+                      ? LocaleKeys.cancel.tr()
+                      : LocaleKeys.back.tr(),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 
@@ -312,14 +337,16 @@ class _WalletImportWrapperState extends State<WalletSimpleImport> {
       return null;
     }
 
-    final maybeFailedReason =
-        context.read<KomodoDefiSdk>().mnemonicValidator.validateMnemonic(
-              seed ?? '',
-              minWordCount: 12,
-              maxWordCount: 24,
-              isHd: _isHdMode,
-              allowCustomSeed: _allowCustomSeed,
-            );
+    final maybeFailedReason = context
+        .read<KomodoDefiSdk>()
+        .mnemonicValidator
+        .validateMnemonic(
+          seed ?? '',
+          minWordCount: 12,
+          maxWordCount: 24,
+          isHd: _isHdMode,
+          allowCustomSeed: _allowCustomSeed,
+        );
 
     if (maybeFailedReason == null) {
       return null;
@@ -328,9 +355,10 @@ class _WalletImportWrapperState extends State<WalletSimpleImport> {
     return switch (maybeFailedReason) {
       MnemonicFailedReason.empty =>
         LocaleKeys.walletCreationEmptySeedError.tr(),
-      MnemonicFailedReason.customNotSupportedForHd => _isHdMode
-          ? LocaleKeys.walletCreationHdBip39SeedError.tr()
-          : LocaleKeys.walletCreationBip39SeedError.tr(),
+      MnemonicFailedReason.customNotSupportedForHd =>
+        _isHdMode
+            ? LocaleKeys.walletCreationHdBip39SeedError.tr()
+            : LocaleKeys.walletCreationBip39SeedError.tr(),
       MnemonicFailedReason.customNotAllowed =>
         LocaleKeys.customSeedWarningText.tr(),
       MnemonicFailedReason.invalidLength =>


### PR DESCRIPTION
## Summary
- show auth error feedback in wallets manager
- reset progress on wallet creation errors
- handle restore errors for simple imports
- ignore runtime AGENTS_1.md file

## Testing
- `dart format lib/views/wallets_manager/widgets/iguana_wallets_manager.dart lib/views/wallets_manager/widgets/wallet_creation.dart lib/views/wallets_manager/widgets/wallet_simple_import.dart`
- `flutter analyze --no-pub` *(fails: Undefined functions/classes due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68596c331604832691b0fa9a7976adbb