### PR TITLE
fix(auth): trezor auth flow and wallet main state updates

### DIFF
--- a/lib/bloc/auth_bloc/auth_bloc.dart
+++ b/lib/bloc/auth_bloc/auth_bloc.dart
@@ -2,11 +2,11 @@ import 'dart:async';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:komodo_defi_rpc_methods/komodo_defi_rpc_methods.dart'
+    show PrivateKeyPolicy;
 import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 import 'package:logging/logging.dart';
-import 'package:komodo_defi_rpc_methods/komodo_defi_rpc_methods.dart'
-    show PrivateKeyPolicy;
 import 'package:web_dex/app_config/app_config.dart';
 import 'package:web_dex/bloc/settings/settings_repository.dart';
 import 'package:web_dex/blocs/wallets_repository.dart';
@@ -327,12 +327,16 @@ class AuthBloc extends Bloc<AuthBlocEvent, AuthBlocState> with TrezorAuthMixin {
     Emitter<AuthBlocState> emit,
   ) async {
     final currentUser = await _kdfSdk.auth.currentUser;
-    if (currentUser != null) {
+    final isTrezorWallet = currentUser?.walletId.authOptions.privKeyPolicy ==
+        const PrivateKeyPolicy.trezor();
+
+    if (currentUser != null && !isTrezorWallet) {
       emit(AuthBlocState.loggedIn(currentUser));
       _listenToAuthStateChanges();
     }
   }
 
+  @override
   void _listenToAuthStateChanges() {
     _authChangesSubscription?.cancel();
     _authChangesSubscription = _kdfSdk.auth.watchCurrentUser().listen((user) {


### PR DESCRIPTION
Fixes the Trezor auth login bug by 

- Calling `setState` in `addPostFrameCallback` to fix the issue with BlocConsumer not calling the builder function for auth state updates (successful login). 
- Skipping the lifecycle resume check for Trezor for now until the connection status RPC can be incorporated to check the connection status on resume.

## Before

https://github.com/user-attachments/assets/7d604bae-885d-4f0d-be64-22214c5e034c

## After

https://github.com/user-attachments/assets/9e0ec908-ce52-4dcf-993a-759e6437e317


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab navigation stability in the wallet view, ensuring smoother updates when authentication status changes.
  * Enhanced authentication handling to better support Trezor wallets, preventing certain users from being incorrectly logged in.

* **Refactor**
  * Streamlined internal state management for authentication and wallet tab controls for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->