### PR TITLE
use segwit variant for default trezor coins

### DIFF
--- a/lib/app_config/app_config.dart
+++ b/lib/app_config/app_config.dart
@@ -151,9 +151,9 @@ List<String> get enabledByDefaultCoins => [
     ];
 
 List<String> get enabledByDefaultTrezorCoins => [
-      'BTC',
+      'BTC-segwit',
       'KMD',
-      'LTC',
+      'LTC-segwit',
     ];
 
 List<String> get coinsWithFaucet => ['RICK', 'MORTY', 'DOC', 'MARTY'];


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/komodo-wallet/issues/2830


To test:
- Login with Trezor
- See LTC-segwit and BTC-segwit enabled by default. 