### PR TITLE
feat(wallet): add order checks on coin disable

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -232,6 +232,7 @@
     "clickAssetToRemoveHint": "Select assets to remove",
     "defaultCoinDisableWarning": "You can't disable {}, it is a default coin",
     "parentCoinDisableWarning": "Disabling {} will also disable its tokens: {}. Continue?",
+    "coinDisableOpenOrdersWarning": "There are {} open orders for {}. Cancel these orders and disable the coin?",
     "supportFrequentlyQuestionSpan": "Frequently asked questions",
     "support": "Support",
     "supportInfoTitle1": "Do you store my private keys?",

--- a/lib/blocs/trading_entities_bloc.dart
+++ b/lib/blocs/trading_entities_bloc.dart
@@ -54,9 +54,8 @@ class TradingEntitiesBloc implements BlocBase {
   Stream<List<Swap>> get outSwaps => _swapsController.stream;
   List<Swap> get swaps => _swaps;
   set swaps(List<Swap> swapList) {
-    swapList.sort(
-        (first, second) =>
-            (second.myInfo?.startedAt ?? 0) - (first.myInfo?.startedAt ?? 0));
+    swapList.sort((first, second) =>
+        (second.myInfo?.startedAt ?? 0) - (first.myInfo?.startedAt ?? 0));
     _swaps = swapList;
     _inSwaps.add(_swaps);
   }
@@ -105,6 +104,29 @@ class TradingEntitiesBloc implements BlocBase {
         0;
   }
 
+  bool hasActiveSwap(String coin) {
+    return _swaps
+        .where((swap) => !swap.isCompleted)
+        .any((swap) => swap.sellCoin == coin || swap.buyCoin == coin);
+  }
+
+  bool hasOpenOrders(String coin) {
+    return _myOrders.any((order) => order.base == coin || order.rel == coin);
+  }
+
+  int openOrdersCount(String coin) {
+    return _myOrders
+        .where((order) => order.base == coin || order.rel == coin)
+        .length;
+  }
+
+  Future<void> cancelOrdersForCoin(String coin) async {
+    final futures = _myOrders
+        .where((o) => o.base == coin || o.rel == coin)
+        .map((o) => cancelOrder(o.uuid));
+    await Future.wait(futures);
+  }
+
   double getPriceFromAmount(Rational sellAmount, Rational buyAmount) {
     final sellDoubleAmount = sellAmount.toDouble();
     final buyDoubleAmount = buyAmount.toDouble();
@@ -124,10 +146,8 @@ class TradingEntitiesBloc implements BlocBase {
         .map((id) => getSwap(id))
         .whereType<Swap>()
         .toList();
-    final double swapFill = swaps.fold(
-        0,
-        (previousValue, swap) =>
-            previousValue + (swap.myInfo?.myAmount ?? 0));
+    final double swapFill = swaps.fold(0,
+        (previousValue, swap) => previousValue + (swap.myInfo?.myAmount ?? 0));
     return swapFill / order.baseAmount.toDouble();
   }
 

--- a/lib/generated/codegen_loader.g.dart
+++ b/lib/generated/codegen_loader.g.dart
@@ -2,7 +2,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-abstract class  LocaleKeys {
+abstract class LocaleKeys {
   static const plsActivateKmd = 'plsActivateKmd';
   static const rewardClaiming = 'rewardClaiming';
   static const noKmdAddress = 'noKmdAddress';
@@ -106,39 +106,50 @@ abstract class  LocaleKeys {
   static const seedPhrase = 'seedPhrase';
   static const assetNumber = 'assetNumber';
   static const clipBoard = 'clipBoard';
-  static const walletsManagerCreateWalletButton = 'walletsManagerCreateWalletButton';
-  static const walletsManagerImportWalletButton = 'walletsManagerImportWalletButton';
-  static const walletsManagerStepBuilderCreationWalletError = 'walletsManagerStepBuilderCreationWalletError';
+  static const walletsManagerCreateWalletButton =
+      'walletsManagerCreateWalletButton';
+  static const walletsManagerImportWalletButton =
+      'walletsManagerImportWalletButton';
+  static const walletsManagerStepBuilderCreationWalletError =
+      'walletsManagerStepBuilderCreationWalletError';
   static const walletCreationTitle = 'walletCreationTitle';
   static const walletImportTitle = 'walletImportTitle';
   static const walletImportByFileTitle = 'walletImportByFileTitle';
-  static const walletImportCreatePasswordTitle = 'walletImportCreatePasswordTitle';
+  static const walletImportCreatePasswordTitle =
+      'walletImportCreatePasswordTitle';
   static const walletImportByFileDescription = 'walletImportByFileDescription';
   static const walletLogInTitle = 'walletLogInTitle';
   static const walletCreationNameHint = 'walletCreationNameHint';
   static const walletCreationPasswordHint = 'walletCreationPasswordHint';
-  static const walletCreationConfirmPasswordHint = 'walletCreationConfirmPasswordHint';
+  static const walletCreationConfirmPasswordHint =
+      'walletCreationConfirmPasswordHint';
   static const walletCreationConfirmPassword = 'walletCreationConfirmPassword';
   static const walletCreationUploadFile = 'walletCreationUploadFile';
   static const walletCreationEmptySeedError = 'walletCreationEmptySeedError';
   static const walletCreationExistNameError = 'walletCreationExistNameError';
   static const walletCreationNameLengthError = 'walletCreationNameLengthError';
-  static const walletCreationFormatPasswordError = 'walletCreationFormatPasswordError';
-  static const walletCreationConfirmPasswordError = 'walletCreationConfirmPasswordError';
+  static const walletCreationFormatPasswordError =
+      'walletCreationFormatPasswordError';
+  static const walletCreationConfirmPasswordError =
+      'walletCreationConfirmPasswordError';
   static const incorrectPassword = 'incorrectPassword';
   static const importSeedEnterSeedPhraseHint = 'importSeedEnterSeedPhraseHint';
   static const passphraseCheckingTitle = 'passphraseCheckingTitle';
   static const passphraseCheckingDescription = 'passphraseCheckingDescription';
   static const passphraseCheckingEnterWord = 'passphraseCheckingEnterWord';
-  static const passphraseCheckingEnterWordHint = 'passphraseCheckingEnterWordHint';
+  static const passphraseCheckingEnterWordHint =
+      'passphraseCheckingEnterWordHint';
   static const back = 'back';
   static const settingsMenuGeneral = 'settingsMenuGeneral';
   static const settingsMenuLanguage = 'settingsMenuLanguage';
   static const settingsMenuSecurity = 'settingsMenuSecurity';
   static const settingsMenuAbout = 'settingsMenuAbout';
-  static const seedPhraseSettingControlsViewSeed = 'seedPhraseSettingControlsViewSeed';
-  static const seedPhraseSettingControlsDownloadSeed = 'seedPhraseSettingControlsDownloadSeed';
-  static const debugSettingsResetActivatedCoins = 'debugSettingsResetActivatedCoins';
+  static const seedPhraseSettingControlsViewSeed =
+      'seedPhraseSettingControlsViewSeed';
+  static const seedPhraseSettingControlsDownloadSeed =
+      'seedPhraseSettingControlsDownloadSeed';
+  static const debugSettingsResetActivatedCoins =
+      'debugSettingsResetActivatedCoins';
   static const debugSettingsDownloadButton = 'debugSettingsDownloadButton';
   static const or = 'or';
   static const passwordTitle = 'passwordTitle';
@@ -148,16 +159,19 @@ abstract class  LocaleKeys {
   static const changePasswordSpan1 = 'changePasswordSpan1';
   static const updatePassword = 'updatePassword';
   static const passwordHasChanged = 'passwordHasChanged';
-  static const confirmationForShowingSeedPhraseTitle = 'confirmationForShowingSeedPhraseTitle';
+  static const confirmationForShowingSeedPhraseTitle =
+      'confirmationForShowingSeedPhraseTitle';
   static const saveAndRemember = 'saveAndRemember';
   static const seedPhraseShowingTitle = 'seedPhraseShowingTitle';
   static const seedPhraseShowingWarning = 'seedPhraseShowingWarning';
   static const seedPhraseShowingShowPhrase = 'seedPhraseShowingShowPhrase';
   static const seedPhraseShowingCopySeed = 'seedPhraseShowingCopySeed';
-  static const seedPhraseShowingSavedPhraseButton = 'seedPhraseShowingSavedPhraseButton';
+  static const seedPhraseShowingSavedPhraseButton =
+      'seedPhraseShowingSavedPhraseButton';
   static const seedAccessSpan1 = 'seedAccessSpan1';
   static const backupSeedNotificationTitle = 'backupSeedNotificationTitle';
-  static const backupSeedNotificationDescription = 'backupSeedNotificationDescription';
+  static const backupSeedNotificationDescription =
+      'backupSeedNotificationDescription';
   static const backupSeedNotificationButton = 'backupSeedNotificationButton';
   static const swapConfirmationTitle = 'swapConfirmationTitle';
   static const swapConfirmationYouReceive = 'swapConfirmationYouReceive';
@@ -165,41 +179,54 @@ abstract class  LocaleKeys {
   static const tradingDetailsTitleFailed = 'tradingDetailsTitleFailed';
   static const tradingDetailsTitleCompleted = 'tradingDetailsTitleCompleted';
   static const tradingDetailsTitleInProgress = 'tradingDetailsTitleInProgress';
-  static const tradingDetailsTitleOrderMatching = 'tradingDetailsTitleOrderMatching';
+  static const tradingDetailsTitleOrderMatching =
+      'tradingDetailsTitleOrderMatching';
   static const tradingDetailsTotalSpentTime = 'tradingDetailsTotalSpentTime';
-  static const tradingDetailsTotalSpentTimeWithHours = 'tradingDetailsTotalSpentTimeWithHours';
+  static const tradingDetailsTotalSpentTimeWithHours =
+      'tradingDetailsTotalSpentTimeWithHours';
   static const swapRecoverButtonTitle = 'swapRecoverButtonTitle';
   static const swapRecoverButtonText = 'swapRecoverButtonText';
   static const swapRecoverButtonErrorMessage = 'swapRecoverButtonErrorMessage';
-  static const swapRecoverButtonSuccessMessage = 'swapRecoverButtonSuccessMessage';
+  static const swapRecoverButtonSuccessMessage =
+      'swapRecoverButtonSuccessMessage';
   static const swapProgressStatusFailed = 'swapProgressStatusFailed';
   static const swapDetailsStepStatusFailed = 'swapDetailsStepStatusFailed';
   static const disclaimerAcceptEulaCheckbox = 'disclaimerAcceptEulaCheckbox';
-  static const disclaimerAcceptTermsAndConditionsCheckbox = 'disclaimerAcceptTermsAndConditionsCheckbox';
+  static const disclaimerAcceptTermsAndConditionsCheckbox =
+      'disclaimerAcceptTermsAndConditionsCheckbox';
   static const disclaimerAcceptDescription = 'disclaimerAcceptDescription';
-  static const swapDetailsStepStatusInProcess = 'swapDetailsStepStatusInProcess';
-  static const swapDetailsStepStatusTimeSpent = 'swapDetailsStepStatusTimeSpent';
+  static const swapDetailsStepStatusInProcess =
+      'swapDetailsStepStatusInProcess';
+  static const swapDetailsStepStatusTimeSpent =
+      'swapDetailsStepStatusTimeSpent';
   static const milliseconds = 'milliseconds';
   static const seconds = 'seconds';
   static const minutes = 'minutes';
   static const hours = 'hours';
-  static const coinAddressDetailsNotificationTitle = 'coinAddressDetailsNotificationTitle';
-  static const coinAddressDetailsNotificationDescription = 'coinAddressDetailsNotificationDescription';
+  static const coinAddressDetailsNotificationTitle =
+      'coinAddressDetailsNotificationTitle';
+  static const coinAddressDetailsNotificationDescription =
+      'coinAddressDetailsNotificationDescription';
   static const swapFeeDetailsPaidFromBalance = 'swapFeeDetailsPaidFromBalance';
   static const swapFeeDetailsSendCoinTxFee = 'swapFeeDetailsSendCoinTxFee';
-  static const swapFeeDetailsReceiveCoinTxFee = 'swapFeeDetailsReceiveCoinTxFee';
+  static const swapFeeDetailsReceiveCoinTxFee =
+      'swapFeeDetailsReceiveCoinTxFee';
   static const swapFeeDetailsTradingFee = 'swapFeeDetailsTradingFee';
-  static const swapFeeDetailsSendTradingFeeTxFee = 'swapFeeDetailsSendTradingFeeTxFee';
+  static const swapFeeDetailsSendTradingFeeTxFee =
+      'swapFeeDetailsSendTradingFeeTxFee';
   static const swapFeeDetailsNone = 'swapFeeDetailsNone';
-  static const swapFeeDetailsPaidFromReceivedVolume = 'swapFeeDetailsPaidFromReceivedVolume';
+  static const swapFeeDetailsPaidFromReceivedVolume =
+      'swapFeeDetailsPaidFromReceivedVolume';
   static const logoutPopupTitle = 'logoutPopupTitle';
-  static const logoutPopupDescriptionWalletOnly = 'logoutPopupDescriptionWalletOnly';
+  static const logoutPopupDescriptionWalletOnly =
+      'logoutPopupDescriptionWalletOnly';
   static const logoutPopupDescription = 'logoutPopupDescription';
   static const transactionDetailsTitle = 'transactionDetailsTitle';
   static const customSeedWarningText = 'customSeedWarningText';
   static const customSeedIUnderstand = 'customSeedIUnderstand';
   static const walletCreationBip39SeedError = 'walletCreationBip39SeedError';
-  static const walletCreationHdBip39SeedError = 'walletCreationHdBip39SeedError';
+  static const walletCreationHdBip39SeedError =
+      'walletCreationHdBip39SeedError';
   static const walletPageNoSuchAsset = 'walletPageNoSuchAsset';
   static const swapCoin = 'swapCoin';
   static const fiatBalance = 'fiatBalance';
@@ -229,6 +256,7 @@ abstract class  LocaleKeys {
   static const clickAssetToRemoveHint = 'clickAssetToRemoveHint';
   static const defaultCoinDisableWarning = 'defaultCoinDisableWarning';
   static const parentCoinDisableWarning = 'parentCoinDisableWarning';
+  static const coinDisableOpenOrdersWarning = 'coinDisableOpenOrdersWarning';
   static const supportFrequentlyQuestionSpan = 'supportFrequentlyQuestionSpan';
   static const support = 'support';
   static const supportInfoTitle1 = 'supportInfoTitle1';
@@ -272,7 +300,8 @@ abstract class  LocaleKeys {
   static const sellCryptoDescription = 'sellCryptoDescription';
   static const buy = 'buy';
   static const changingWalletPassword = 'changingWalletPassword';
-  static const changingWalletPasswordDescription = 'changingWalletPasswordDescription';
+  static const changingWalletPasswordDescription =
+      'changingWalletPasswordDescription';
   static const dark = 'dark';
   static const darkMode = 'darkMode';
   static const light = 'light';
@@ -295,7 +324,8 @@ abstract class  LocaleKeys {
   static const email = 'email';
   static const emailValidatorError = 'emailValidatorError';
   static const feedbackValidatorEmptyError = 'feedbackValidatorEmptyError';
-  static const feedbackValidatorMaxLengthError = 'feedbackValidatorMaxLengthError';
+  static const feedbackValidatorMaxLengthError =
+      'feedbackValidatorMaxLengthError';
   static const yourFeedback = 'yourFeedback';
   static const sendFeedback = 'sendFeedback';
   static const sendFeedbackError = 'sendFeedbackError';
@@ -344,7 +374,8 @@ abstract class  LocaleKeys {
   static const noSenderAddress = 'noSenderAddress';
   static const confirmOnTrezor = 'confirmOnTrezor';
   static const alphaVersionWarningTitle = 'alphaVersionWarningTitle';
-  static const alphaVersionWarningDescription = 'alphaVersionWarningDescription';
+  static const alphaVersionWarningDescription =
+      'alphaVersionWarningDescription';
   static const sendToAnalytics = 'sendToAnalytics';
   static const backToWallet = 'backToWallet';
   static const backToDex = 'backToDex';
@@ -366,12 +397,14 @@ abstract class  LocaleKeys {
   static const currentPassword = 'currentPassword';
   static const walletNotFound = 'walletNotFound';
   static const passwordIsEmpty = 'passwordIsEmpty';
-  static const passwordContainsTheWordPassword = 'passwordContainsTheWordPassword';
+  static const passwordContainsTheWordPassword =
+      'passwordContainsTheWordPassword';
   static const passwordTooShort = 'passwordTooShort';
   static const passwordMissingDigit = 'passwordMissingDigit';
   static const passwordMissingLowercase = 'passwordMissingLowercase';
   static const passwordMissingUppercase = 'passwordMissingUppercase';
-  static const passwordMissingSpecialCharacter = 'passwordMissingSpecialCharacter';
+  static const passwordMissingSpecialCharacter =
+      'passwordMissingSpecialCharacter';
   static const passwordConsecutiveCharacters = 'passwordConsecutiveCharacters';
   static const passwordSecurity = 'passwordSecurity';
   static const allowWeakPassword = 'allowWeakPassword';
@@ -400,13 +433,16 @@ abstract class  LocaleKeys {
   static const bridgeMaxSendAmountError = 'bridgeMaxSendAmountError';
   static const bridgeMinOrderAmountError = 'bridgeMinOrderAmountError';
   static const bridgeMaxOrderAmountError = 'bridgeMaxOrderAmountError';
-  static const bridgeInsufficientBalanceError = 'bridgeInsufficientBalanceError';
+  static const bridgeInsufficientBalanceError =
+      'bridgeInsufficientBalanceError';
   static const lowTradeVolumeError = 'lowTradeVolumeError';
   static const bridgeSelectReceiveCoinError = 'bridgeSelectReceiveCoinError';
   static const withdrawNoParentCoinError = 'withdrawNoParentCoinError';
   static const withdrawTopUpBalanceError = 'withdrawTopUpBalanceError';
-  static const withdrawNotEnoughBalanceForGasError = 'withdrawNotEnoughBalanceForGasError';
-  static const withdrawNotSufficientBalanceError = 'withdrawNotSufficientBalanceError';
+  static const withdrawNotEnoughBalanceForGasError =
+      'withdrawNotEnoughBalanceForGasError';
+  static const withdrawNotSufficientBalanceError =
+      'withdrawNotSufficientBalanceError';
   static const withdrawZeroBalanceError = 'withdrawZeroBalanceError';
   static const withdrawAmountTooLowError = 'withdrawAmountTooLowError';
   static const withdrawNoSuchCoinError = 'withdrawNoSuchCoinError';
@@ -478,8 +514,10 @@ abstract class  LocaleKeys {
   static const availableForSwaps = 'availableForSwaps';
   static const swapNow = 'swapNow';
   static const passphrase = 'passphrase';
-  static const enterPassphraseHiddenWalletTitle = 'enterPassphraseHiddenWalletTitle';
-  static const enterPassphraseHiddenWalletDescription = 'enterPassphraseHiddenWalletDescription';
+  static const enterPassphraseHiddenWalletTitle =
+      'enterPassphraseHiddenWalletTitle';
+  static const enterPassphraseHiddenWalletDescription =
+      'enterPassphraseHiddenWalletDescription';
   static const skip = 'skip';
   static const activateToSeeFunds = 'activateToSeeFunds';
   static const allowCustomFee = 'allowCustomFee';
@@ -543,8 +581,10 @@ abstract class  LocaleKeys {
   static const collectibles = 'collectibles';
   static const sendingProcess = 'sendingProcess';
   static const ercStandardDisclaimer = 'ercStandardDisclaimer';
-  static const nftReceiveNonSwapAddressWarning = 'nftReceiveNonSwapAddressWarning';
-  static const nftReceiveNonSwapWalletDetails = 'nftReceiveNonSwapWalletDetails';
+  static const nftReceiveNonSwapAddressWarning =
+      'nftReceiveNonSwapAddressWarning';
+  static const nftReceiveNonSwapWalletDetails =
+      'nftReceiveNonSwapWalletDetails';
   static const nftMainLoggedOut = 'nftMainLoggedOut';
   static const confirmLogoutOnAnotherTab = 'confirmLogoutOnAnotherTab';
   static const refreshList = 'refreshList';
@@ -558,8 +598,10 @@ abstract class  LocaleKeys {
   static const noWalletsAvailable = 'noWalletsAvailable';
   static const selectWalletToReset = 'selectWalletToReset';
   static const qrScannerTitle = 'qrScannerTitle';
-  static const qrScannerErrorControllerUninitialized = 'qrScannerErrorControllerUninitialized';
-  static const qrScannerErrorPermissionDenied = 'qrScannerErrorPermissionDenied';
+  static const qrScannerErrorControllerUninitialized =
+      'qrScannerErrorControllerUninitialized';
+  static const qrScannerErrorPermissionDenied =
+      'qrScannerErrorPermissionDenied';
   static const qrScannerErrorGenericError = 'qrScannerErrorGenericError';
   static const qrScannerErrorTitle = 'qrScannerErrorTitle';
   static const spend = 'spend';
@@ -604,7 +646,8 @@ abstract class  LocaleKeys {
   static const fiatPaymentInProgressMessage = 'fiatPaymentInProgressMessage';
   static const pleaseWait = 'pleaseWait';
   static const bitrefillPaymentSuccessfull = 'bitrefillPaymentSuccessfull';
-  static const bitrefillPaymentSuccessfullInstruction = 'bitrefillPaymentSuccessfullInstruction';
+  static const bitrefillPaymentSuccessfullInstruction =
+      'bitrefillPaymentSuccessfullInstruction';
   static const tradingBot = 'tradingBot';
   static const margin = 'margin';
   static const updateInterval = 'updateInterval';
@@ -680,5 +723,4 @@ abstract class  LocaleKeys {
   static const chart = 'chart';
   static const tradingDisabledTooltip = 'tradingDisabledTooltip';
   static const tradingDisabled = 'tradingDisabled';
-
 }

--- a/lib/shared/utils/utils.dart
+++ b/lib/shared/utils/utils.dart
@@ -40,7 +40,8 @@ Future<void> copyToClipBoard(
 
     if (!context.mounted) return;
     final scaffoldMessenger = ScaffoldMessenger.maybeOf(context) ??
-        ScaffoldMessenger.of(scaffoldKey.currentContext!);    scaffoldMessenger.showSnackBar(
+        ScaffoldMessenger.of(scaffoldKey.currentContext!);
+    scaffoldMessenger.showSnackBar(
       SnackBar(
         width: isMobile ? null : 400.0,
         content: Row(
@@ -61,7 +62,7 @@ Future<void> copyToClipBoard(
     );
   } catch (e) {
     log('Error copyToClipBoard: $e', isError: true);
-    if (!context.mounted) return;    // Show error feedback using SnackBar
+    if (!context.mounted) return; // Show error feedback using SnackBar
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: const Text('Failed to copy to clipboard'),
@@ -719,6 +720,34 @@ Future<bool> confirmParentCoinDisable(
       title: Text(LocaleKeys.disable.tr()),
       content: Text(
         LocaleKeys.parentCoinDisableWarning.tr(args: [parent, tokenList]),
+      ),
+      actions: [
+        TextButton(
+          child: Text(LocaleKeys.cancel.tr()),
+          onPressed: () => Navigator.of(context).pop(false),
+        ),
+        TextButton(
+          child: Text(LocaleKeys.disable.tr()),
+          onPressed: () => Navigator.of(context).pop(true),
+        ),
+      ],
+    ),
+  );
+  return result ?? false;
+}
+
+Future<bool> confirmCoinDisableWithOrders(
+  BuildContext context, {
+  required String coin,
+  required int ordersCount,
+}) async {
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(LocaleKeys.disable.tr()),
+      content: Text(
+        LocaleKeys.coinDisableOpenOrdersWarning
+            .tr(args: [ordersCount.toString(), coin]),
       ),
       actions: [
         TextButton(


### PR DESCRIPTION
## Summary
- prevent coin deactivation when swaps are in progress for coin or its tokens
- warn about open orders and allow cancelling them
- add translation for open orders disable warning

## Testing
- `flutter pub get --enforce-lockfile`
- `dart format lib/blocs/trading_entities_bloc.dart lib/shared/utils/utils.dart lib/views/wallet/coins_manager/coins_manager_list_wrapper.dart lib/generated/codegen_loader.g.dart`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_686d6d0cb5e48326a0d06a63b904a0de