### PR TITLE
fix: import analytics scroll event

### DIFF
--- a/lib/views/wallet/wallet_page/wallet_main/wallet_main.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/wallet_main.dart
@@ -32,6 +32,7 @@ import 'package:web_dex/views/common/pages/page_layout.dart';
 import 'package:web_dex/views/dex/dex_helpers.dart';
 import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
 import 'package:web_dex/analytics/events.dart';
+import 'package:web_dex/analytics/events/misc_events.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_details_info/charts/portfolio_growth_chart.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_details_info/charts/portfolio_profit_loss_chart.dart';
 import 'package:web_dex/views/wallet/wallet_page/charts/coin_prices_chart.dart';


### PR DESCRIPTION
## Summary
- ensure ScrollAttemptOutsideContentEventData is imported in wallet_main

## Testing
- `flutter pub get --offline` *(fails: version solving failed)*
- `flutter analyze` *(fails: requires Flutter SDK >=3.32.2)*

------
https://chatgpt.com/codex/tasks/task_e_685c16441cfc832690342dcda00605a6