### PR TITLE
fix: prevent crash on `null` `my_info` by adding `SwapMyInfo.empty()` fallback

### DIFF
--- a/lib/model/swap.dart
+++ b/lib/model/swap.dart
@@ -412,7 +412,15 @@ class SwapMyInfo extends Equatable {
     required this.startedAt,
   });
 
-  factory SwapMyInfo.fromJson(Map<String, dynamic> json) {
+  const SwapMyInfo.empty()
+      : myCoin = '',
+        otherCoin = '',
+        myAmount = 0,
+        otherAmount = 0,
+        startedAt = 0;
+
+  factory SwapMyInfo.fromJson(Map<String, dynamic>? json) {
+    if (json == null) return const SwapMyInfo.empty();
     return SwapMyInfo(
       myCoin: json['my_coin'],
       otherCoin: json['other_coin'],


### PR DESCRIPTION
Sometimes Komodo Wallet doesn’t show the history of swaps or swaps in progress at all. It displays the list as empty, but in reality, that’s not the case.

The backend (`kdf`) could return a swap object with `"my_info": null`:
```json
{
        "type": "Maker",
        "uuid": "b08947c8-8a23-40df-aae2-2e38a6cbc3a0",
        "my_order_uuid": "fc4b3b3d-d19e-4f0a-a234-aa69a3922021",
        "events": [
          {
            "timestamp": 1750323085783,
            "event": {
              "type": "StartFailed",
              "data": {
                "error": "maker_swap:522] !check_balance_for_maker_swap check_balance:75] Not enough MCL for swap: available 829.00733485, required at least 829.00734485, locked by swaps Some(BigDecimal(\"1700.00001\"))"
              }
            }
          },
          {
            "timestamp": 1750323085785,
            "event": {
              "type": "Finished"
            }
          }
        ],
        "maker_amount": "829.00733485",
        "maker_coin": "MCL",
        "maker_coin_usd_price": null,
        "taker_amount": "67.9786014577",
        "taker_coin": "KMD",
        "taker_coin_usd_price": null,
        "gui": "komodo-defi-flutter-auth",
        "mm_version": "2.4.0-beta_c800ea03f",
        "success_events": [
          "Started",
          "Negotiated",
          "MakerPaymentInstructionsReceived",
          "TakerFeeValidated",
          "MakerPaymentSent",
          "TakerPaymentReceived",
          "TakerPaymentWaitConfirmStarted",
          "TakerPaymentValidatedAndConfirmed",
          "TakerPaymentSpent",
          "TakerPaymentSpendConfirmStarted",
          "TakerPaymentSpendConfirmed",
          "Finished"
        ],
        "error_events": [
          "StartFailed",
          "NegotiateFailed",
          "TakerFeeValidateFailed",
          "MakerPaymentTransactionFailed",
          "MakerPaymentDataSendFailed",
          "MakerPaymentWaitConfirmFailed",
          "TakerPaymentValidateFailed",
          "TakerPaymentWaitConfirmFailed",
          "TakerPaymentSpendFailed",
          "TakerPaymentSpendConfirmFailed",
          "MakerPaymentWaitRefundStarted",
          "MakerPaymentRefundStarted",
          "MakerPaymentRefunded",
          "MakerPaymentRefundFailed",
          "MakerPaymentRefundFinished"
        ],
        "my_info": null,
        "recoverable": false,
        "is_finished": true,
        "is_success": false
      },
```
Our deserialization flow called

```dart
SwapMyInfo.fromJson(json['my_info'])
```

without a null-check, so `json` inside `SwapMyInfo.fromJson` became `null`.
This triggered a type cast exception at runtime:

```
type 'Null' is not a subtype of type 'Map<String, dynamic>'
```

and the whole `getMyRecentSwaps()` call aborted.

### \:white\_check\_mark: Solution

Introduce an **empty, constant constructor** for `SwapMyInfo` that represents the “missing” state and update the factory to use it:

```dart
/// New sentinel-object constructor
const SwapMyInfo.empty()
    : myCoin = '',
      otherCoin = '',
      myAmount = 0,
      otherAmount = 0,
      startedAt = 0;

/// Updated factory with null-guard
factory SwapMyInfo.fromJson(Map<String, dynamic>? json) {
  if (json == null) return const SwapMyInfo.empty();
  return SwapMyInfo(
    myCoin: json['my_coin'],
    // ...
  );
}
```

`Swap.fromJson` remains unchanged; it can safely call `SwapMyInfo.fromJson` without extra checks, and will now receive a non-null `SwapMyInfo` instance every time.

### \:memo: Additional notes

* Keeps existing `Swap` API intact (no new nullable field).
* Introduces a single, explicit place to handle the absent-data case.

No other files or tests were affected.
