### PR TITLE
feat(theme): add ultra dark mode

### DIFF
--- a/app_theme/lib/app_theme.dart
+++ b/app_theme/lib/app_theme.dart
@@ -7,6 +7,7 @@ import 'src/dark/theme_custom_dark.dart';
 import 'src/light/theme_custom_light.dart';
 import 'src/new_theme/new_theme_dark.dart';
 import 'src/new_theme/new_theme_light.dart';
+import 'src/new_theme/new_theme_ultra_dark.dart';
 import 'src/theme_global.dart';
 
 export 'src/new_theme/extensions/color_scheme_extension.dart';
@@ -17,11 +18,14 @@ final theme = AppTheme();
 class AppTheme {
   final ThemeDataGlobal global = ThemeDataGlobal();
   ThemeMode mode = ThemeMode.dark;
+  bool isUltraDarkModeEnabled = false;
 
   ThemeCustomBase get custom =>
       mode == ThemeMode.dark ? _themeCustomDark : _themeCustomLight;
   ThemeData get currentGlobal =>
-      mode == ThemeMode.dark ? global.dark : global.light;
+      mode == ThemeMode.dark
+          ? (isUltraDarkModeEnabled ? global.ultraDark : global.dark)
+          : global.light;
 }
 
 ThemeCustomBase get _themeCustomLight => ThemeCustomLight();
@@ -32,3 +36,4 @@ DexPageTheme get dexPageColors => theme.custom.dexPageTheme;
 
 ThemeData get newThemeDark => newThemeDataDark;
 ThemeData get newThemeLight => newThemeDataLight;
+ThemeData get newThemeUltraDark => newThemeDataUltraDark;

--- a/app_theme/lib/src/new_theme/new_theme_ultra_dark.dart
+++ b/app_theme/lib/src/new_theme/new_theme_ultra_dark.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+import '../../app_theme.dart';
+
+const ColorSchemeExtension _colorSchemeExtension = ColorSchemeExtension(
+  primary: Color.fromRGBO(61, 119, 233, 1),
+  p50: Color.fromRGBO(31, 60, 117, 1),
+  p40: Color.fromRGBO(24, 48, 93, 1),
+  p10: Color.fromRGBO(6, 12, 23, 1),
+  secondary: Color.fromRGBO(173, 175, 196, 1),
+  s70: Color.fromRGBO(121, 123, 137, 1),
+  s50: Color.fromRGBO(87, 88, 98, 1),
+  s40: Color.fromRGBO(69, 70, 78, 1),
+  s30: Color.fromRGBO(52, 53, 59, 1),
+  s20: Color.fromRGBO(35, 35, 39, 1),
+  s10: Color.fromRGBO(17, 18, 20, 1),
+  e10: Color.fromRGBO(21, 6, 10, 1),
+  e20: Color.fromRGBO(42, 11, 21, 1),
+  e50: Color.fromRGBO(105, 29, 52, 1),
+  error: Color.fromRGBO(210, 57, 104, 1),
+  g10: Color.fromRGBO(9, 19, 17, 1),
+  g20: Color.fromRGBO(18, 38, 34, 1),
+  green: Color.fromRGBO(88, 192, 171, 1),
+  surf: Color.fromRGBO(255, 255, 255, 1),
+  surfCont: Color.fromRGBO(33, 35, 54, 1),
+  surfContHigh: Color.fromRGBO(43, 45, 64, 1),
+  surfContHighest: Color.fromRGBO(53, 55, 74, 1),
+  surfContLow: Color.fromRGBO(23, 25, 38, 1),
+  surfContLowest: Color.fromRGBO(0, 0, 0, 1),
+  orange: Color.fromRGBO(237, 170, 70, 1),
+  yellow: Color.fromRGBO(230, 188, 65, 1),
+  purple: Color.fromRGBO(123, 73, 221, 1),
+);
+
+final ColorScheme _colorScheme = theme.global.ultraDark.colorScheme.copyWith(
+  primary: _colorSchemeExtension.primary,
+  secondary: _colorSchemeExtension.secondary,
+);
+final TextTheme _textTheme = theme.global.ultraDark.textTheme.copyWith();
+final TextThemeExtension _textThemeExtension = TextThemeExtension(
+  textColor: _colorSchemeExtension.secondary,
+);
+
+final ThemeData newThemeDataUltraDark = theme.global.ultraDark.copyWith(
+  colorScheme: _colorScheme,
+  textTheme: _textTheme,
+  inputDecorationTheme: theme.global.ultraDark.inputDecorationTheme.copyWith(
+    hintStyle:
+        _textThemeExtension.bodySBold.copyWith(color: _colorSchemeExtension.s50),
+    labelStyle:
+        _textThemeExtension.bodyXSBold.copyWith(color: _colorSchemeExtension.primary),
+    errorStyle:
+        _textThemeExtension.bodyS.copyWith(color: _colorSchemeExtension.error),
+    enabledBorder: _outlineBorderLight(_colorSchemeExtension.secondary),
+    disabledBorder: _outlineBorderLight(_colorSchemeExtension.secondary),
+    focusedBorder: _outlineBorderLight(_colorSchemeExtension.primary),
+    errorBorder: _outlineBorderLight(_colorSchemeExtension.error),
+    fillColor: Colors.transparent,
+    hoverColor: Colors.transparent,
+  ),
+  extensions: [_colorSchemeExtension, _textThemeExtension],
+);
+
+OutlineInputBorder _outlineBorderLight(Color accentColor) => OutlineInputBorder(
+      borderSide: BorderSide(color: accentColor, width: 2),
+      borderRadius: BorderRadius.circular(18),
+    );

