### PR TITLE
fix(app): set wallet as homepage

### DIFF
--- a/lib/bloc/app_bloc_root.dart
+++ b/lib/bloc/app_bloc_root.dart
@@ -154,7 +154,7 @@ class AppBlocRoot extends StatelessWidget {
 
     // startup bloc run steps
     tradingEntitiesBloc.runUpdate();
-    routingState.selectedMenu = MainMenuValue.dex;
+    routingState.selectedMenu = MainMenuValue.defaultMenu();
 
     return MultiRepositoryProvider(
       providers: [

--- a/lib/router/parsers/dex_route_parser.dart
+++ b/lib/router/parsers/dex_route_parser.dart
@@ -4,6 +4,22 @@ import 'package:web_dex/router/state/dex_state.dart';
 
 class _DexRouteParser implements BaseRouteParser {
   const _DexRouteParser();
+
+  bool handlesDeepLinkParameters(Iterable<String> keys) {
+    const dexParams = {
+      'from_currency',
+      'from_amount',
+      'to_currency',
+      'to_amount',
+      'order_type',
+    };
+
+    for (final key in keys) {
+      if (dexParams.contains(key)) return true;
+    }
+    return false;
+  }
+
   @override
   AppRoutePath getRoutePath(Uri uri) {
     if (uri.pathSegments.length == 3) {

--- a/lib/router/parsers/root_route_parser.dart
+++ b/lib/router/parsers/root_route_parser.dart
@@ -40,7 +40,10 @@ class RootRouteInformationParser extends RouteInformationParser<AppRoutePath> {
   }
 
   BaseRouteParser _getRoutParser(Uri uri) {
-    final defaultRouteParser = dexRouteParser;
+    final defaultRouteParser =
+        dexRouteParser.handlesDeepLinkParameters(uri.queryParameters.keys)
+            ? dexRouteParser
+            : WalletRouteParser(coinsBloc);
 
     if (uri.pathSegments.isEmpty) return defaultRouteParser;
     return _parsers[uri.pathSegments.first] ?? defaultRouteParser;


### PR DESCRIPTION
## Summary
- keep homepage on wallet tab instead of redirecting to the DEX
- delegate deep link detection to `DexRouteParser`

## Testing
- `flutter pub get --enforce-lockfile --offline`
- `flutter analyze` *(fails: FileSystemException Broken pipe)*

------
https://chatgpt.com/codex/tasks/task_e_6867f826c088832696be14c78734d5ea