### PR TITLE
Implement streamed auth and trezor mixin

### DIFF
--- a/lib/bloc/auth_bloc/auth_bloc_event.dart
+++ b/lib/bloc/auth_bloc/auth_bloc_event.dart
@@ -53,3 +53,34 @@ class AuthWalletDownloadRequested extends AuthBlocEvent {
   const AuthWalletDownloadRequested({required this.password});
   final String password;
 }
+
+class AuthTrezorInitAndAuthStarted extends AuthBlocEvent {
+  const AuthTrezorInitAndAuthStarted({
+    required this.isRegister,
+    required this.derivationMethod,
+  });
+
+  final bool isRegister;
+  final DerivationMethod derivationMethod;
+}
+
+class AuthTrezorPinProvided extends AuthBlocEvent {
+  const AuthTrezorPinProvided({required this.taskId, required this.pin});
+
+  final int taskId;
+  final String pin;
+}
+
+class AuthTrezorPassphraseProvided extends AuthBlocEvent {
+  const AuthTrezorPassphraseProvided({
+    required this.taskId,
+    required this.passphrase,
+  });
+
+  final int taskId;
+  final String passphrase;
+}
+
+class AuthTrezorCancelled extends AuthBlocEvent {
+  const AuthTrezorCancelled();
+}

--- a/lib/bloc/auth_bloc/auth_bloc_state.dart
+++ b/lib/bloc/auth_bloc/auth_bloc_state.dart
@@ -1,6 +1,16 @@
 part of 'auth_bloc.dart';
 
