### PR TITLE
refactor(feedback): adopt bloc pattern

### DIFF
--- a/lib/bloc/feedback_form/feedback_form_bloc.dart
+++ b/lib/bloc/feedback_form/feedback_form_bloc.dart
@@ -1,0 +1,207 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:feedback/feedback.dart';
+import 'package:web_dex/generated/codegen_loader.g.dart';
+import 'package:web_dex/shared/constants.dart';
+import 'package:web_dex/services/feedback/feedback_models.dart';
+
+part 'feedback_form_event.dart';
+part 'feedback_form_state.dart';
+
+class FeedbackFormBloc extends Bloc<FeedbackFormEvent, FeedbackFormState> {
+  FeedbackFormBloc(this._onSubmit) : super(const FeedbackFormState()) {
+    on<FeedbackFormTypeChanged>(_onTypeChanged);
+    on<FeedbackFormMessageChanged>(_onMessageChanged);
+    on<FeedbackFormContactMethodChanged>(_onContactMethodChanged);
+    on<FeedbackFormContactDetailsChanged>(_onContactDetailsChanged);
+    on<FeedbackFormSubmitted>(_onSubmitted);
+  }
+
+  final OnSubmit _onSubmit;
+
+  void _onTypeChanged(
+    FeedbackFormTypeChanged event,
+    Emitter<FeedbackFormState> emit,
+  ) {
+    final contactError = _validateContactDetails(
+      state.contactDetails,
+      event.type,
+      state.contactMethod,
+    );
+    emit(state.copyWith(
+      feedbackType: event.type,
+      contactDetailsError: contactError,
+    ));
+  }
+
+  void _onMessageChanged(
+    FeedbackFormMessageChanged event,
+    Emitter<FeedbackFormState> emit,
+  ) {
+    final text = _sanitizeInput(event.message);
+    emit(state.copyWith(
+      feedbackText: text,
+      feedbackTextError: _validateFeedbackText(text),
+    ));
+  }
+
+  void _onContactMethodChanged(
+    FeedbackFormContactMethodChanged event,
+    Emitter<FeedbackFormState> emit,
+  ) {
+    final error = _validateContactDetails(
+      state.contactDetails,
+      state.feedbackType,
+      event.method,
+    );
+    emit(state.copyWith(
+        contactMethod: event.method, contactDetailsError: error));
+  }
+
+  void _onContactDetailsChanged(
+    FeedbackFormContactDetailsChanged event,
+    Emitter<FeedbackFormState> emit,
+  ) {
+    final details = _sanitizeInput(event.details);
+    final error = _validateContactDetails(
+      details,
+      state.feedbackType,
+      state.contactMethod,
+    );
+    emit(state.copyWith(contactDetails: details, contactDetailsError: error));
+  }
+
+  Future<void> _onSubmitted(
+    FeedbackFormSubmitted event,
+    Emitter<FeedbackFormState> emit,
+  ) async {
+    final feedbackErr = _validateFeedbackText(state.feedbackText);
+    final contactErr = _validateContactDetails(
+      state.contactDetails,
+      state.feedbackType,
+      state.contactMethod,
+    );
+
+    if (state.feedbackType == null ||
+        feedbackErr != null ||
+        contactErr != null) {
+      emit(state.copyWith(
+        feedbackTextError: feedbackErr,
+        contactDetailsError: contactErr,
+      ));
+      return;
+    }
+
+    emit(state.copyWith(status: FeedbackFormStatus.submitting));
+    try {
+      final data = CustomFeedback(
+        feedbackType: state.feedbackType,
+        feedbackText: state.feedbackText,
+        contactMethod: state.contactMethod,
+        contactDetails:
+            state.contactDetails.isNotEmpty ? state.contactDetails : null,
+      );
+      await _onSubmit(
+        data.toFormattedDescription(),
+        extras: data.toMap(),
+      );
+      emit(state.copyWith(status: FeedbackFormStatus.success));
+    } catch (e) {
+      emit(state.copyWith(
+          status: FeedbackFormStatus.failure, errorMessage: '$e'));
+    }
+  }
+
+  String? _validateFeedbackText(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return LocaleKeys.feedbackValidatorEmptyError.tr();
+    }
+    if (trimmed.length > feedbackMaxLength) {
+      return LocaleKeys.feedbackValidatorMaxLengthError.tr(
+        args: [feedbackMaxLength.toString()],
+      );
+    }
+    return null;
+  }
+
+  String? _validateContactDetails(
+    String value,
+    FeedbackType? type,
+    ContactMethod? method,
+  ) {
+    final trimmed = value.trim();
+    final hasMethod = method != null;
+    final hasDetails = trimmed.isNotEmpty;
+
+    if (type == FeedbackType.support) {
+      if (!hasMethod || !hasDetails) {
+        return LocaleKeys.contactRequiredError.tr();
+      }
+    } else {
+      if ((hasMethod && !hasDetails) || (!hasMethod && hasDetails)) {
+        return LocaleKeys.contactRequiredError.tr();
+      }
+    }
+
+    if (!hasDetails) {
+      return null;
+    }
+
+    if (trimmed.length > contactDetailsMaxLength) {
+      return 'Contact details must be $contactDetailsMaxLength characters or less';
+    }
+
+    switch (method) {
+      case ContactMethod.email:
+        if (!_isValidEmail(trimmed)) {
+          return LocaleKeys.emailValidatorError.tr();
+        }
+        break;
+      case ContactMethod.discord:
+        if (!_isValidDiscordUsername(trimmed)) {
+          return 'Please enter a valid Discord username (2-32 characters, letters, numbers, dots, underscores)';
+        }
+        break;
+      case ContactMethod.telegram:
+        if (!_isValidTelegramUsername(trimmed)) {
+          return 'Please enter a valid Telegram username (5-32 characters, letters, numbers, underscores)';
+        }
+        break;
+      case ContactMethod.matrix:
+        if (!_isValidMatrixId(trimmed)) {
+          return 'Please enter a valid Matrix ID (e.g., @username:server.com)';
+        }
+        break;
+      case null:
+        break;
+    }
+    return null;
+  }
+
+  String _sanitizeInput(String input) {
+    return input
+        .trim()
+        .replaceAll(RegExp(r'<[^>]*>'), '')
+        .replaceAll(
+            RegExp(r'<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>',
+                caseSensitive: false),
+            '')
+        .replaceAll(RegExp(r'javascript:', caseSensitive: false), '')
+        .replaceAll(RegExp(r'data:[^,]*script[^,]*,', caseSensitive: false), '')
+        .replaceAll(RegExp(r'\n{3,}'), '\n\n');
+  }
+
+  bool _isValidEmail(String email) => emailRegex.hasMatch(email);
+
+  bool _isValidDiscordUsername(String username) =>
+      discordUsernameRegex.hasMatch(username);
+
+  bool _isValidTelegramUsername(String username) {
+    final clean = username.startsWith('@') ? username.substring(1) : username;
+    return telegramUsernameRegex.hasMatch(clean);
+  }
+
+  bool _isValidMatrixId(String matrixId) => matrixIdRegex.hasMatch(matrixId);
+}

