### PR TITLE
feat(wallet): link asset stats to price chart

### DIFF
--- a/lib/views/wallet/wallet_page/common/asset_list_item.dart
+++ b/lib/views/wallet/wallet_page/common/asset_list_item.dart
@@ -13,6 +13,7 @@ class AssetListItem extends StatelessWidget {
     required this.assetId,
     required this.backgroundColor,
     required this.onTap,
+    this.onStatisticsTap,
     this.isActivating = false,
     this.priceChangePercentage24h,
   });
@@ -20,6 +21,7 @@ class AssetListItem extends StatelessWidget {
   final AssetId assetId;
   final Color backgroundColor;
   final void Function(AssetId) onTap;
+  final void Function(AssetId, Duration period)? onStatisticsTap;
   final bool isActivating;
   final double? priceChangePercentage24h;
 
@@ -39,6 +41,7 @@ class AssetListItem extends StatelessWidget {
             assetId: assetId,
             backgroundColor: backgroundColor,
             onTap: onTap,
+            onStatisticsTap: onStatisticsTap,
           );
   }
 }

--- a/lib/views/wallet/wallet_page/common/asset_list_item_desktop.dart
+++ b/lib/views/wallet/wallet_page/common/asset_list_item_desktop.dart
@@ -14,12 +14,14 @@ class AssetListItemDesktop extends StatelessWidget {
     required this.assetId,
     required this.backgroundColor,
     required this.onTap,
+    this.onStatisticsTap,
     this.priceChangePercentage24h,
   });
 
   final AssetId assetId;
   final Color backgroundColor;
   final void Function(AssetId) onTap;
+  final void Function(AssetId, Duration period)? onStatisticsTap;
 
   /// The 24-hour price change percentage for the asset
   final double? priceChangePercentage24h;
@@ -58,17 +60,29 @@ class AssetListItemDesktop extends StatelessWidget {
                 Expanded(
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 12.0),
-                    child: TrendPercentageText(
-                      percentage: priceChangePercentage24h ?? 0,
-                      showIcon: true,
-                      iconSize: 16,
-                      precision: 2,
+                    child: InkWell(
+                      onTap: () => onStatisticsTap?.call(
+                        assetId,
+                        const Duration(days: 1),
+                      ),
+                      child: TrendPercentageText(
+                        percentage: priceChangePercentage24h ?? 0,
+                        showIcon: true,
+                        iconSize: 16,
+                        precision: 2,
+                      ),
                     ),
                   ),
                 ),
                 Expanded(
                   flex: 2,
-                  child: CoinSparkline(coinId: assetId.id),
+                  child: InkWell(
+                    onTap: () => onStatisticsTap?.call(
+                      assetId,
+                      const Duration(days: 7),
+                    ),
+                    child: CoinSparkline(coinId: assetId.id),
+                  ),
                 ),
               ],
             ),

--- a/lib/views/wallet/wallet_page/common/assets_list.dart
+++ b/lib/views/wallet/wallet_page/common/assets_list.dart
@@ -11,6 +11,7 @@ class AssetsList extends StatelessWidget {
     super.key,
     required this.assets,
     required this.onAssetItemTap,
+    this.onStatisticsTap,
     this.withBalance = false,
     this.searchPhrase = '',
     this.useGroupedView = false,
@@ -19,6 +20,7 @@ class AssetsList extends StatelessWidget {
 
   final List<AssetId> assets;
   final Function(AssetId) onAssetItemTap;
+  final void Function(AssetId, Duration period)? onStatisticsTap;
   final bool withBalance;
   final String searchPhrase;
   final bool useGroupedView;
@@ -47,6 +49,7 @@ class AssetsList extends StatelessWidget {
             assetId: asset,
             backgroundColor: backgroundColor,
             onTap: onAssetItemTap,
+            onStatisticsTap: onStatisticsTap,
             priceChangePercentage24h: priceChangePercentages[asset.id],
           );
         },
@@ -71,6 +74,7 @@ class AssetsList extends StatelessWidget {
           assets: group.value,
           backgroundColor: backgroundColor,
           onTap: onAssetItemTap,
+          onStatisticsTap: onStatisticsTap,
         );
       },
       separatorBuilder: (BuildContext context, int index) {

--- a/lib/views/wallet/wallet_page/common/grouped_asset_ticker_item.dart
+++ b/lib/views/wallet/wallet_page/common/grouped_asset_ticker_item.dart
@@ -20,6 +20,7 @@ class GroupedAssetTickerItem extends StatefulWidget {
     required this.assets,
     required this.backgroundColor,
     required this.onTap,
+    this.onStatisticsTap,
     this.expanded,
     this.isActivating = false,
   });