-enum AuthStatus { initial, loading, success, failure }
+enum AuthStatus {
+  initial,
+  loading,
+  success,
+  failure,
+  trezorInitializing,
+  trezorAwaitingConfirmation,
+  trezorPinRequired,
+  trezorPassphraseRequired,
+  trezorReady,
+}
 
 class AuthBlocState extends Equatable {
   const AuthBlocState({
@@ -8,6 +18,8 @@ class AuthBlocState extends Equatable {
     this.currentUser,
     this.status = AuthStatus.initial,
     this.authError,
+    this.message,
+    this.taskId,
   });
 
   factory AuthBlocState.initial() =>
@@ -26,16 +38,54 @@ class AuthBlocState extends Equatable {
         status: AuthStatus.success,
         currentUser: user,
       );
+  factory AuthBlocState.trezorInitializing({String? message, int? taskId}) =>
+      AuthBlocState(
+        mode: AuthorizeMode.noLogin,
+        status: AuthStatus.trezorInitializing,
+        message: message,
+        taskId: taskId,
+      );
+  factory AuthBlocState.trezorAwaitingConfirmation(
+          {String? message, int? taskId}) =>
+      AuthBlocState(
+        mode: AuthorizeMode.noLogin,
+        status: AuthStatus.trezorAwaitingConfirmation,
+        message: message,
+        taskId: taskId,
+      );
+  factory AuthBlocState.trezorPinRequired(
+          {String? message, required int taskId}) =>
+      AuthBlocState(
+        mode: AuthorizeMode.noLogin,
+        status: AuthStatus.trezorPinRequired,
+        message: message,
+        taskId: taskId,
+      );
+  factory AuthBlocState.trezorPassphraseRequired(
+          {String? message, required int taskId}) =>
+      AuthBlocState(
+        mode: AuthorizeMode.noLogin,
+        status: AuthStatus.trezorPassphraseRequired,
+        message: message,
+        taskId: taskId,
+      );
+  factory AuthBlocState.trezorReady() => const AuthBlocState(
+        mode: AuthorizeMode.noLogin,
+        status: AuthStatus.trezorReady,
+      );
 
   final KdfUser? currentUser;
   final AuthorizeMode mode;
   final AuthStatus status;
   final AuthException? authError;
+  final String? message;
+  final int? taskId;
 
   bool get isSignedIn => currentUser != null;
   bool get isLoading => status == AuthStatus.loading;
   bool get isError => status == AuthStatus.failure;
 
   @override
-  List<Object?> get props => [mode, currentUser, status, authError];
+  List<Object?> get props =>
+      [mode, currentUser, status, authError, message, taskId];
 }

--- a/lib/bloc/auth_bloc/trezor_auth_mixin.dart
+++ b/lib/bloc/auth_bloc/trezor_auth_mixin.dart
@@ -1,0 +1,141 @@
+part of 'auth_bloc.dart';
+
+/// Mixin that exposes Trezor authentication helpers for [AuthBloc].
+mixin TrezorAuthMixin on Bloc<AuthBlocEvent, AuthBlocState> {
+  KomodoDefiSdk get _sdk;
+
+  /// Registers handlers for Trezor specific events.
+  void setupTrezorEventHandlers() {
+    on<AuthTrezorInitAndAuthStarted>(_onTrezorInitAndAuth);
+    on<AuthTrezorPinProvided>(_onTrezorProvidePin);
+    on<AuthTrezorPassphraseProvided>(_onTrezorProvidePassphrase);
+    on<AuthTrezorCancelled>(_onTrezorCancel);
+  }
+
+  Future<void> _onTrezorInitAndAuth(
+    AuthTrezorInitAndAuthStarted event,
+    Emitter<AuthBlocState> emit,
+  ) async {
+    try {
+      final authOptions = AuthOptions(
+        derivationMethod: event.derivationMethod,
+        privKeyPolicy: const PrivateKeyPolicy.trezor(),
+      );
+
+      final Stream<AuthenticationState> authStream = event.isRegister
+          ? _sdk.auth.registerStream(
+              walletName: 'My Trezor',
+              password: '',
+              options: authOptions,
+            )
+          : _sdk.auth.signInStream(
+              walletName: 'My Trezor',
+              password: '',
+              options: authOptions,
+            );
+
+      await for (final authState in authStream) {
+        final mappedState = _handleAuthenticationState(authState);
+        emit(mappedState);
+        if (authState.status == AuthenticationStatus.completed ||
+            authState.status == AuthenticationStatus.error ||
+            authState.status == AuthenticationStatus.cancelled) {
+          break;
+        }
+      }
+    } catch (e) {
+      emit(
+        AuthBlocState.error(
+          AuthException(
+            e.toString(),
+            type: AuthExceptionType.generalAuthError,
+          ),
+        ),
+      );
+    }
+  }
+
+  AuthBlocState _handleAuthenticationState(AuthenticationState authState) {
+    switch (authState.status) {
+      case AuthenticationStatus.initializing:
+        return AuthBlocState.trezorInitializing(
+          message: authState.message ?? 'Initializing Trezor device...',
+          taskId: authState.taskId,
+        );
+      case AuthenticationStatus.waitingForDevice:
+        return AuthBlocState.trezorInitializing(
+          message:
+              authState.message ?? 'Waiting for Trezor device connection...',
+          taskId: authState.taskId,
+        );
+      case AuthenticationStatus.waitingForDeviceConfirmation:
+        return AuthBlocState.trezorAwaitingConfirmation(
+          message: authState.message ??
+              'Please follow instructions on your Trezor device',
+          taskId: authState.taskId,
+        );
+      case AuthenticationStatus.pinRequired:
+        return AuthBlocState.trezorPinRequired(
+          message: authState.message ?? 'Please enter your Trezor PIN',
+          taskId: authState.taskId!,
+        );
+      case AuthenticationStatus.passphraseRequired:
+        return AuthBlocState.trezorPassphraseRequired(
+          message: authState.message ?? 'Please enter your Trezor passphrase',
+          taskId: authState.taskId!,
+        );
+      case AuthenticationStatus.authenticating:
+        return AuthBlocState.loading();
+      case AuthenticationStatus.completed:
+        if (authState.user != null) {
+          return AuthBlocState.loggedIn(authState.user!);
+        } else {
+          return AuthBlocState.trezorReady();
+        }
+      case AuthenticationStatus.error:
+        return AuthBlocState.error(
+          AuthException('Trezor authentication failed: ${authState.message}',
+              type: AuthExceptionType.generalAuthError),
+        );
+      case AuthenticationStatus.cancelled:
+        return AuthBlocState.error(
+          AuthException('Trezor authentication was cancelled',
+              type: AuthExceptionType.generalAuthError),
+        );
+    }
+  }
+
+  Future<void> _onTrezorProvidePin(
+    AuthTrezorPinProvided event,
+    Emitter<AuthBlocState> emit,
+  ) async {
+    try {
+      await _sdk.auth.setHardwareDevicePin(event.taskId, event.pin);
+    } catch (_) {
+      emit(AuthBlocState.error(AuthException('Failed to provide PIN',
+          type: AuthExceptionType.generalAuthError)));
+    }
+  }
+
+  Future<void> _onTrezorProvidePassphrase(
+    AuthTrezorPassphraseProvided event,
+    Emitter<AuthBlocState> emit,
+  ) async {
+    try {
+      await _sdk.auth.setHardwareDevicePassphrase(
+        event.taskId,
+        event.passphrase,
+      );
+    } catch (_) {
+      emit(AuthBlocState.error(AuthException('Failed to provide passphrase',
+          type: AuthExceptionType.generalAuthError)));
+    }
+  }
+
+  Future<void> _onTrezorCancel(
+    AuthTrezorCancelled event,
+    Emitter<AuthBlocState> emit,
+  ) async {
+    emit(AuthBlocState.initial());
+  }
+}

--- a/lib/bloc/trezor_init_bloc/trezor_init_bloc.dart
+++ b/lib/bloc/trezor_init_bloc/trezor_init_bloc.dart
@@ -285,7 +285,7 @@ class TrezorInitBloc extends Bloc<TrezorInitEvent, TrezorInitState> {
     String? password,
     AuthOptions authOptions = const AuthOptions(
       derivationMethod: DerivationMethod.hdWallet,
-      privKeyPolicy: PrivateKeyPolicy.trezor,
+      privKeyPolicy: PrivateKeyPolicy.trezor(),
     ),
   }) async {
     try {

--- a/lib/views/common/hw_wallet_dialog/show_trezor_passphrase_dialog.dart
+++ b/lib/views/common/hw_wallet_dialog/show_trezor_passphrase_dialog.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:web_dex/bloc/trezor_bloc/trezor_repo.dart';
+import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
 import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/dispatchers/popup_dispatcher.dart';
 import 'package:web_dex/model/hw_wallet/trezor_task.dart';
@@ -25,9 +25,13 @@ Future<void> showTrezorPassphraseDialog(TrezorTask task) async {
     onDismiss: close,
     popupContent: TrezorDialogSelectWallet(
       onComplete: (String passphrase) async {
-        final trezorRepo = RepositoryProvider.of<TrezorRepo>(context);
-        await trezorRepo.sendPassphrase(passphrase, task);
-        // todo(yurii): handle invalid pin
+        final authBloc = context.read<AuthBloc>();
+        authBloc.add(
+          AuthTrezorPassphraseProvided(
+            taskId: task.taskId,
+            passphrase: passphrase,
+          ),
+        );
         close();
       },
     ),

--- a/lib/views/common/hw_wallet_dialog/show_trezor_pin_dialog.dart
+++ b/lib/views/common/hw_wallet_dialog/show_trezor_pin_dialog.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:web_dex/bloc/trezor_bloc/trezor_repo.dart';
+import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
 import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/dispatchers/popup_dispatcher.dart';
 import 'package:web_dex/model/hw_wallet/trezor_task.dart';
@@ -24,9 +24,10 @@ Future<void> showTrezorPinDialog(TrezorTask task) async {
     onDismiss: close,
     popupContent: TrezorDialogPinPad(
       onComplete: (String pin) async {
-        final trezorRepo = RepositoryProvider.of<TrezorRepo>(context);
-        await trezorRepo.sendPin(pin, task);
-        // todo(yurii): handle invalid pin
+        final authBloc = context.read<AuthBloc>();
+        authBloc.add(
+          AuthTrezorPinProvided(taskId: task.taskId, pin: pin),
+        );
         close();
       },
       onClose: close,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -648,7 +648,7 @@ packages:
     description:
       path: "packages/komodo_cex_market_data"
       ref: dev
-      resolved-ref: "3e9f73c1ee5df4d2e6154d554e9dc7356d64d4f8"
+      resolved-ref: "24d09fd3703b1f299f8c92a89329269a1d1d92fe"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.0.1"
@@ -657,7 +657,7 @@ packages:
     description:
       path: "packages/komodo_coin_updates"
       ref: dev
-      resolved-ref: "3e9f73c1ee5df4d2e6154d554e9dc7356d64d4f8"
+      resolved-ref: "24d09fd3703b1f299f8c92a89329269a1d1d92fe"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "1.0.0"
@@ -666,7 +666,7 @@ packages:
     description:
       path: "packages/komodo_coins"
       ref: dev
-      resolved-ref: "3e9f73c1ee5df4d2e6154d554e9dc7356d64d4f8"
+      resolved-ref: "24d09fd3703b1f299f8c92a89329269a1d1d92fe"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -675,7 +675,7 @@ packages:
     description:
       path: "packages/komodo_defi_framework"
       ref: dev
-      resolved-ref: "3e9f73c1ee5df4d2e6154d554e9dc7356d64d4f8"
+      resolved-ref: "24d09fd3703b1f299f8c92a89329269a1d1d92fe"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0"
@@ -684,7 +684,7 @@ packages:
     description:
       path: "packages/komodo_defi_local_auth"
       ref: dev
-      resolved-ref: "3e9f73c1ee5df4d2e6154d554e9dc7356d64d4f8"
+      resolved-ref: "24d09fd3703b1f299f8c92a89329269a1d1d92fe"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -693,7 +693,7 @@ packages:
     description:
       path: "packages/komodo_defi_rpc_methods"
       ref: dev
-      resolved-ref: "3e9f73c1ee5df4d2e6154d554e9dc7356d64d4f8"
+      resolved-ref: "24d09fd3703b1f299f8c92a89329269a1d1d92fe"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -702,7 +702,7 @@ packages:
     description:
       path: "packages/komodo_defi_sdk"
       ref: dev
-      resolved-ref: "3e9f73c1ee5df4d2e6154d554e9dc7356d64d4f8"
+      resolved-ref: "24d09fd3703b1f299f8c92a89329269a1d1d92fe"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -711,7 +711,7 @@ packages:
     description:
       path: "packages/komodo_defi_types"
       ref: dev
-      resolved-ref: "3e9f73c1ee5df4d2e6154d554e9dc7356d64d4f8"
+      resolved-ref: "24d09fd3703b1f299f8c92a89329269a1d1d92fe"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -727,7 +727,7 @@ packages:
     description:
       path: "packages/komodo_ui"
       ref: dev
-      resolved-ref: "3e9f73c1ee5df4d2e6154d554e9dc7356d64d4f8"
+      resolved-ref: "24d09fd3703b1f299f8c92a89329269a1d1d92fe"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"
@@ -743,7 +743,7 @@ packages:
     description:
       path: "packages/komodo_wallet_build_transformer"
       ref: dev
-      resolved-ref: "3e9f73c1ee5df4d2e6154d554e9dc7356d64d4f8"
+      resolved-ref: "24d09fd3703b1f299f8c92a89329269a1d1d92fe"
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.2.0+0"


### PR DESCRIPTION
## Summary
- migrate auth bloc to streamed sign-in/register
- add TrezorAuthMixin with streamed hardware authentication
- hook up pin/passphrase dialogs to auth bloc
- update sdk lockfile hash

## Testing
- `dart format lib/bloc/auth_bloc/auth_bloc.dart lib/bloc/auth_bloc/auth_bloc_state.dart lib/bloc/auth_bloc/trezor_auth_mixin.dart lib/bloc/auth_bloc/auth_bloc_event.dart lib/views/common/hw_wallet_dialog/show_trezor_passphrase_dialog.dart lib/views/common/hw_wallet_dialog/show_trezor_pin_dialog.dart`
- `flutter analyze lib/bloc/auth_bloc/auth_bloc.dart lib/bloc/auth_bloc/auth_bloc_event.dart lib/bloc/auth_bloc/auth_bloc_state.dart lib/bloc/auth_bloc/trezor_auth_mixin.dart lib/views/common/hw_wallet_dialog/show_trezor_passphrase_dialog.dart lib/views/common/hw_wallet_dialog/show_trezor_pin_dialog.dart lib/bloc/trezor_init_bloc/trezor_init_bloc.dart`
- `flutter build web` *(failed: Proxy failed to establish tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_685c46eaf0d48331873619bb03776c76