--- a/app_theme/lib/src/theme_global.dart
+++ b/app_theme/lib/src/theme_global.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 
 import 'dark/theme_global_dark.dart';
 import 'light/theme_global_light.dart';
+import 'ultra_dark/theme_global_ultra_dark.dart';
 
 class ThemeDataGlobal {
   final ThemeData light = themeGlobalLight;
   final ThemeData dark = themeGlobalDark;
+  final ThemeData ultraDark = themeGlobalUltraDark;
 }

--- a/app_theme/lib/src/ultra_dark/theme_global_ultra_dark.dart
+++ b/app_theme/lib/src/ultra_dark/theme_global_ultra_dark.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import '../dark/theme_custom_dark.dart';
+
+ThemeData get themeGlobalUltraDark {
+  const Color inputBackgroundColor = Color.fromRGBO(51, 57, 72, 1);
+  const Color textColor = Color.fromRGBO(255, 255, 255, 1);
+
+  OutlineInputBorder outlineBorderLight(Color lightAccentColor) =>
+      OutlineInputBorder(
+        borderSide: BorderSide(color: lightAccentColor),
+        borderRadius: BorderRadius.circular(18),
+      );
+
+  final ColorScheme colorScheme = ColorScheme.fromSeed(
+    brightness: Brightness.dark,
+    seedColor: const Color.fromRGBO(61, 119, 233, 1),
+    primary: const Color.fromRGBO(61, 119, 233, 1),
+    secondary: const Color.fromRGBO(90, 104, 230, 1),
+    tertiary: const Color.fromRGBO(28, 32, 59, 1),
+    surface: const Color(0xFF000000),
+    onSurface: const Color(0xFF000000),
+    error: const Color.fromRGBO(202, 78, 61, 1),
+  );
+
+  final TextTheme textTheme = TextTheme(
+    headlineMedium: const TextStyle(
+      fontSize: 16,
+      fontWeight: FontWeight.w700,
+      color: textColor,
+    ),
+    headlineSmall: const TextStyle(
+      fontSize: 40,
+      fontWeight: FontWeight.w700,
+      color: textColor,
+    ),
+    titleLarge: const TextStyle(
+      fontSize: 26.0,
+      color: textColor,
+      fontWeight: FontWeight.w700,
+    ),
+    titleSmall: const TextStyle(fontSize: 18.0, color: textColor),
+    bodyMedium: const TextStyle(
+      fontSize: 16.0,
+      color: textColor,
+      fontWeight: FontWeight.w300,
+    ),
+    labelLarge: const TextStyle(fontSize: 16.0, color: textColor),
+    bodyLarge: TextStyle(
+      fontSize: 14.0,
+      color: textColor.withAlpha(128),
+    ),
+    bodySmall: TextStyle(
+      fontSize: 12.0,
+      color: textColor.withAlpha(204),
+      fontWeight: FontWeight.w400,
+    ),
+  );
+
+  SnackBarThemeData snackBarThemeLight() => SnackBarThemeData(
+        elevation: 12.0,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(18)),
+        ),
+        behavior: SnackBarBehavior.floating,
+        backgroundColor: colorScheme.primaryContainer,
+        contentTextStyle: textTheme.bodyLarge!.copyWith(
+          color: colorScheme.onPrimaryContainer,
+        ),
+        actionTextColor: colorScheme.onPrimaryContainer,
+        showCloseIcon: true,
+        closeIconColor: colorScheme.onPrimaryContainer.withAlpha(179),
+      );
+
+  final customTheme = ThemeCustomDark();
+  final theme = ThemeData(
+    useMaterial3: false,
+    fontFamily: 'Manrope',
+    scaffoldBackgroundColor: colorScheme.onSurface,
+    cardColor: colorScheme.surface,
+    cardTheme: CardThemeData(
+      color: colorScheme.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(18)),
+      ),
+    ),
+    colorScheme: colorScheme,
+    primaryColor: colorScheme.primary,
+    dividerColor: const Color.fromRGBO(56, 67, 108, 1),
+    appBarTheme: AppBarTheme(color: colorScheme.surface),
+    iconTheme: IconThemeData(color: colorScheme.primary),
+    progressIndicatorTheme: ProgressIndicatorThemeData(
+      color: colorScheme.primary,
+    ),
+    dialogTheme: const DialogThemeData(
+      backgroundColor: Color.fromRGBO(14, 16, 27, 1),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(16)),
+      ),
+    ),
+    canvasColor: colorScheme.surface,
+    hintColor: const Color.fromRGBO(183, 187, 191, 1),
+    snackBarTheme: snackBarThemeLight(),
+    textSelectionTheme: TextSelectionThemeData(
+      cursorColor: const Color.fromRGBO(57, 161, 238, 1),
+      selectionColor: const Color.fromRGBO(
+        57,
+        161,
+        238,
+        1,
+      ).withAlpha(77),
+      selectionHandleColor: const Color.fromRGBO(57, 161, 238, 1),
+    ),
+    inputDecorationTheme: InputDecorationTheme(
+      enabledBorder: outlineBorderLight(Colors.transparent),
+      disabledBorder: outlineBorderLight(Colors.transparent),
+      border: outlineBorderLight(Colors.transparent),
+      focusedBorder: outlineBorderLight(Colors.transparent),
+      errorBorder: outlineBorderLight(colorScheme.error),
+      fillColor: inputBackgroundColor,
+      focusColor: inputBackgroundColor,
+      hoverColor: Colors.transparent,
+      errorStyle: TextStyle(color: colorScheme.error),
+      filled: true,
+      contentPadding: const EdgeInsets.symmetric(vertical: 12, horizontal: 22),
+      hintStyle: TextStyle(
+        color: textColor.withAlpha(148),
+      ),
+      labelStyle: TextStyle(
+        color: textColor.withAlpha(148),
+      ),
+      prefixIconColor: textColor.withAlpha(148),
+    ),
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ButtonStyle(
+        backgroundColor: WidgetStateProperty.resolveWith<Color?>(
+          (Set<WidgetState> states) {
+            if (states.contains(WidgetState.disabled)) return Colors.grey;
+            return colorScheme.primary;
+          },
+        ),
+      ),
+    ),
+    segmentedButtonTheme: SegmentedButtonThemeData(
+      style: SegmentedButton.styleFrom(
+        backgroundColor: colorScheme.surfaceContainerLowest,
+        surfaceTintColor: Colors.purple,
+        selectedBackgroundColor: colorScheme.primary,
+        foregroundColor: textColor.withAlpha(179),
+        selectedForegroundColor: textColor,
+        side: BorderSide(color: colorScheme.outlineVariant),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+      ),
+    ),
+    tabBarTheme: TabBarThemeData(
+      labelColor: textColor,
+      indicator: UnderlineTabIndicator(
+        borderSide: BorderSide(width: 2.0, color: colorScheme.primary),
+        insets: const EdgeInsets.symmetric(horizontal: 18),
+      ),
+    ),
+    checkboxTheme: CheckboxThemeData(
+      checkColor: WidgetStateProperty.all<Color>(Colors.white),
+      fillColor: WidgetStateProperty.all<Color>(colorScheme.primary),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(2)),
+    ),
+    floatingActionButtonTheme: FloatingActionButtonThemeData(
+      backgroundColor: colorScheme.primary,
+    ),
+    textTheme: textTheme,
+    scrollbarTheme: ScrollbarThemeData(
+      thumbColor: WidgetStateProperty.all<Color?>(
+        colorScheme.primary.withAlpha(204),
+      ),
+    ),
+    bottomNavigationBarTheme: BottomNavigationBarThemeData(
+      type: BottomNavigationBarType.fixed,
+      backgroundColor: colorScheme.surface,
+      selectedItemColor: textColor,
+      unselectedItemColor: const Color.fromRGBO(173, 175, 198, 1),
+      unselectedLabelStyle: const TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w600,
+      ),
+      selectedLabelStyle: const TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w700,
+      ),
+    ),
+    extensions: [customTheme],
+  );
+
+  customTheme.initializeThemeDependentColors(theme);
+
+  return theme;
+}

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -279,6 +279,7 @@
     "darkMode": "Dark mode",
     "light": "Light",
     "lightMode": "Light mode",