@@ -27,6 +28,7 @@ class GroupedAssetTickerItem extends StatefulWidget {
   final List<AssetId> assets;
   final Color backgroundColor;
   final void Function(AssetId)? onTap;
+  final void Function(AssetId, Duration period)? onStatisticsTap;
   final bool? expanded;
   final bool isActivating;
 
@@ -63,7 +65,7 @@ class _GroupedAssetTickerItemState extends State<GroupedAssetTickerItem> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);  
+    final theme = Theme.of(context);
     return Opacity(
       opacity: widget.isActivating ? 0.3 : 1,
       child: Material(
@@ -114,15 +116,22 @@ class _GroupedAssetTickerItemState extends State<GroupedAssetTickerItem> {
                       flex: 2,
                       child: BlocBuilder<CoinsBloc, CoinsState>(
                         builder: (context, state) {
-                          return TrendPercentageText(
-                            textStyle: theme.textTheme.bodyMedium?.copyWith(
-                              fontWeight: FontWeight.w500,
+                          return InkWell(
+                            onTap: () => widget.onStatisticsTap?.call(
+                              _primaryAsset,
+                              const Duration(days: 1),
                             ),
-                            percentage:
-                                state.get24hChangeForAsset(_primaryAsset) ?? 0,
-                            showIcon: true,
-                            iconSize: 16,
-                            precision: 2,
+                            child: TrendPercentageText(
+                              textStyle: theme.textTheme.bodyMedium?.copyWith(
+                                fontWeight: FontWeight.w500,
+                              ),
+                              percentage:
+                                  state.get24hChangeForAsset(_primaryAsset) ??
+                                      0,
+                              showIcon: true,
+                              iconSize: 16,
+                              precision: 2,
+                            ),
                           );
                         },
                       ),
@@ -134,7 +143,13 @@ class _GroupedAssetTickerItemState extends State<GroupedAssetTickerItem> {
                           maxWidth: 130,
                           maxHeight: 35,
                         ),
-                        child: CoinSparkline(coinId: _primaryAsset.id),
+                        child: InkWell(
+                          onTap: () => widget.onStatisticsTap?.call(
+                            _primaryAsset,
+                            const Duration(days: 7),
+                          ),
+                          child: CoinSparkline(coinId: _primaryAsset.id),
+                        ),
                       ),
                     ),
                     ConstrainedBox(

--- a/lib/views/wallet/wallet_page/common/grouped_assets_list.dart
+++ b/lib/views/wallet/wallet_page/common/grouped_assets_list.dart
@@ -12,6 +12,7 @@ class GroupedAssetsList extends StatelessWidget {
     super.key,
     required this.assets,
     required this.onAssetItemTap,
+    this.onStatisticsTap,
     this.searchPhrase = '',
   });
 
@@ -20,6 +21,7 @@ class GroupedAssetsList extends StatelessWidget {
 
   /// Callback function when an asset is tapped
   final Function(AssetId) onAssetItemTap;
+  final void Function(AssetId, Duration period)? onStatisticsTap;
 
   /// Optional search phrase to filter assets
   final String searchPhrase;
@@ -45,6 +47,7 @@ class GroupedAssetsList extends StatelessWidget {
           assets: assetGroup,
           backgroundColor: backgroundColor,
           onTap: onAssetItemTap,
+          onStatisticsTap: onStatisticsTap,
         );
       },
       itemCount: groupedAssets.length,

--- a/lib/views/wallet/wallet_page/wallet_main/wallet_main.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/wallet_main.dart
@@ -35,6 +35,9 @@ import 'package:web_dex/analytics/events/misc_events.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_details_info/charts/portfolio_growth_chart.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_details_info/charts/portfolio_profit_loss_chart.dart';
 import 'package:web_dex/views/wallet/wallet_page/charts/coin_prices_chart.dart';
+import 'package:web_dex/bloc/cex_market_data/price_chart/price_chart_bloc.dart';
+import 'package:web_dex/bloc/cex_market_data/price_chart/price_chart_event.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart';
 import 'package:web_dex/views/wallet/wallet_page/common/assets_list.dart';
 import 'package:web_dex/views/wallet/wallet_page/wallet_main/active_coins_list.dart';
 import 'package:web_dex/views/wallet/wallet_page/wallet_main/wallet_manage_section.dart';
@@ -256,6 +259,16 @@ class _WalletMainState extends State<WalletMain>
     _popupDispatcher!.show();
   }
 
+  void _onAssetStatisticsTap(AssetId assetId, Duration period) {
+    context.read<PriceChartBloc>().add(
+          PriceChartStarted(
+            symbols: [assetId.symbol.configSymbol],
+            period: period,
+          ),
+        );
+    _tabController.animateTo(1);
+  }
+
   List<Widget> _buildTabSlivers(AuthorizeMode mode, List<Coin> walletCoins) {
     switch (_activeTabIndex) {
       case 0:
@@ -276,6 +289,7 @@ class _WalletMainState extends State<WalletMain>
             withBalance: _showCoinWithBalance,
             onActiveCoinItemTap: _onActiveCoinItemTap,
             onAssetItemTap: _onAssetItemTap,
+            onAssetStatisticsTap: _onAssetStatisticsTap,
           ),
         ];
       case 1:
@@ -372,6 +386,7 @@ class CoinListView extends StatelessWidget {
     required this.withBalance,
     required this.onActiveCoinItemTap,
     required this.onAssetItemTap,
+    required this.onAssetStatisticsTap,
   });
 
   final AuthorizeMode mode;
@@ -379,6 +394,7 @@ class CoinListView extends StatelessWidget {
   final bool withBalance;
   final Function(Coin) onActiveCoinItemTap;
   final Function(Coin) onAssetItemTap;
+  final void Function(AssetId, Duration period) onAssetStatisticsTap;
 
   @override
   Widget build(BuildContext context) {
@@ -407,6 +423,7 @@ class CoinListView extends StatelessWidget {
                   (coin) => coin.assetId == assetId,
                 ),
           ),
+          onStatisticsTap: onAssetStatisticsTap,
         );
     }
   }
@@ -425,8 +442,7 @@ class _SliverSearchBarDelegate extends SliverPersistentHeaderDelegate {
   final AuthorizeMode mode;
 
   @override
-  double get minExtent =>
-      isMobile ? 64 : 68;
+  double get minExtent => isMobile ? 64 : 68;
   @override
   double get maxExtent =>
       isMobile ? (mode == AuthorizeMode.logIn ? 112 : 64) : 106;


### PR DESCRIPTION
## Summary
- allow tapping asset statistics to open the price chart
- wire the stats chart and text to the chart tab with matching period

## Testing
- `flutter analyze`
- `dart format .`

------
https://chatgpt.com/codex/tasks/task_e_68654867823c83268b608c1e1b90a739