### PR TITLE
fix(trading): remove legacy fallback

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -682,5 +682,5 @@
     "searchAddresses": "Search addresses",
     "trend7d": "7d trend",
     "tradingDisabledTooltip": "Trading features are currently disabled",
-    "tradingDisabled": "Trading is currently unavailable"
+    "tradingDisabled": "Trading unavailable in your location"
 }

--- a/lib/shared/constants.dart
+++ b/lib/shared/constants.dart
@@ -47,7 +47,5 @@ const String nftAntiSpamUrl = 'https://nft.antispam.dragonhound.info';
 
 const String geoBlockerApiUrl =
     'https://komodo-wallet-bouncer.komodoplatform.com';
-const String legacyGeoBlockerUrl =
-    'https://defi-stats.komodo.earth/api/v3/utils/bouncer';
 const String tradingBlacklistUrl =
     'https://defi-stats.komodo.earth/api/v3/utils/blacklist';


### PR DESCRIPTION
## Summary
- remove legacy geo-blocker fallback and return disabled when missing API key
- update trading disabled text

## Testing
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_686f8ef8c7f88326a55d9f0cc3129801