+    "ultraDark": "Ultra dark",
     "defaultText": "Default",
     "clear": "Clear",
     "remove": "Remove",

--- a/lib/bloc/app_bloc_root.dart
+++ b/lib/bloc/app_bloc_root.dart
@@ -361,7 +361,9 @@ class _MyAppViewState extends State<_MyAppView> {
       onGenerateTitle: (_) => appTitle,
       themeMode: context
           .select((SettingsBloc settingsBloc) => settingsBloc.state.themeMode),
-      darkTheme: theme.global.dark,
+      darkTheme: context.watch<SettingsBloc>().state.ultraDark
+          ? theme.global.ultraDark
+          : theme.global.dark,
       theme: theme.global.light,
       routerDelegate: _routerDelegate,
       locale: context.locale,

--- a/lib/bloc/settings/settings_bloc.dart
+++ b/lib/bloc/settings/settings_bloc.dart
@@ -14,8 +14,10 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
         super(SettingsState.fromStored(stored)) {
     _storedSettings = stored;
     theme.mode = state.themeMode;
+    theme.isUltraDarkModeEnabled = state.ultraDark;
 
     on<ThemeModeChanged>(_onThemeModeChanged);
+    on<UltraDarkChanged>(_onUltraDarkChanged);
     on<MarketMakerBotSettingsChanged>(_onMarketMakerBotSettingsChanged);
     on<TestCoinsEnabledChanged>(_onTestCoinsEnabledChanged);
     on<WeakPasswordsAllowedChanged>(_onWeakPasswordsAllowedChanged);
@@ -66,5 +68,17 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
       _storedSettings.copyWith(weakPasswordsAllowed: event.weakPasswordsAllowed),
     );
     emitter(state.copyWith(weakPasswordsAllowed: event.weakPasswordsAllowed));
+  }
+
+  Future<void> _onUltraDarkChanged(
+    UltraDarkChanged event,
+    Emitter<SettingsState> emitter,
+  ) async {
+    await _settingsRepo.updateSettings(
+      _storedSettings.copyWith(ultraDark: event.enabled),
+    );
+    theme.isUltraDarkModeEnabled = event.enabled;
+    emitter(state.copyWith(ultraDark: event.enabled));
+    rebuildAll(null);
   }
 }

