### PR TITLE
fix(feedback): validate message not empty

### DIFF
--- a/lib/shared/constants.dart
+++ b/lib/shared/constants.dart
@@ -1,6 +1,7 @@
 RegExp numberRegExp = RegExp('^\$|^(0|([1-9][0-9]{0,12}))([.,]{1}[0-9]{0,8})?');
 RegExp emailRegex = RegExp(
-    r'^[a-zA-Z0-9.!#$%&*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$');
+  r'^[a-zA-Z0-9.!#$%&*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$',
+);
 const int decimalRange = 8;
 
 // stored app preferences
@@ -33,13 +34,16 @@ const String txByHashUrl = '$ercTxHistoryUrl/v1/transactions_by_hash';
 
 const String updateCheckerEndpoint = 'https://komodo.earth/adexwebversion';
 final Uri feedbackUrl = Uri.parse('https://komodo.earth:8181/webform/');
+const int feedbackMaxLength = 1000;
 final Uri pricesUrlV3 = Uri.parse(
   'https://defi-stats.komodo.earth/api/v3/prices/tickers_v2?expire_at=60',
 );
 
 const int millisecondsIn24H = 86400000;
 
-const bool isTestMode =
-    bool.fromEnvironment('testing_mode', defaultValue: false);
+const bool isTestMode = bool.fromEnvironment(
+  'testing_mode',
+  defaultValue: false,
+);
 const String moralisProxyUrl = 'https://moralis-proxy.komodo.earth';
 const String nftAntiSpamUrl = 'https://nft.antispam.dragonhound.info';


### PR DESCRIPTION
## Summary
- add `feedbackMaxLength` constant
- validate feedback text isn't empty or too long
- show feedback validation errors in the UI

## Testing
- `dart format lib/shared/constants.dart lib/services/feedback/custom_feedback_form.dart`
- `flutter analyze` *(fails: requires Flutter SDK >=3.32.2)*

------
https://chatgpt.com/codex/tasks/task_e_685bf299429083268464bf4e13020cb7