--- a/lib/bloc/feedback_form/feedback_form_event.dart
+++ b/lib/bloc/feedback_form/feedback_form_event.dart
@@ -1,0 +1,48 @@
+part of 'feedback_form_bloc.dart';
+
+sealed class FeedbackFormEvent extends Equatable {
+  const FeedbackFormEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class FeedbackFormTypeChanged extends FeedbackFormEvent {
+  const FeedbackFormTypeChanged(this.type);
+
+  final FeedbackType? type;
+
+  @override
+  List<Object?> get props => [type];
+}
+
+class FeedbackFormMessageChanged extends FeedbackFormEvent {
+  const FeedbackFormMessageChanged(this.message);
+
+  final String message;
+
+  @override
+  List<Object?> get props => [message];
+}
+
+class FeedbackFormContactMethodChanged extends FeedbackFormEvent {
+  const FeedbackFormContactMethodChanged(this.method);
+
+  final ContactMethod? method;
+
+  @override
+  List<Object?> get props => [method];
+}
+
+class FeedbackFormContactDetailsChanged extends FeedbackFormEvent {
+  const FeedbackFormContactDetailsChanged(this.details);
+
+  final String details;
+
+  @override
+  List<Object?> get props => [details];
+}
+
+class FeedbackFormSubmitted extends FeedbackFormEvent {
+  const FeedbackFormSubmitted();
+}

--- a/lib/bloc/feedback_form/feedback_form_state.dart
+++ b/lib/bloc/feedback_form/feedback_form_state.dart
@@ -1,0 +1,65 @@
+part of 'feedback_form_bloc.dart';
+
+enum FeedbackFormStatus { initial, submitting, success, failure }
+
+class FeedbackFormState extends Equatable {
+  const FeedbackFormState({
+    this.feedbackType,
+    this.feedbackText = '',
+    this.feedbackTextError,
+    this.contactMethod,
+    this.contactDetails = '',
+    this.contactDetailsError,
+    this.status = FeedbackFormStatus.initial,
+    this.errorMessage,
+  });
+
+  final FeedbackType? feedbackType;
+  final String feedbackText;
+  final String? feedbackTextError;
+  final ContactMethod? contactMethod;
+  final String contactDetails;
+  final String? contactDetailsError;
+  final FeedbackFormStatus status;
+  final String? errorMessage;
+
+  bool get isValid =>
+      feedbackType != null &&
+      feedbackTextError == null &&
+      contactDetailsError == null &&
+      feedbackText.trim().isNotEmpty;
+
+  FeedbackFormState copyWith({
+    FeedbackType? feedbackType,
+    String? feedbackText,
+    String? feedbackTextError,
+    ContactMethod? contactMethod,
+    String? contactDetails,
+    String? contactDetailsError,
+    FeedbackFormStatus? status,
+    String? errorMessage,
+  }) {
+    return FeedbackFormState(
+      feedbackType: feedbackType ?? this.feedbackType,
+      feedbackText: feedbackText ?? this.feedbackText,
+      feedbackTextError: feedbackTextError,
+      contactMethod: contactMethod ?? this.contactMethod,
+      contactDetails: contactDetails ?? this.contactDetails,
+      contactDetailsError: contactDetailsError,
+      status: status ?? this.status,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        feedbackType,
+        feedbackText,
+        feedbackTextError,
+        contactMethod,
+        contactDetails,
+        contactDetailsError,
+        status,
+        errorMessage,
+      ];
+}

--- a/lib/services/feedback/custom_feedback_form.dart
+++ b/lib/services/feedback/custom_feedback_form.dart
@@ -1,547 +1,210 @@
 import 'package:feedback/feedback.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
+import 'package:web_dex/bloc/feedback_form/feedback_form_bloc.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
+import 'package:web_dex/services/feedback/feedback_models.dart';
 import 'package:web_dex/shared/constants.dart';
 
-/// A data type holding user feedback consisting of a feedback type and free-form text
-class CustomFeedback {
-  CustomFeedback({
-    this.feedbackType,
-    this.feedbackText,
-    this.contactMethod,
-    this.contactDetails,
-  });
-
-  FeedbackType? feedbackType;
-  String? feedbackText;
-  ContactMethod? contactMethod;
-  String? contactDetails;
-
-  @override
-  String toString() {
-    return {
-      'feedback_type': feedbackType.toString(),
-      'feedback_text': feedbackText,
-      'contact_method': contactMethod?.name,
-      'contact_details': contactDetails,
-    }.toString();
-  }
-
-  Map<String, dynamic> toMap() {
-    return <String, dynamic>{
-      'feedback_type': feedbackType.toString(),
-      'feedback_text': feedbackText,
-      'contact_method': contactMethod?.name,
-      'contact_details': contactDetails,
-    };
-  }
-
-  /// Creates a properly formatted description for agent review
-  String toFormattedDescription() {
-    final buffer = StringBuffer();
-
-    // Header with feedback type
-    buffer.writeln('═══════════════════════════════════════');
-    buffer
-        .writeln('📋 ${feedbackType?.description ?? 'Unknown'}'.toUpperCase());
-    buffer.writeln('═══════════════════════════════════════');
-    buffer.writeln();
-
-    // User feedback content
-    buffer.writeln('💬 USER FEEDBACK:');
-    buffer.writeln('─' * 40);
-    if (feedbackText?.trim().isNotEmpty == true) {
-      // Split into paragraphs and format nicely
-      final paragraphs = feedbackText!.trim().split('\n');
-      for (int i = 0; i < paragraphs.length; i++) {
-        final paragraph = paragraphs[i].trim();
-        if (paragraph.isNotEmpty) {
-          buffer.writeln('   $paragraph');
-          if (i < paragraphs.length - 1) buffer.writeln();
-        }
-      }
-    } else {
-      buffer.writeln('   [No feedback text provided]');
-    }
-    buffer.writeln();
-
-    // Contact information section
-    buffer.writeln('📞 CONTACT INFORMATION:');
-    buffer.writeln('─' * 40);
-    if (contactMethod != null && contactDetails?.trim().isNotEmpty == true) {
-      final contact = contactDetails!.trim();
-
-      switch (contactMethod!) {
-        case ContactMethod.email:
-          buffer.writeln('   📧 Email: $contact');
-          break;
-        case ContactMethod.discord:
-          buffer.writeln('   🎮 Discord: $contact');
-          break;
-        case ContactMethod.telegram:
-          buffer.writeln(
-              '   📱 Telegram: ${contact.startsWith('@') ? contact : '@$contact'}');
-          break;
-        case ContactMethod.matrix:
-          buffer.writeln('   🔗 Matrix: $contact');
-          break;
-      }
-
-      // Add priority indicator for support requests
-      if (feedbackType == FeedbackType.support) {
-        buffer.writeln(
-            '   ⚠️  PRIORITY: Contact details provided for support request');
-      }
-    } else {
-      buffer.writeln('   ❌ No contact information provided');
-      if (feedbackType == FeedbackType.support) {
-        buffer.writeln(
-            '   ⚠️  WARNING: Support request without contact details!');
-      }
-    }
-
-    return buffer.toString();
-  }
-}
-
-/// What type of feedback the user wants to provide.
-enum FeedbackType {
-  bugReport,
-  featureRequest,
-  support,
-  other;
-
-  // TODO: Localisation
-  String get description {
-    switch (this) {
-      case bugReport:
-        return 'Bug Report';
-      case featureRequest:
-        return 'Feature Request';
-      case support:
-        return 'Support Request';
-      case other:
-        return 'Other';
-    }
-  }
-}
-
-/// A form that prompts the user for the type of feedback they want to give and free form text feedback.
-/// The submit button is disabled until the user provides the feedback type. All other fields are optional.
-class CustomFeedbackForm extends StatefulWidget {
+/// A form that prompts the user for feedback using BLoC for state management.
+class CustomFeedbackForm extends StatelessWidget {
   const CustomFeedbackForm({
     super.key,
-    required this.onSubmit,
     required this.scrollController,
   });
 
-  final OnSubmit onSubmit;
   final ScrollController? scrollController;
 
   static FeedbackBuilder get feedbackBuilder =>
-      (context, onSubmit, scrollController) => CustomFeedbackForm(
-            onSubmit: onSubmit,
-            scrollController: scrollController,
+      (context, onSubmit, scrollController) => BlocProvider(
+            create: (_) => FeedbackFormBloc(onSubmit),
+            child: CustomFeedbackForm(scrollController: scrollController),
           );
 
   @override
-  State<CustomFeedbackForm> createState() => _CustomFeedbackFormState();
-}
-
-// TODO: Refactor into a bloc and show validation errors.
-class _CustomFeedbackFormState extends State<CustomFeedbackForm> {
-  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
-  final CustomFeedback _customFeedback = CustomFeedback();
-  bool _isLoading = false;
-
-  /// Validates feedback text
-  String? _validateFeedbackText(String? value) {
-    final trimmedValue = value?.trim() ?? '';
-    if (trimmedValue.isEmpty) {
-      return LocaleKeys.feedbackValidatorEmptyError.tr();
-    }
-    if (trimmedValue.length > feedbackMaxLength) {
-      return LocaleKeys.feedbackValidatorMaxLengthError.tr(
-        args: [feedbackMaxLength.toString()],
-      );
-    }
-    return null;
-  }
-
-  /// Validates contact details based on selected method
-  String? _validateContactDetails(String? value) {
-    final trimmedValue = value?.trim() ?? '';
-    final hasContactMethod = _customFeedback.contactMethod != null;
-    final hasContactDetails = trimmedValue.isNotEmpty;
-
-    // For support requests, contact details are required
-    if (_customFeedback.feedbackType == FeedbackType.support) {
-      if (!hasContactMethod || !hasContactDetails) {
-        return LocaleKeys.contactRequiredError.tr();
-      }
-    } else {
-      // For other types, if one is provided, both must be provided
-      if ((hasContactMethod && !hasContactDetails) ||
-          (!hasContactMethod && hasContactDetails)) {
-        return LocaleKeys.contactRequiredError.tr();
-      }
-    }
-
-    // If no contact details provided, validation passes
-    if (!hasContactDetails) {
-      return null;
-    }
-
-    // Check maximum length
-    if (trimmedValue.length > contactDetailsMaxLength) {
-      return 'Contact details must be $contactDetailsMaxLength characters or less';
-    }
-
-    // Validate based on contact method
-    if (_customFeedback.contactMethod != null) {
-      switch (_customFeedback.contactMethod!) {
-        case ContactMethod.email:
-          if (!_isValidEmail(trimmedValue)) {
-            return LocaleKeys.emailValidatorError.tr();
-          }
-          break;
-        case ContactMethod.discord:
-          if (!_isValidDiscordUsername(trimmedValue)) {
-            return 'Please enter a valid Discord username (2-32 characters, letters, numbers, dots, underscores)';
-          }
-          break;
-        case ContactMethod.telegram:
-          if (!_isValidTelegramUsername(trimmedValue)) {
-            return 'Please enter a valid Telegram username (5-32 characters, letters, numbers, underscores)';
-          }
-          break;
-        case ContactMethod.matrix:
-          if (!_isValidMatrixId(trimmedValue)) {
-            return 'Please enter a valid Matrix ID (e.g., @username:server.com)';
-          }
-          break;
-      }
-    }
-
-    return null;
-  }
-
-  /// Sanitizes input text by removing potentially harmful content
-  String _sanitizeInput(String input) {
-    return input
-        .trim()
-        // Remove HTML tags
-        .replaceAll(RegExp(r'<[^>]*>'), '')
-        // Remove script content
-        .replaceAll(
-            RegExp(r'<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>',
-                caseSensitive: false),
-            '')
-        // Remove javascript: protocols
-        .replaceAll(RegExp(r'javascript:', caseSensitive: false), '')
-        // Remove data: protocols that could contain scripts
-        .replaceAll(RegExp(r'data:[^,]*script[^,]*,', caseSensitive: false), '')
-        // Limit line breaks to prevent excessive formatting
-        .replaceAll(RegExp(r'\n{3,}'), '\n\n');
-  }
-
-  /// Determines if the feedback form is valid and can be submitted
-  bool get _isFormValid {
-    // Always validate the current state to ensure we have the latest validation results
-    return _formKey.currentState?.validate() ?? false;
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final formValid = _isFormValid && !_isLoading;
-
-    return Form(
-      key: _formKey,
-      autovalidateMode: AutovalidateMode.onUserInteraction,
-      child: Column(
-        children: [
-          Expanded(
-            child: Stack(
-              children: [
-                if (widget.scrollController != null)
-                  const FeedbackSheetDragHandle(),
-                ListView(
-                  controller: widget.scrollController,
-                  padding: EdgeInsets.fromLTRB(
-                    16,
-                    widget.scrollController != null ? 20 : 16,
-                    16,
-                    0,
-                  ),
+    return BlocBuilder<FeedbackFormBloc, FeedbackFormState>(
+      builder: (context, state) {
+        final theme = Theme.of(context);
+        final isLoading = state.status == FeedbackFormStatus.submitting;
+        final formValid = state.isValid && !isLoading;
+        return Form(
+          autovalidateMode: AutovalidateMode.onUserInteraction,
+          child: Column(
+            children: [
+              Expanded(
+                child: Stack(
                   children: [
-                    Text(
-                      'What kind of feedback do you want to give?',
-                      style: theme.textTheme.titleMedium,
-                    ),
-                    const SizedBox(height: 8),
-                    DropdownButtonFormField<FeedbackType>(
-                      isExpanded: true,
-                      value: _customFeedback.feedbackType,
-                      decoration: InputDecoration(
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(8),
-                        ),
+                    if (scrollController != null)
+                      const FeedbackSheetDragHandle(),
+                    ListView(
+                      controller: scrollController,
+                      padding: EdgeInsets.fromLTRB(
+                        16,
+                        scrollController != null ? 20 : 16,
+                        16,
+                        0,
                       ),
-                      validator: (value) {
-                        if (value == null) {
-                          return 'Please select a feedback type';
-                        }
-                        return null;
-                      },
-                      items: FeedbackType.values
-                          .map(
-                            (type) => DropdownMenuItem<FeedbackType>(
-                              value: type,
-
-                              // TODO: l10n
-                              child: Text(type.description),
-                            ),
-                          )
-                          .toList(),
-                      onChanged: _isLoading
-                          ? null
-                          : (feedbackType) {
-                              setState(() {
-                                _customFeedback.feedbackType = feedbackType;
-                              });
-                              // Revalidate the form when feedback type changes
-                              // This is important because contact requirements change based on feedback type
-                              Future.microtask(() {
-                                _formKey.currentState?.validate();
-                              });
-                            },
-                    ),
-                    const SizedBox(height: 16),
-                    Text(
-                      'Please describe your feedback:',
-                      style: theme.textTheme.titleMedium,
-                    ),
-                    const SizedBox(height: 8),
-                    UiTextFormField(
-                      // maxLines: 3,
-                      maxLength: feedbackMaxLength,
-                      maxLengthEnforcement: MaxLengthEnforcement.enforced,
-                      enabled: !_isLoading,
-                      hintText: 'Enter your feedback here...',
-                      validator: _validateFeedbackText,
-                      validationMode: InputValidationMode.eager,
-                      onChanged: (value) {
-                        _customFeedback.feedbackText =
-                            _sanitizeInput(value ?? '');
-                        setState(() {});
-                      },
-                    ),
-                    const SizedBox(height: 16),
-                    Text(
-                      _customFeedback.feedbackType == FeedbackType.support
-                          ? "How can we contact you?"
-                          : "How can we contact you? (Optional)",
-                      style: theme.textTheme.titleMedium,
-                    ),
-                    const SizedBox(height: 8),
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        SizedBox(
-                          width: 130,
-                          child: DropdownButtonFormField<ContactMethod>(
-                            isExpanded: true,
-                            value: _customFeedback.contactMethod,
-                            hint: const Text('Select'),
-                            decoration: InputDecoration(
-                              border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(8),
+                        Text(
+                          'What kind of feedback do you want to give?',
+                          style: theme.textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: 8),
+                        DropdownButtonFormField<FeedbackType>(
+                          isExpanded: true,
+                          value: state.feedbackType,
+                          decoration: InputDecoration(
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                          ),
+                          validator: (value) {
+                            if (value == null) {
+                              return 'Please select a feedback type';
+                            }
+                            return null;
+                          },
+                          items: FeedbackType.values
+                              .map(
+                                (type) => DropdownMenuItem<FeedbackType>(
+                                  value: type,
+                                  child: Text(type.description),
+                                ),
+                              )
+                              .toList(),
+                          onChanged: isLoading
+                              ? null
+                              : (feedbackType) => context
+                                  .read<FeedbackFormBloc>()
+                                  .add(FeedbackFormTypeChanged(feedbackType)),
+                        ),
+                        const SizedBox(height: 16),
+                        Text(
+                          'Please describe your feedback:',
+                          style: theme.textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: 8),
+                        UiTextFormField(
+                          maxLength: feedbackMaxLength,
+                          maxLengthEnforcement: MaxLengthEnforcement.enforced,
+                          enabled: !isLoading,
+                          hintText: 'Enter your feedback here...',
+                          errorText: state.feedbackTextError,
+                          validationMode: InputValidationMode.eager,
+                          onChanged: (value) => context
+                              .read<FeedbackFormBloc>()
+                              .add(FeedbackFormMessageChanged(value ?? '')),
+                        ),
+                        const SizedBox(height: 16),
+                        Text(
+                          state.feedbackType == FeedbackType.support
+                              ? 'How can we contact you?'
+                              : 'How can we contact you? (Optional)',
+                          style: theme.textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: 8),
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            SizedBox(
+                              width: 130,
+                              child: DropdownButtonFormField<ContactMethod>(
+                                isExpanded: true,
+                                value: state.contactMethod,
+                                hint: const Text('Select'),
+                                decoration: InputDecoration(
+                                  border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(8),
+                                  ),
+                                ),
+                                items: ContactMethod.values
+                                    .map(
+                                      (method) =>
+                                          DropdownMenuItem<ContactMethod>(
+                                        value: method,
+                                        child: Text(method.label),
+                                      ),
+                                    )
+                                    .toList(),
+                                onChanged: isLoading
+                                    ? null
+                                    : (method) => context
+                                        .read<FeedbackFormBloc>()
+                                        .add(FeedbackFormContactMethodChanged(
+                                            method)),
                               ),
                             ),
-                            items: ContactMethod.values
-                                .map(
-                                  (method) => DropdownMenuItem<ContactMethod>(
-                                    value: method,
-                                    child: Text(method.label),
-                                  ),
-                                )
-                                .toList(),
-                            onChanged: _isLoading
-                                ? null
-                                : (contactMethod) {
-                                    setState(() {
-                                      _customFeedback.contactMethod =
-                                          contactMethod;
-                                    });
-                                    // Revalidate contact details when method changes
-                                    Future.microtask(() {
-                                      _formKey.currentState?.validate();
-                                    });
-                                  },
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: UiTextFormField(
-                            enabled: !_isLoading,
-                            maxLength: contactDetailsMaxLength,
-                            maxLengthEnforcement: MaxLengthEnforcement.enforced,
-                            hintText: _getContactHint(
-                              _customFeedback.contactMethod,
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: UiTextFormField(
+                                enabled: !isLoading,
+                                maxLength: contactDetailsMaxLength,
+                                maxLengthEnforcement:
+                                    MaxLengthEnforcement.enforced,
+                                hintText: _getContactHint(state.contactMethod),
+                                errorText: state.contactDetailsError,
+                                validationMode: InputValidationMode.eager,
+                                onChanged: (value) => context
+                                    .read<FeedbackFormBloc>()
+                                    .add(FeedbackFormContactDetailsChanged(
+                                        value ?? '')),
+                              ),
                             ),
-                            validator: _validateContactDetails,
-                            validationMode: InputValidationMode.eager,
-                            onChanged: (value) {
-                              _customFeedback.contactDetails =
-                                  _sanitizeInput(value ?? '');
-                              setState(() {});
-                            },
-                          ),
+                          ],
                         ),
                       ],
                     ),
                   ],
                 ),
-              ],
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.all(16),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                if (_isLoading)
-                  Padding(
-                    padding: const EdgeInsets.only(right: 16.0),
-                    child: SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2.0,
-                        valueColor: AlwaysStoppedAnimation<Color>(
-                          theme.colorScheme.primary,
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    if (isLoading)
+                      const Padding(
+                        padding: EdgeInsets.only(right: 16.0),
+                        child: SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2.0),
                         ),
                       ),
+                    TextButton(
+                      onPressed: formValid
+                          ? () => context
+                              .read<FeedbackFormBloc>()
+                              .add(const FeedbackFormSubmitted())
+                          : null,
+                      child: const Text('SUBMIT'),
                     ),
-                  ),
-                TextButton(
-                  onPressed: formValid ? () => _submitFeedback() : null,
-                  child: const Text('SUBMIT'),
+                  ],
                 ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _submitFeedback() {
-    // Force validation of the entire form before submission
-    if (!(_formKey.currentState?.validate() ?? false)) {
-      return;
-    }
-
-    setState(() {
-      _isLoading = true;
-    });
-
-    // Ensure we're using sanitized data for submission
-    final sanitizedFeedback =
-        _sanitizeInput(_customFeedback.feedbackText ?? '');
-    final sanitizedContactDetails = _customFeedback.contactDetails != null
-        ? _sanitizeInput(_customFeedback.contactDetails!)
-        : null;
-
-    final submissionData = CustomFeedback(
-      feedbackType: _customFeedback.feedbackType,
-      feedbackText: sanitizedFeedback,
-      contactMethod: _customFeedback.contactMethod,
-      contactDetails: sanitizedContactDetails,
-    ); // Call the onSubmit callback provided by BetterFeedback
-    widget
-        .onSubmit(
-      submissionData.toFormattedDescription(),
-      extras: submissionData.toMap(),
-    )
-        .then((_) {
-      if (mounted) {
-        setState(() {
-          _isLoading = false;
-        });
-      }
-    }).catchError((error) {
-      if (mounted) {
-        setState(() {
-          _isLoading = false;
-        });
-        // Show error to user
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Failed to submit feedback. Please try again.'),
-            backgroundColor: Theme.of(context).colorScheme.error,
+              ),
+            ],
           ),
         );
-      }
-    });
-  }
-
-  bool _isValidEmail(String email) {
-    return emailRegex.hasMatch(email);
-  }
-
-  bool _isValidDiscordUsername(String username) {
-    return discordUsernameRegex.hasMatch(username);
-  }
-
-  bool _isValidTelegramUsername(String username) {
-    // Remove @ prefix if present
-    final cleanUsername =
-        username.startsWith('@') ? username.substring(1) : username;
-    return telegramUsernameRegex.hasMatch(cleanUsername);
-  }
-
-  bool _isValidMatrixId(String matrixId) {
-    return matrixIdRegex.hasMatch(matrixId);
-  }
-
-  String _getContactHint(ContactMethod? method) {
-    switch (method) {
-      case ContactMethod.discord:
-        return 'Discord username (e.g., username123)';
-      case ContactMethod.matrix:
-        return 'Matrix ID (e.g., @user:matrix.org)';
-      case ContactMethod.telegram:
-        return 'Telegram username (e.g., @username)';
-      case ContactMethod.email:
-        return 'Your email address';
-      default:
-        return 'Enter your contact details';
-    }
+      },
+    );
   }
 }
 
-/// Contact methods available for feedback follow-up
-enum ContactMethod {
-  discord,
-  matrix,
-  telegram,
-  email;
-
-  String get label {
-    switch (this) {
-      case discord:
-        return 'Discord';
-      case matrix:
-        return 'Matrix';
-      case telegram:
-        return 'Telegram';
-      case email:
-        return 'Email';
-    }
+String _getContactHint(ContactMethod? method) {
+  switch (method) {
+    case ContactMethod.discord:
+      return 'Discord username (e.g., username123)';
+    case ContactMethod.matrix:
+      return 'Matrix ID (e.g., @user:matrix.org)';
+    case ContactMethod.telegram:
+      return 'Telegram username (e.g., @username)';
+    case ContactMethod.email:
+      return 'Your email address';
+    default:
+      return 'Enter your contact details';
   }
 }

--- a/lib/services/feedback/feedback_models.dart
+++ b/lib/services/feedback/feedback_models.dart
@@ -1,0 +1,131 @@
+class CustomFeedback {
+  CustomFeedback({
+    this.feedbackType,
+    this.feedbackText,
+    this.contactMethod,
+    this.contactDetails,
+  });
+
+  FeedbackType? feedbackType;
+  String? feedbackText;
+  ContactMethod? contactMethod;
+  String? contactDetails;
+
+  @override
+  String toString() {
+    return {
+      'feedback_type': feedbackType.toString(),
+      'feedback_text': feedbackText,
+      'contact_method': contactMethod?.name,
+      'contact_details': contactDetails,
+    }.toString();
+  }
+
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'feedback_type': feedbackType.toString(),
+      'feedback_text': feedbackText,
+      'contact_method': contactMethod?.name,
+      'contact_details': contactDetails,
+    };
+  }
+
+  String toFormattedDescription() {
+    final buffer = StringBuffer();
+    buffer.writeln('═══════════════════════════════════════');
+    buffer
+        .writeln('📋 ${feedbackType?.description ?? 'Unknown'}'.toUpperCase());
+    buffer.writeln('═══════════════════════════════════════');
+    buffer.writeln();
+    buffer.writeln('💬 USER FEEDBACK:');
+    buffer.writeln('─' * 40);
+    if (feedbackText?.trim().isNotEmpty == true) {
+      final paragraphs = feedbackText!.trim().split('\n');
+      for (int i = 0; i < paragraphs.length; i++) {
+        final paragraph = paragraphs[i].trim();
+        if (paragraph.isNotEmpty) {
+          buffer.writeln('   $paragraph');
+          if (i < paragraphs.length - 1) buffer.writeln();
+        }
+      }
+    } else {
+      buffer.writeln('   [No feedback text provided]');
+    }
+    buffer.writeln();
+    buffer.writeln('📞 CONTACT INFORMATION:');
+    buffer.writeln('─' * 40);
+    if (contactMethod != null && contactDetails?.trim().isNotEmpty == true) {
+      final contact = contactDetails!.trim();
+      switch (contactMethod!) {
+        case ContactMethod.email:
+          buffer.writeln('   📧 Email: $contact');
+          break;
+        case ContactMethod.discord:
+          buffer.writeln('   🎮 Discord: $contact');
+          break;
+        case ContactMethod.telegram:
+          buffer.writeln(
+              '   📱 Telegram: ${contact.startsWith('@') ? contact : '@$contact'}');
+          break;
+        case ContactMethod.matrix:
+          buffer.writeln('   🔗 Matrix: $contact');
+          break;
+      }
+      if (feedbackType == FeedbackType.support) {
+        buffer.writeln(
+            '   ⚠️  PRIORITY: Contact details provided for support request');
+      }
+    } else {
+      buffer.writeln('   ❌ No contact information provided');
+      if (feedbackType == FeedbackType.support) {
+        buffer.writeln(
+            '   ⚠️  WARNING: Support request without contact details!');
+      }
+    }
+    return buffer.toString();
+  }
+}
+
+enum FeedbackType {
+  bugReport,
+  featureRequest,
+  support,
+  other;
+}
+
+extension FeedbackTypeDescription on FeedbackType {
+  String get description {
+    switch (this) {
+      case FeedbackType.bugReport:
+        return 'Bug Report';
+      case FeedbackType.featureRequest:
+        return 'Feature Request';
+      case FeedbackType.support:
+        return 'Support Request';
+      case FeedbackType.other:
+        return 'Other';
+    }
+  }
+}
+
+enum ContactMethod {
+  discord,
+  matrix,
+  telegram,
+  email;
+}
+
+extension ContactMethodLabel on ContactMethod {
+  String get label {
+    switch (this) {
+      case ContactMethod.discord:
+        return 'Discord';
+      case ContactMethod.matrix:
+        return 'Matrix';
+      case ContactMethod.telegram:
+        return 'Telegram';
+      case ContactMethod.email:
+        return 'Email';
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- migrate feedback form to BLoC architecture
- add FeedbackFormBloc, events and states
- move feedback data models to separate file
- update CustomFeedbackForm to use the new bloc

## Testing
- `flutter pub get --offline`
- `flutter analyze`
- `flutter test test_integration/tests/misc_tests/feedback_tests.dart` *(fails: Proxy failed to establish tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_686eb2c4b2208326838725a9da0a2859