--- a/lib/bloc/settings/settings_event.dart
+++ b/lib/bloc/settings/settings_event.dart
@@ -14,6 +14,11 @@ class ThemeModeChanged extends SettingsEvent {
   final ThemeMode mode;
 }
 
+class UltraDarkChanged extends SettingsEvent {
+  const UltraDarkChanged({required this.enabled});
+  final bool enabled;
+}
+
 class TestCoinsEnabledChanged extends SettingsEvent {
   const TestCoinsEnabledChanged({required this.testCoinsEnabled});
   final bool testCoinsEnabled;

--- a/lib/bloc/settings/settings_state.dart
+++ b/lib/bloc/settings/settings_state.dart
@@ -9,6 +9,7 @@ class SettingsState extends Equatable {
     required this.mmBotSettings,
     required this.testCoinsEnabled,
     required this.weakPasswordsAllowed,
+    required this.ultraDark,
   });
 
   factory SettingsState.fromStored(StoredSettings stored) {
@@ -17,6 +18,7 @@ class SettingsState extends Equatable {
       mmBotSettings: stored.marketMakerBotSettings,
       testCoinsEnabled: stored.testCoinsEnabled,
       weakPasswordsAllowed: stored.weakPasswordsAllowed,
+      ultraDark: stored.ultraDark,
     );
   }
 
