### PR TITLE
feat(localization): rename chart key

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -679,7 +679,7 @@
     "previewWithdrawal": "Preview Withdrawal",
     "createNewAddress": "Create New Address",
     "searchAddresses": "Search addresses",
-    "chart": "Chart",
+    "trend7d": "7d trend",
     "tradingDisabledTooltip": "Trading features are currently disabled",
     "tradingDisabled": "Trading is currently unavailable"
 }

--- a/lib/generated/codegen_loader.g.dart
+++ b/lib/generated/codegen_loader.g.dart
@@ -676,7 +676,7 @@ abstract class  LocaleKeys {
   static const previewWithdrawal = 'previewWithdrawal';
   static const createNewAddress = 'createNewAddress';
   static const searchAddresses = 'searchAddresses';
-  static const chart = 'chart';
+  static const trend7d = 'trend7d';
   static const tradingDisabledTooltip = 'tradingDisabledTooltip';
   static const tradingDisabled = 'tradingDisabled';
 

--- a/lib/views/wallet/wallet_page/common/coins_list_header.dart
+++ b/lib/views/wallet/wallet_page/common/coins_list_header.dart
@@ -86,8 +86,8 @@ class _CoinsListHeaderDesktop extends StatelessWidget {
             // 24h change header
             Expanded(flex: 2, child: Text(LocaleKeys.change24hRevert.tr())),
 
-            // Chart header
-            Expanded(flex: 2, child: Text(LocaleKeys.chart.tr())),
+            // 7d trend header
+            Expanded(flex: 2, child: Text(LocaleKeys.trend7d.tr())),
 
             // Space for expand button
             Container(constraints: const BoxConstraints(minWidth: 48)),


### PR DESCRIPTION
## Summary
- rename the `chart` locale entry to `trend7d`
- update generated locale keys
- update coins list header to show the new label

## Testing
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_686501e013f4832688a9c94145138b90