### PR TITLE
chore: bump version to 0.9.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.9.1+1
+version: 0.9.2+1
 
 environment:
   # TODO: Upgrade mininum Dart version to 3.7.0 only after the release is concluded because

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.9.2+1
+version: 0.9.2+0
 
 environment:
   # TODO: Upgrade mininum Dart version to 3.7.0 only after the release is concluded because


### PR DESCRIPTION
## Summary
- bump version number from `0.9.1` to `0.9.2`

## Testing
- `flutter analyze`
- `dart format .`

------
https://chatgpt.com/codex/tasks/task_e_686eb40aedcc8326a276ef00a5a2ab81