### PR TITLE
chore: update Flutter version to 3.32.5

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/ubuntu:22.04
 
-ENV FLUTTER_VERSION="3.32.2"
+ENV FLUTTER_VERSION="3.32.5"
 ENV USER="komodo"
 ENV USER_ID=1000
 ENV PATH=$PATH:/opt/flutter/bin

--- a/.docker/komodo-wallet-android.dockerfile
+++ b/.docker/komodo-wallet-android.dockerfile
@@ -1,6 +1,6 @@
 FROM komodo/android-sdk:35 AS final
 
-ENV FLUTTER_VERSION="3.32.2"
+ENV FLUTTER_VERSION="3.32.5"
 ENV HOME="/home/komodo"
 ENV USER="komodo"
 ENV PATH=$PATH:$HOME/flutter/bin

--- a/.github/actions/flutter-deps/action.yml
+++ b/.github/actions/flutter-deps/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: subosito/flutter-action@v2
       with:
         # NB! Keep up-to-date with the flutter version used for development
-        flutter-version: "3.32.2"
+        flutter-version: "3.32.5"
         channel: "stable"
 
     - name: Prepare build directory

--- a/.github/workflows/mobile-builds.yml
+++ b/.github/workflows/mobile-builds.yml
@@ -69,7 +69,7 @@ jobs:
           FEEDBACK_TEST_URL: ${{ secrets.FEEDBACK_TEST_URL }}
 
       # Flutter build with `--no-pub` flag fails on Android due to a
-      # known regression with the build system in 3.32.2.
+      # known regression with the build system in 3.32.5.
       # https://github.com/flutter/flutter/issues/169336
       - name: Temporary workaround for Android build issue
         if: ${{ matrix.platform == 'Android' }}

--- a/.github/workflows/roll-sdk-packages.yml
+++ b/.github/workflows/roll-sdk-packages.yml
@@ -45,7 +45,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           # NB! Keep up-to-date with the flutter version used for development
-          flutter-version: "3.32.2"
+          flutter-version: "3.32.5"
           channel: "stable"
 
       - name: Determine configuration

--- a/app_theme/pubspec.lock
+++ b/app_theme/pubspec.lock
@@ -61,4 +61,4 @@ packages:
     version: "2.1.4"
 sdks:
   dart: ">=3.7.0-0 <4.0.0"
-  flutter: ">=3.32.2"
+  flutter: ">=3.32.5"

--- a/app_theme/pubspec.yaml
+++ b/app_theme/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
-  flutter: ^3.32.2
+  flutter: ^3.32.5
 
 dependencies:
   flutter:

--- a/docs/FLUTTER_VERSION.md
+++ b/docs/FLUTTER_VERSION.md
@@ -2,7 +2,7 @@
 
 ## Supported Flutter Version
 
-This project supports Flutter `3.32.2` (latest stable release). We aim to keep the project up-to-date with the most recent stable Flutter versions.
+This project supports Flutter `3.32.5` (latest stable release). We aim to keep the project up-to-date with the most recent stable Flutter versions.
 
 ## Recommended Approach: Multiple Flutter Versions
 
@@ -15,14 +15,14 @@ See our guide on [Multiple Flutter Versions](MULTIPLE_FLUTTER_VERSIONS.md) for d
 While it's possible to pin your global Flutter installation to a specific version, **this approach is not recommended** due to:
 
 - Lack of isolation between projects
-- Known issues with `flutter pub get` when using Flutter 3.32.2
+- Known issues with `flutter pub get` when using Flutter 3.32.5
 - Difficulty switching between versions for different projects
 
 If you still choose to use this method, you can run:
 
 ```bash
 cd ~/flutter
-git checkout 3.32.2
+git checkout 3.32.5
 flutter doctor
 ```
 

--- a/docs/MULTIPLE_FLUTTER_VERSIONS.md
+++ b/docs/MULTIPLE_FLUTTER_VERSIONS.md
@@ -57,7 +57,7 @@ sudo pacman -R flutter   # for Arch
 
 2. Launch Flutter Sidekick
 
-3. Click on "Versions" in the sidebar and download Flutter version `3.32.2`
+3. Click on "Versions" in the sidebar and download Flutter version `3.32.5`
 
 4. Set this version as the global default by clicking the "Set as Global" button
 
@@ -91,11 +91,11 @@ sudo pacman -R flutter   # for Arch
    curl -fsSL https://fvm.app/install.sh | bash
    ```
 
-2. Install and use Flutter 3.32.2:
+2. Install and use Flutter 3.32.5:
 
    ```bash
-   fvm install 3.32.2
-   fvm global 3.32.2
+   fvm install 3.32.5
+   fvm global 3.32.5
    ```
 
 3. Add FVM's default Flutter version to your PATH by adding the following to your `~/.bashrc`, `~/.zshrc`, or equivalent:
@@ -130,11 +130,11 @@ sudo pacman -R flutter   # for Arch
    choco install fvm
    ```
 
-3. Install and use Flutter 3.32.2:
+3. Install and use Flutter 3.32.5:
 
    ```powershell
-   fvm install 3.32.2
-   fvm global 3.32.2
+   fvm install 3.32.5
+   fvm global 3.32.5
    ```
 
 4. Add FVM's Flutter version to your PATH:
@@ -156,7 +156,7 @@ To use a specific Flutter version for a project:
 2. Run:
 
    ```bash
-   fvm use 3.32.2
+   fvm use 3.32.5
    ```
 
 This will create a `.fvmrc` file in your project, which specifies the Flutter version to use for this project.

--- a/packages/komodo_ui_kit/pubspec.lock
+++ b/packages/komodo_ui_kit/pubspec.lock
@@ -196,4 +196,4 @@ packages:
     version: "1.1.1"
 sdks:
   dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.32.2"
+  flutter: ">=3.32.5"

--- a/packages/komodo_ui_kit/pubspec.yaml
+++ b/packages/komodo_ui_kit/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
-  flutter: ^3.32.2
+  flutter: ^3.32.5
 
 dependencies:
   flutter:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1571,4 +1571,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.2"
+  flutter: ">=3.32.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ environment:
   # the new formatting style may cause conflicts. This allows to run 3.7.0, but it will not
   # enforce the new formatting style until the mininum Dart version is updated.
   sdk: ">=3.6.0 <4.0.0"
-  flutter: ^3.32.2
+  flutter: ^3.32.5
 
 dependencies:
   ## ---- Flutter SDK


### PR DESCRIPTION
## Summary
- upgrade Flutter version references to 3.32.5
- update Dockerfiles and CI workflows
- document the new version in FLUTTER_VERSION.md
- bump version constraints in pubspec files

## Testing
- `dart format` *(fails: Could not parse non-Dart files)*
- `flutter analyze` *(fails: requires Flutter 3.32.5)*
- `flutter pub get --offline --enforce-lockfile` *(fails: requires Flutter 3.32.5)*

------
https://chatgpt.com/codex/tasks/task_e_685ebc79b16083268182998eb296e784