### PR TITLE
fix(wallet): refresh pubkeys after new address

### DIFF
--- a/lib/bloc/coin_addresses/bloc/coin_addresses_bloc.dart
+++ b/lib/bloc/coin_addresses/bloc/coin_addresses_bloc.dart
@@ -11,9 +11,11 @@ class CoinAddressesBloc extends Bloc<CoinAddressesEvent, CoinAddressesState> {
   final KomodoDefiSdk sdk;
   final String assetId;
   final AnalyticsBloc analyticsBloc;
-
-  CoinAddressesBloc(this.sdk, this.assetId, this.analyticsBloc)
-      : super(const CoinAddressesState()) {
+  CoinAddressesBloc(
+    this.sdk,
+    this.assetId,
+    this.analyticsBloc,
+  ) : super(const CoinAddressesState()) {
     on<SubmitCreateAddressEvent>(_onSubmitCreateAddress);
     on<LoadAddressesEvent>(_onLoadAddresses);
     on<UpdateHideZeroBalanceEvent>(_onUpdateHideZeroBalance);

--- a/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
@@ -94,9 +94,18 @@ class _CoinDetailsInfoState extends State<CoinDetailsInfo>
   Widget build(BuildContext context) {
     return BlocProvider.value(
       value: _coinAddressesBloc,
-      child: PageLayout(
-        header: PageHeader(
-          title: widget.coin.name,
+      child: BlocListener<CoinAddressesBloc, CoinAddressesState>(
+        listenWhen: (previous, current) =>
+            previous.createAddressStatus != current.createAddressStatus &&
+            current.createAddressStatus == FormStatus.success,
+        listener: (context, state) {
+          context
+              .read<CoinsBloc>()
+              .add(CoinsPubkeysRequested(widget.coin.abbr));
+        },
+        child: PageLayout(
+          header: PageHeader(
+            title: widget.coin.name,
           widgetTitle: widget.coin.mode == CoinMode.segwit
               ? const Padding(
                   padding: EdgeInsets.only(left: 6.0),
@@ -107,8 +116,9 @@ class _CoinDetailsInfoState extends State<CoinDetailsInfo>
           onBackButtonPressed: _onBackButtonPressed,
           actions: [_buildDisableButton()],
         ),
-        content: Expanded(
-          child: _buildContent(context),
+          content: Expanded(
+            child: _buildContent(context),
+          ),
         ),
       ),
     );

--- a/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
@@ -6,6 +6,7 @@ import 'package:flutter_svg/svg.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 import 'package:web_dex/app_config/app_config.dart';
+import 'package:web_dex/bloc/coin_addresses/bloc/coin_addresses_state.dart';
 import 'package:web_dex/bloc/trading_status/trading_status_bloc.dart';
 import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
 import 'package:web_dex/bloc/cex_market_data/portfolio_growth/portfolio_growth_bloc.dart';
@@ -106,16 +107,16 @@ class _CoinDetailsInfoState extends State<CoinDetailsInfo>
         child: PageLayout(
           header: PageHeader(
             title: widget.coin.name,
-          widgetTitle: widget.coin.mode == CoinMode.segwit
-              ? const Padding(
-                  padding: EdgeInsets.only(left: 6.0),
-                  child: SegwitIcon(height: 22),
-                )
-              : null,
-          backText: _backText,
-          onBackButtonPressed: _onBackButtonPressed,
-          actions: [_buildDisableButton()],
-        ),
+            widgetTitle: widget.coin.mode == CoinMode.segwit
+                ? const Padding(
+                    padding: EdgeInsets.only(left: 6.0),
+                    child: SegwitIcon(height: 22),
+                  )
+                : null,
+            backText: _backText,
+            onBackButtonPressed: _onBackButtonPressed,
+            actions: [_buildDisableButton()],
+          ),
           content: Expanded(
             child: _buildContent(context),
           ),


### PR DESCRIPTION
## Summary
- refresh global pubkeys when generating a new coin address using a BlocListener
- remove cross-bloc reference from CoinAddressesBloc

## Testing
- `flutter pub get --enforce-lockfile` *(fails: Flutter SDK version solving failed)*
- `flutter pub get --offline` *(fails: Flutter SDK version solving failed)*
- `flutter analyze` *(fails: Flutter SDK version solving failed)*
- `dart format -o none lib/bloc/coin_addresses/bloc/coin_addresses_bloc.dart lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart`

------
https://chatgpt.com/codex/tasks/task_e_685959e8340c832691a2e26778732db5