### PR TITLE
refactor(bloc): use balance spendable

### DIFF
--- a/lib/bloc/bridge_form/bridge_bloc.dart
+++ b/lib/bloc/bridge_form/bridge_bloc.dart
@@ -404,8 +404,8 @@ class BridgeBloc extends Bloc<BridgeEvent, BridgeState> {
         availableBalanceState: () => AvailableBalanceState.unavailable,
       ));
     } else {
-      Rational? maxSellAmount =
-          await _dexRepository.getMaxTakerVolume(state.sellCoin!.abbr);
+      final balanceInfo = await _coinsRepository.balance(state.sellCoin!.id);
+      Rational? maxSellAmount = balanceInfo?.spendable.toRational();
       if (maxSellAmount != null) {
         emit(state.copyWith(
           maxSellAmount: () => maxSellAmount,
@@ -599,8 +599,8 @@ class BridgeBloc extends Bloc<BridgeEvent, BridgeState> {
     int attempts = 5;
     Rational? maxSellAmount;
     while (attempts > 0) {
-      maxSellAmount =
-          await _dexRepository.getMaxTakerVolume(state.sellCoin!.abbr);
+      final balanceInfo = await _coinsRepository.balance(state.sellCoin!.id);
+      maxSellAmount = balanceInfo?.spendable.toRational();
       if (maxSellAmount != null) {
         return maxSellAmount;
       }

--- a/lib/bloc/taker_form/taker_bloc.dart
+++ b/lib/bloc/taker_form/taker_bloc.dart
@@ -401,8 +401,8 @@ class TakerBloc extends Bloc<TakerEvent, TakerState> {
       emitter(state.copyWith(
           availableBalanceState: () => AvailableBalanceState.unavailable));
     } else {
-      Rational? maxSellAmount =
-          await _dexRepo.getMaxTakerVolume(state.sellCoin!.abbr);
+      final balanceInfo = await _coinsRepo.balance(state.sellCoin!.id);
+      Rational? maxSellAmount = balanceInfo?.spendable.toRational();
       if (maxSellAmount != null) {
         emitter(state.copyWith(
           maxSellAmount: () => maxSellAmount,
@@ -424,7 +424,8 @@ class TakerBloc extends Bloc<TakerEvent, TakerState> {
     int attempts = 5;
     Rational? maxSellAmount;
     while (attempts > 0) {
-      maxSellAmount = await _dexRepo.getMaxTakerVolume(state.sellCoin!.abbr);
+      final balanceInfo = await _coinsRepo.balance(state.sellCoin!.id);
+      maxSellAmount = balanceInfo?.spendable.toRational();
       if (maxSellAmount != null) {
         return maxSellAmount;
       }


### PR DESCRIPTION
## Summary
- use coins repo `BalanceInfo` spendable when updating max sell amount
- remove reliance on `max_taker_volume`

## Testing
- `flutter analyze --no-pub` *(fails: Target of URI doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_685d757668fc8326908cb2473a8aab60