@@ -24,6 +26,7 @@ class SettingsState extends Equatable {
   final MarketMakerBotSettings mmBotSettings;
   final bool testCoinsEnabled;
   final bool weakPasswordsAllowed;
+  final bool ultraDark;
 
   @override
   List<Object?> get props => [
@@ -31,6 +34,7 @@ class SettingsState extends Equatable {
         mmBotSettings,
         testCoinsEnabled,
         weakPasswordsAllowed,
+        ultraDark,
       ];
 
   SettingsState copyWith({
@@ -38,12 +42,14 @@ class SettingsState extends Equatable {
     MarketMakerBotSettings? marketMakerBotSettings,
     bool? testCoinsEnabled,
     bool? weakPasswordsAllowed,
+    bool? ultraDark,
   }) {
     return SettingsState(
       themeMode: mode ?? themeMode,
       mmBotSettings: marketMakerBotSettings ?? mmBotSettings,
       testCoinsEnabled: testCoinsEnabled ?? this.testCoinsEnabled,
       weakPasswordsAllowed: weakPasswordsAllowed ?? this.weakPasswordsAllowed,
+      ultraDark: ultraDark ?? this.ultraDark,
     );
   }
 }

--- a/lib/generated/codegen_loader.g.dart
+++ b/lib/generated/codegen_loader.g.dart
@@ -276,6 +276,7 @@ abstract class  LocaleKeys {
   static const darkMode = 'darkMode';
   static const light = 'light';
   static const lightMode = 'lightMode';
+  static const ultraDark = 'ultraDark';
   static const defaultText = 'defaultText';
   static const clear = 'clear';
   static const remove = 'remove';

--- a/lib/model/stored_settings.dart
+++ b/lib/model/stored_settings.dart
@@ -10,6 +10,7 @@ class StoredSettings {
     required this.marketMakerBotSettings,
     required this.testCoinsEnabled,
     required this.weakPasswordsAllowed,
+    required this.ultraDark,
   });
 
   final ThemeMode mode;
@@ -17,6 +18,7 @@ class StoredSettings {
   final MarketMakerBotSettings marketMakerBotSettings;
   final bool testCoinsEnabled;
   final bool weakPasswordsAllowed;
+  final bool ultraDark;
 
   static StoredSettings initial() {
     return StoredSettings(
@@ -25,6 +27,7 @@ class StoredSettings {
       marketMakerBotSettings: MarketMakerBotSettings.initial(),
       testCoinsEnabled: true,
       weakPasswordsAllowed: false,
+      ultraDark: false,
     );
   }
 
@@ -39,6 +42,7 @@ class StoredSettings {
       ),
       testCoinsEnabled: json['testCoinsEnabled'] ?? true,
       weakPasswordsAllowed: json['weakPasswordsAllowed'] ?? false,
+      ultraDark: json['ultraDark'] ?? false,
     );
   }
 
@@ -49,6 +53,7 @@ class StoredSettings {
       storedMarketMakerSettingsKey: marketMakerBotSettings.toJson(),
       'testCoinsEnabled': testCoinsEnabled,
       'weakPasswordsAllowed': weakPasswordsAllowed,
+      'ultraDark': ultraDark,
     };
   }
 
@@ -58,6 +63,7 @@ class StoredSettings {
     MarketMakerBotSettings? marketMakerBotSettings,
     bool? testCoinsEnabled,
     bool? weakPasswordsAllowed,
+    bool? ultraDark,
   }) {
     return StoredSettings(
       mode: mode ?? this.mode,
@@ -66,6 +72,7 @@ class StoredSettings {
           marketMakerBotSettings ?? this.marketMakerBotSettings,
       testCoinsEnabled: testCoinsEnabled ?? this.testCoinsEnabled,
       weakPasswordsAllowed: weakPasswordsAllowed ?? this.weakPasswordsAllowed,
+      ultraDark: ultraDark ?? this.ultraDark,
     );
   }
 }

