### PR TITLE
disable Firebase Analytics on Linux and explicitly handle Unsupported…

### DIFF
--- a/lib/bloc/analytics/analytics_repo.dart
+++ b/lib/bloc/analytics/analytics_repo.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:async';
-import 'dart:io';
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, kIsWeb, TargetPlatform;
 
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -115,7 +116,7 @@ class FirebaseAnalyticsRepo implements AnalyticsRepo {
   /// Initialize with retry mechanism
   Future<void> _initializeWithRetry(AnalyticsSettings settings) async {
     // Firebase is not supported on Linux
-    if (Platform.isLinux) {
+    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.linux) {
       _isInitialized = false;
       _isEnabled = false;
       _initCompleter.completeError(UnsupportedError);

--- a/lib/bloc/analytics/analytics_repo.dart
+++ b/lib/bloc/analytics/analytics_repo.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:async';
+import 'dart:io';
 
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -113,6 +114,14 @@ class FirebaseAnalyticsRepo implements AnalyticsRepo {
 
   /// Initialize with retry mechanism
   Future<void> _initializeWithRetry(AnalyticsSettings settings) async {
+    // Firebase is not supported on Linux
+    if (Platform.isLinux) {
+      _isInitialized = false;
+      _isEnabled = false;
+      _initCompleter.completeError(UnsupportedError);
+      return;
+    }
+
     try {
       if (kDebugMode) {
         log(
@@ -131,9 +140,19 @@ class FirebaseAnalyticsRepo implements AnalyticsRepo {
       await loadPersistedQueue();
 
       // Initialize Firebase
-      await Firebase.initializeApp(
-        options: DefaultFirebaseOptions.currentPlatform,
-      );
+      try {
+        await Firebase.initializeApp(
+          options: DefaultFirebaseOptions.currentPlatform,
+        );
+      } on UnsupportedError {
+        _isInitialized = false;
+        _isEnabled = false;
+        if (kDebugMode) {
+          log('Firebase Analytics initializeApp failed with UnsupportedError');
+        }
+        _initCompleter.completeError(UnsupportedError);
+        return;
+      }
       _instance = FirebaseAnalytics.instance;
 
       _isInitialized = true;


### PR DESCRIPTION
…Error in init

* Add a `Platform.isLinux` guard to immediately disable analytics on unsupported platforms
* Wrap `Firebase.initializeApp` in its own `try/catch` to catch `UnsupportedError` and short-circuit initialization
* Complete the `_initCompleter` with an error on unsupported platforms to unblock awaiting callers
* Preserve existing retry logic for other initialization failures without retrying when unsupported
* Log debug messages when initialization is skipped or fails due to lack of Linux support