### PR TITLE
refactor(auth): use watchCurrentUser for user stream

### DIFF
--- a/lib/bloc/auth_bloc/auth_bloc.dart
+++ b/lib/bloc/auth_bloc/auth_bloc.dart
@@ -306,7 +306,7 @@ class AuthBloc extends Bloc<AuthBlocEvent, AuthBlocState> {
 
   void _listenToAuthStateChanges() {
     _authChangesSubscription?.cancel();
-    _authChangesSubscription = _kdfSdk.auth.authStateChanges.listen((user) {
+    _authChangesSubscription = _kdfSdk.auth.watchCurrentUser().listen((user) {
       final AuthorizeMode event =
           user != null ? AuthorizeMode.logIn : AuthorizeMode.noLogin;
       add(AuthModeChanged(mode: event, currentUser: user));

--- a/lib/bloc/bridge_form/bridge_bloc.dart
+++ b/lib/bloc/bridge_form/bridge_bloc.dart
@@ -78,7 +78,8 @@ class BridgeBloc extends Bloc<BridgeEvent, BridgeState> {
       dexRepository: dexRepository,
     );
 
-    _authorizationSubscription = _kdfSdk.auth.authStateChanges.listen((event) {
+    _authorizationSubscription =
+        _kdfSdk.auth.watchCurrentUser().listen((event) {
       _isLoggedIn = event != null;
       if (!_isLoggedIn) add(const BridgeLogout());
     });

--- a/lib/bloc/dex_tab_bar/dex_tab_bar_bloc.dart
+++ b/lib/bloc/dex_tab_bar/dex_tab_bar_bloc.dart
@@ -54,7 +54,8 @@ class DexTabBarBloc extends Bloc<DexTabBarEvent, DexTabBarState> {
     ListenToOrdersRequested event,
     Emitter<DexTabBarState> emit,
   ) {
-    _authorizationSubscription = _kdfSdk.auth.authStateChanges.listen((event) {
+    _authorizationSubscription =
+        _kdfSdk.auth.watchCurrentUser().listen((event) {
       if (event != null) {
         add(const TabChanged(0));
       }

--- a/lib/bloc/nft_transactions/bloc/nft_transactions_bloc.dart
+++ b/lib/bloc/nft_transactions/bloc/nft_transactions_bloc.dart
@@ -41,7 +41,7 @@ class NftTransactionsBloc extends Bloc<NftTxnEvent, NftTxnState> {
     on<NftTxnEventFullFilterChanged>(_changeFullFilter);
     on<NftTxnEventNoLogin>(_noLogin);
 
-    _authorizationSubscription = kdfSdk.auth.authStateChanges.listen((event) {
+    _authorizationSubscription = kdfSdk.auth.watchCurrentUser().listen((event) {
       final bool prevLoginState = _isLoggedIn;
       _isLoggedIn = event != null;
 

--- a/lib/bloc/nfts/nft_main_bloc.dart
+++ b/lib/bloc/nfts/nft_main_bloc.dart
@@ -27,7 +27,7 @@ class NftMainBloc extends Bloc<NftMainEvent, NftMainState> {
     on<NftMainUpdateNftsStarted>(_onStartUpdate);
     on<NftMainUpdateNftsStopped>(_onStopUpdate);
 
-    _authorizationSubscription = _sdk.auth.authStateChanges.listen((event) {
+    _authorizationSubscription = _sdk.auth.watchCurrentUser().listen((event) {
       final isSignedIn = event != null;
       if (isSignedIn) {
         add(const NftMainChainUpdateRequested());

--- a/lib/bloc/taker_form/taker_bloc.dart
+++ b/lib/bloc/taker_form/taker_bloc.dart
@@ -69,7 +69,7 @@ class TakerBloc extends Bloc<TakerEvent, TakerState> {
     on<TakerVerifyOrderVolume>(_onVerifyOrderVolume);
     on<TakerSetWalletIsReady>(_onSetWalletReady);
 
-    _authorizationSubscription = kdfSdk.auth.authStateChanges.listen((event) {
+    _authorizationSubscription = kdfSdk.auth.watchCurrentUser().listen((event) {
       if (event != null && state.step == TakerStep.confirm) {
         add(TakerBackButtonClick());
       }

--- a/lib/bloc/trezor_connection_bloc/trezor_connection_bloc.dart
+++ b/lib/bloc/trezor_connection_bloc/trezor_connection_bloc.dart
@@ -19,7 +19,8 @@ class TrezorConnectionBloc
         super(TrezorConnectionState.initial()) {
     _trezorConnectionStatusListener = trezorRepo.connectionStatusStream
         .listen(_onTrezorConnectionStatusChanged);
-    _authModeListener = kdfSdk.auth.authStateChanges.listen(_onAuthModeChanged);
+    _authModeListener =
+        kdfSdk.auth.watchCurrentUser().listen(_onAuthModeChanged);
 
     on<TrezorConnectionStatusChange>(_onConnectionStatusChange);
   }

--- a/lib/bloc/trezor_init_bloc/trezor_init_bloc.dart
+++ b/lib/bloc/trezor_init_bloc/trezor_init_bloc.dart
@@ -48,7 +48,7 @@ class TrezorInitBloc extends Bloc<TrezorInitEvent, TrezorInitState> {
     on<TrezorInitSendPassphrase>(_onSendPassphrase);
     on<TrezorInitUpdateAuthMode>(_onAuthModeChange);
 
-    _authorizationSubscription = _kdfSdk.auth.authStateChanges.listen((user) {
+    _authorizationSubscription = _kdfSdk.auth.watchCurrentUser().listen((user) {
       add(TrezorInitUpdateAuthMode(user));
     });
   }


### PR DESCRIPTION
## Summary
- update all blocs listening for `authStateChanges` to use `watchCurrentUser`
  so that the initial user value is emitted when listening starts

## Testing
- `dart format lib/bloc/auth_bloc/auth_bloc.dart lib/bloc/nft_transactions/bloc/nft_transactions_bloc.dart lib/bloc/taker_form/taker_bloc.dart lib/bloc/trezor_init_bloc/trezor_init_bloc.dart lib/bloc/trezor_connection_bloc/trezor_connection_bloc.dart lib/bloc/bridge_form/bridge_bloc.dart lib/bloc/nfts/nft_main_bloc.dart lib/bloc/dex_tab_bar/dex_tab_bar_bloc.dart`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_686537c86a348326aafd50eae20a7323