### PR TITLE
linux: call XInitThreads() to make X11 access thread-safe

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -52,6 +52,7 @@ add_subdirectory(${FLUTTER_MANAGED_DIR})
 
 # System-level dependencies.
 find_package(PkgConfig REQUIRED)
+find_package(X11 REQUIRED)
 pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
 
 add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
@@ -71,6 +72,7 @@ add_executable(${BINARY_NAME}
 apply_standard_settings(${BINARY_NAME})
 
 # Add dependency libraries. Add any application-specific dependencies here.
+target_link_libraries(${BINARY_NAME} PRIVATE X11)
 target_link_libraries(${BINARY_NAME} PRIVATE flutter)
 target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
 

--- a/linux/main.cc
+++ b/linux/main.cc
@@ -1,6 +1,8 @@
+#include <X11/Xlib.h>
 #include "my_application.h"
 
 int main(int argc, char** argv) {
+  XInitThreads();
   g_autoptr(MyApplication) app = my_application_new();
   return g_application_run(G_APPLICATION(app), argc, argv);
 }


### PR DESCRIPTION
Flutter’s engine spawns multiple threads (UI, raster, etc.). Under X11 these threads may issue X calls concurrently, which is undefined unless XInitThreads() is invoked before the first X request.

Without this, the app aborts on launch with:

```
  [xcb] Unknown request in queue while dequeuing
  [xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
  KomodoWallet: xcb_io.c:175: dequeue_pending_request: Assertion `!xcb_xlib_unknown_req_in_deq' failed.
```

This patch:

* adds `#include <X11/Xlib.h>`
* calls `XInitThreads()` at the very start of `main()` in `linux/runner/main.cc`
* ensures libX11 is linked via CMake

Wayland sessions were already stable; this change fixes crashes when running under pure X11 or XWayland.

- https://github.com/flutter/flutter/issues/170937
- https://github.com/flutter/flutter/issues/169470