--- a/lib/views/common/main_menu/main_menu_desktop.dart
+++ b/lib/views/common/main_menu/main_menu_desktop.dart
@@ -119,7 +119,11 @@ class _MainMenuDesktopState extends State<MainMenuDesktop> {
                       isSelected: _checkSelectedItem(MainMenuValue.settings),
                     ),
                     Theme(
-                      data: isDarkTheme ? newThemeDark : newThemeLight,
+                      data: isDarkTheme
+                          ? (settingsState.ultraDark
+                              ? newThemeUltraDark
+                              : newThemeDark)
+                          : newThemeLight,
                       child: Builder(builder: (context) {
                         final ColorSchemeExtension colorScheme =
                             Theme.of(context)

--- a/lib/views/dex/dex_list_filter/common/dex_list_filter_type.dart
+++ b/lib/views/dex/dex_list_filter/common/dex_list_filter_type.dart
@@ -1,6 +1,8 @@
 import 'package:app_theme/app_theme.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:web_dex/bloc/settings/settings_bloc.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 
@@ -56,10 +58,13 @@ class _DexListFilterTypeDesktop<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final settings = context.watch<SettingsBloc>().state;
     return Theme(
       data: Theme.of(context).brightness == Brightness.light
           ? newThemeLight
-          : newThemeDark,
+          : settings.ultraDark
+              ? newThemeUltraDark
+              : newThemeDark,
       child: Builder(builder: (context) {
         final ext = Theme.of(context).extension<ColorSchemeExtension>();
         return MultiSelectDropdownButton<T>(

--- a/lib/views/dex/dex_list_filter/desktop/dex_list_filter_coin_desktop.dart
+++ b/lib/views/dex/dex_list_filter/desktop/dex_list_filter_coin_desktop.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_repo.dart';
 import 'package:web_dex/blocs/trading_entities_bloc.dart';
+import 'package:web_dex/bloc/settings/settings_bloc.dart';
 import 'package:web_dex/model/coin.dart';
 import 'package:web_dex/model/dex_list_type.dart';
 import 'package:web_dex/model/my_orders/my_order.dart';
@@ -175,10 +176,13 @@ class _DropDownButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final settings = context.watch<SettingsBloc>().state;
     return Theme(
       data: Theme.of(context).brightness == Brightness.light
           ? newThemeLight
-          : newThemeDark,
+          : settings.ultraDark
+              ? newThemeUltraDark
+              : newThemeDark,
       child: Builder(
         builder: (context) {
           final ext = Theme.of(context).extension<ColorSchemeExtension>();

--- a/lib/views/dex/dex_list_filter/desktop/dex_list_filter_desktop.dart
+++ b/lib/views/dex/dex_list_filter/desktop/dex_list_filter_desktop.dart
@@ -2,6 +2,8 @@ import 'package:app_theme/app_theme.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:web_dex/bloc/settings/settings_bloc.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/dex_list_type.dart';
 import 'package:web_dex/model/my_orders/my_order.dart';
@@ -189,7 +191,9 @@ class _DexListFilterDesktopState extends State<DexListFilterDesktop> {
               child: Theme(
                 data: Theme.of(context).brightness == Brightness.light
                     ? newThemeLight
-                    : newThemeDark,
+                    : context.watch<SettingsBloc>().state.ultraDark
+                        ? newThemeUltraDark
+                        : newThemeDark,
                 child: Builder(
                   builder: (context) {
                     final ext =

--- a/lib/views/nfts/nft_page.dart
+++ b/lib/views/nfts/nft_page.dart
@@ -25,14 +25,16 @@ class NftPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocSelector<SettingsBloc, SettingsState, ThemeMode>(
-      selector: (state) {
-        return state.themeMode;
-      },
-      builder: (context, themeMode) {
-        final isLightTheme = themeMode == ThemeMode.light;
+    return BlocBuilder<SettingsBloc, SettingsState>(
+      builder: (context, state) {
+        final isLightTheme = state.themeMode == ThemeMode.light;
+        final data = isLightTheme
+            ? newThemeLight
+            : state.ultraDark
+                ? newThemeUltraDark
+                : newThemeDark;
         return Theme(
-          data: isLightTheme ? newThemeLight : newThemeDark,
+          data: data,
           child: MultiRepositoryProvider(
             providers: [
               RepositoryProvider<NftTxnRepository>(

--- a/lib/views/nfts/nft_transactions/mobile/widgets/nft_txn_mobile_filters.dart
+++ b/lib/views/nfts/nft_transactions/mobile/widgets/nft_txn_mobile_filters.dart
@@ -1,6 +1,8 @@
 import 'package:app_theme/app_theme.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:web_dex/bloc/settings/settings_bloc.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 import 'package:web_dex/app_config/app_config.dart';
 import 'package:web_dex/bloc/nft_transactions/bloc/nft_transactions_filters.dart';
@@ -55,10 +57,13 @@ class _NftTxnMobileFiltersState extends State<NftTxnMobileFilters> {
         dateFrom == null &&
         dateTo == null;
 
+    final settings = context.watch<SettingsBloc>().state;
     return Theme(
       data: Theme.of(context).brightness == Brightness.light
           ? newThemeLight
-          : newThemeDark,
+          : settings.ultraDark
+              ? newThemeUltraDark
+              : newThemeDark,
       child: Builder(builder: (context) {
         final colorScheme = Theme.of(context).extension<ColorSchemeExtension>();
         final textScheme = Theme.of(context).extension<TextThemeExtension>();

--- a/lib/views/settings/widgets/general_settings/settings_theme_switcher.dart
+++ b/lib/views/settings/widgets/general_settings/settings_theme_switcher.dart
@@ -21,21 +21,28 @@ class SettingsThemeSwitcher extends StatelessWidget {
         decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(18.0),
             color: Theme.of(context).colorScheme.onSurface),
-        child: const Row(
+        child: Row(
             mainAxisSize: MainAxisSize.max,
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Expanded(
+              const Expanded(
                 child: Padding(
                   padding: EdgeInsets.only(right: 6.0),
                   child: _SettingsModeSelector(mode: ThemeMode.light),
                 ),
               ),
-              SizedBox(width: 10),
-              Expanded(
+              const SizedBox(width: 10),
+              const Expanded(
                 child: Padding(
                   padding: EdgeInsets.only(right: 6.0),
                   child: _SettingsModeSelector(mode: ThemeMode.dark),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.only(right: 6.0),
+                  child: _UltraDarkSelector(),
                 ),
               ),
             ]),
@@ -157,5 +164,76 @@ class _SettingsModeSelector extends StatelessWidget {
       case ThemeMode.system:
         return const Color.fromRGBO(0, 0, 0, 0);
     }
+  }
+}
+
+class _UltraDarkSelector extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final bool isSelected =
+        context.select((SettingsBloc bloc) => bloc.state.ultraDark);
+    const double size = 16.0;
+    const Color backgroundColor = Colors.black;
+    return InkWell(
+      onTap: () =>
+          context.read<SettingsBloc>().add(UltraDarkChanged(enabled: !isSelected)),
+      mouseCursor: SystemMouseCursors.click,
+      child: Container(
+        key: const Key('theme-settings-switcher-ultra'),
+        height: 60,
+        decoration: const BoxDecoration(
+          borderRadius: BorderRadius.all(Radius.circular(18.0)),
+          color: backgroundColor,
+          image: DecorationImage(
+            filterQuality: FilterQuality.high,
+            image: AssetImage('$assetsPath/logo/dark_theme.png'),
+            alignment: Alignment.centerRight,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8.0),
+          child: Row(
+            children: [
+              Container(
+                width: size,
+                height: size,
+                padding: const EdgeInsets.all(2),
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: Theme.of(context).primaryColor,
+                ),
+                child: Container(
+                  padding: const EdgeInsets.all(2),
+                  decoration: const BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: backgroundColor,
+                  ),
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: isSelected
+                          ? Theme.of(context).primaryColor
+                          : theme.custom.noColor,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                ),
+              ),
+              Flexible(
+                child: Padding(
+                  padding: const EdgeInsets.only(left: 8.0, right: 2),
+                  child: Text(
+                    LocaleKeys.ultraDark.tr(),
+                    style: Theme.of(context)
+                        .textTheme
+                        .labelLarge
+                        ?.copyWith(fontSize: 14, color: Colors.white),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/web/services/theme_checker/theme_checker.js
+++ b/web/services/theme_checker/theme_checker.js
@@ -7,6 +7,7 @@
     }
     const lightBackgroundColor = '#f5f5f5';
     const darkBackgroundColor = '#121420';
+    const ultraDarkBackgroundColor = '#000000';
     const headTag = document.querySelector('head');
     const lightThemeColorMetaTag = document.createElement('meta');
     lightThemeColorMetaTag.setAttribute('media', '(prefers-color-scheme: light)');
@@ -21,6 +22,9 @@
     } else if (themeIndex === 2) {
         lightThemeColorMetaTag.setAttribute('content', darkBackgroundColor);
         darkThemeColorMetaTag.setAttribute('content', darkBackgroundColor);
+    } else if (themeIndex === 3) {
+        lightThemeColorMetaTag.setAttribute('content', ultraDarkBackgroundColor);
+        darkThemeColorMetaTag.setAttribute('content', ultraDarkBackgroundColor);
     }
     headTag.appendChild(lightThemeColorMetaTag);
     headTag.appendChild(darkThemeColorMetaTag);
@@ -31,6 +35,9 @@
         } else if (themeIndex === 2) {
             lightThemeColorMetaTag.setAttribute('content', darkBackgroundColor);
             darkThemeColorMetaTag.setAttribute('content', darkBackgroundColor);
+        } else if (themeIndex === 3) {
+            lightThemeColorMetaTag.setAttribute('content', ultraDarkBackgroundColor);
+            darkThemeColorMetaTag.setAttribute('content', ultraDarkBackgroundColor);
         }
     }
 })();


### PR DESCRIPTION
## Summary
- introduce 'ultra dark' theme with pure black backgrounds
- persist ultra dark preference in settings
- allow enabling ultra dark via settings
- apply ultra dark styling across widgets
- support new theme mode in web theme script

## Testing
- `flutter pub get --offline`
- `flutter analyze`
- `dart format -o none --set-exit-if-changed lib app_theme web assets packages`


------
https://chatgpt.com/codex/tasks/task_e_6866974992b0832690c3342f692965c0