### PR TITLE
feat(auth): restore auth state after sdk init

### DIFF
--- a/lib/bloc/app_bloc_root.dart
+++ b/lib/bloc/app_bloc_root.dart
@@ -346,6 +346,9 @@ class _MyAppViewState extends State<_MyAppView> {
 
     unawaited(_hideAppLoader());
 
+    // Attempt to restore previously authenticated session
+    context.read<AuthBloc>().add(const AuthStateRestoreRequested());
+
     if (kDebugMode) {
       final walletsRepo = RepositoryProvider.of<WalletsRepository>(context);
       final authBloc = context.read<AuthBloc>();

--- a/lib/bloc/auth_bloc/auth_bloc.dart
+++ b/lib/bloc/auth_bloc/auth_bloc.dart
@@ -30,6 +30,7 @@ class AuthBloc extends Bloc<AuthBlocEvent, AuthBlocState> {
     on<AuthRestoreRequested>(_onRestore);
     on<AuthSeedBackupConfirmed>(_onSeedBackupConfirmed);
     on<AuthWalletDownloadRequested>(_onWalletDownloadRequested);
+    on<AuthStateRestoreRequested>(_onStateRestoreRequested);
   }
 
   final KomodoDefiSdk _kdfSdk;
@@ -289,6 +290,24 @@ class AuthBloc extends Bloc<AuthBlocEvent, AuthBlocState> {
       );
     } catch (e, s) {
       _log.shout('Failed to download wallet data', e, s);
+    }
+  }
+
+  Future<void> _onStateRestoreRequested(
+    AuthStateRestoreRequested event,
+    Emitter<AuthBlocState> emit,
+  ) async {
+    final bool signedIn = await _kdfSdk.auth.isSignedIn();
+    final KdfUser? user = signedIn ? await _kdfSdk.auth.currentUser : null;
+    emit(
+      AuthBlocState(
+        mode: signedIn ? AuthorizeMode.logIn : AuthorizeMode.noLogin,
+        currentUser: user,
+      ),
+    );
+
+    if (signedIn) {
+      _listenToAuthStateChanges();
     }
   }
 

--- a/lib/bloc/auth_bloc/auth_bloc_event.dart
+++ b/lib/bloc/auth_bloc/auth_bloc_event.dart
@@ -53,3 +53,10 @@ class AuthWalletDownloadRequested extends AuthBlocEvent {
   const AuthWalletDownloadRequested({required this.password});
   final String password;
 }
+
+/// Dispatched to restore authentication state after the SDK has been
+/// initialized. If a user session exists, the bloc will emit the
+/// appropriate [AuthBlocState].
+class AuthStateRestoreRequested extends AuthBlocEvent {
+  const AuthStateRestoreRequested();
+}


### PR DESCRIPTION
## Summary
- trigger a new `AuthStateRestoreRequested` event after the SDK is initialized
- handle `AuthStateRestoreRequested` in `AuthBloc` to emit the current auth state and start listening to state changes

## Testing
- `dart format lib/bloc/auth_bloc/auth_bloc_event.dart lib/bloc/auth_bloc/auth_bloc.dart lib/bloc/app_bloc_root.dart`
- `flutter analyze`
- `flutter pub get --offline`


------
https://chatgpt.com/codex/tasks/task_e_68650779aa8883268a8d598ef54ee7cd