### PR TITLE
feat(trading): integrate geo blocker api

### DIFF
--- a/lib/bloc/trading_status/trading_status_repository.dart
+++ b/lib/bloc/trading_status/trading_status_repository.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
+import 'package:komodo_defi_types/komodo_defi_type_utils.dart';
+import 'package:web_dex/shared/constants.dart';
 
 class TradingStatusRepository {
   TradingStatusRepository({http.Client? httpClient, Duration? timeout})
@@ -12,13 +14,34 @@ class TradingStatusRepository {
 
   Future<bool> isTradingEnabled({bool? forceFail}) async {
     try {
-      final uri = Uri.parse(
-        (forceFail ?? false)
-            ? 'https://defi-stats.komodo.earth/api/v3/utils/blacklist'
-            : 'https://defi-stats.komodo.earth/api/v3/utils/bouncer',
-      );
-      final res = await _httpClient.get(uri).timeout(_timeout);
-      return res.statusCode == 200;
+      final apiKey = const String.fromEnvironment('FEEDBACK_API_KEY');
+      final bool shouldFail = forceFail ?? false;
+
+      late final Uri uri;
+      final headers = <String, String>{};
+
+      if (shouldFail) {
+        uri = Uri.parse(tradingBlacklistUrl);
+      } else if (apiKey.isNotEmpty) {
+        uri = Uri.parse(geoBlockerApiUrl);
+        headers['X-KW-KEY'] = apiKey;
+      } else {
+        debugPrint(
+          'Warning: FEEDBACK_API_KEY not found. Using legacy geo-blocker.',
+        );
+        uri = Uri.parse(legacyGeoBlockerUrl);
+      }
+
+      final res =
+          await _httpClient.get(uri, headers: headers).timeout(_timeout);
+
+      if (apiKey.isNotEmpty && !shouldFail) {
+        if (res.statusCode != 200) return false;
+        final JsonMap data = jsonFromString(res.body);
+        return !(data.valueOrNull<bool>('blocked') ?? true);
+      } else {
+        return res.statusCode == 200;
+      }
     } catch (_) {
       debugPrint('Network error: Trading status check failed');
       // Block trading features on network failure

--- a/lib/shared/constants.dart
+++ b/lib/shared/constants.dart
@@ -44,3 +44,10 @@ const bool isTestMode =
     bool.fromEnvironment('testing_mode', defaultValue: false);
 const String moralisProxyUrl = 'https://moralis-proxy.komodo.earth';
 const String nftAntiSpamUrl = 'https://nft.antispam.dragonhound.info';
+
+const String geoBlockerApiUrl =
+    'https://komodo-wallet-bouncer.komodoplatform.com';
+const String legacyGeoBlockerUrl =
+    'https://defi-stats.komodo.earth/api/v3/utils/bouncer';
+const String tradingBlacklistUrl =
+    'https://defi-stats.komodo.earth/api/v3/utils/blacklist';


### PR DESCRIPTION
## Summary
- integrate new geo blocker API service using FEEDBACK_API_KEY
- log warning and fall back to legacy service when key is missing
- define geo-blocker URLs in constants

## Testing
- `flutter pub get --enforce-lockfile`
- `dart format .`
- `flutter analyze` *(fails: 485 issues)*

------
https://chatgpt.com/codex/tasks/task_e_686e9c379a508326981602b5bbc4e44a