### PR TITLE
fix: show error on wallet deletion failure

### DIFF
--- a/lib/blocs/wallets_repository.dart
+++ b/lib/blocs/wallets_repository.dart
@@ -54,7 +54,7 @@ class WalletsRepository {
         .toList();
   }
 
-  Future<bool> deleteWallet(
+  Future<void> deleteWallet(
     Wallet wallet, {
     required String password,
   }) async {
@@ -67,7 +67,7 @@ class WalletsRepository {
       final wallets = await _getLegacyWallets();
       wallets.removeWhere((w) => w.id == wallet.id);
       await _legacyWalletStorage.write(allWalletsStorageKey, wallets);
-      return true;
+      return;
     }
 
     try {
@@ -76,7 +76,7 @@ class WalletsRepository {
         password: password,
       );
       _cachedWallets?.removeWhere((w) => w.name == wallet.name);
-      return true;
+      return;
     } catch (e) {
       log('Failed to delete wallet: $e',
               path: 'wallet_bloc => deleteWallet', isError: true)

--- a/lib/blocs/wallets_repository.dart
+++ b/lib/blocs/wallets_repository.dart
@@ -81,7 +81,7 @@ class WalletsRepository {
       log('Failed to delete wallet: $e',
               path: 'wallet_bloc => deleteWallet', isError: true)
           .ignore();
-      return false;
+      rethrow;
     }
   }
 

--- a/lib/views/wallets_manager/widgets/wallet_deleting.dart
+++ b/lib/views/wallets_manager/widgets/wallet_deleting.dart
@@ -147,16 +147,23 @@ class _WalletDeletingState extends State<WalletDeleting> {
     });
     final walletsRepository = RepositoryProvider.of<WalletsRepository>(context);
     try {
-      final success = await walletsRepository.deleteWallet(
+      await walletsRepository.deleteWallet(
         widget.wallet,
         password: _passwordController.text,
       );
-      if (success) {
-        widget.close();
-      }
+      widget.close();
     } catch (e) {
-      if (e is AuthException && e.type == AuthExceptionType.incorrectPassword) {
-        _error = LocaleKeys.incorrectPassword.tr();
+      if (e is AuthException) {
+        switch (e.type) {
+          case AuthExceptionType.incorrectPassword:
+            _error = LocaleKeys.incorrectPassword.tr();
+            break;
+          case AuthExceptionType.walletNotFound:
+            _error = LocaleKeys.walletNotFound.tr();
+            break;
+          default:
+            _error = e.message;
+        }
       } else {
         _error = e.toString();
       }


### PR DESCRIPTION
## Summary
- propagate deletion errors from WalletsRepository
- display specific error messages when wallet deletion fails

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6867f888bcc48326b908c7f8da4636bb