### PR TITLE
fix(wallet): misc wallet page fixes

### DIFF
--- a/lib/bloc/cex_market_data/portfolio_growth/portfolio_growth_bloc.dart
+++ b/lib/bloc/cex_market_data/portfolio_growth/portfolio_growth_bloc.dart
@@ -61,6 +61,7 @@ class PortfolioGrowthBloc
           totalBalance: currentState.totalBalance,
           totalChange24h: currentState.totalChange24h,
           percentageChange24h: currentState.percentageChange24h,
+          isUpdating: true,
         ),
       );
     } else if (currentState is GrowthChartLoadFailure) {
@@ -205,6 +206,7 @@ class PortfolioGrowthBloc
       totalBalance: totalBalance,
       totalChange24h: totalChange24h,
       percentageChange24h: percentageChange24h,
+      isUpdating: false,
     );
   }
 
@@ -260,6 +262,7 @@ class PortfolioGrowthBloc
       totalBalance: totalBalance,
       totalChange24h: totalChange24h,
       percentageChange24h: percentageChange24h,
+      isUpdating: false,
     );
   }
 

--- a/lib/bloc/cex_market_data/portfolio_growth/portfolio_growth_state.dart
+++ b/lib/bloc/cex_market_data/portfolio_growth/portfolio_growth_state.dart
@@ -22,6 +22,7 @@ final class PortfolioGrowthChartLoadSuccess extends PortfolioGrowthState {
     required this.totalBalance,
     required this.totalChange24h,
     required this.percentageChange24h,
+    this.isUpdating = false,
   });
 
   final ChartData portfolioGrowth;
@@ -29,6 +30,7 @@ final class PortfolioGrowthChartLoadSuccess extends PortfolioGrowthState {
   final double totalBalance;
   final double totalChange24h;
   final double percentageChange24h;
+  final bool isUpdating;
 
   @override
   List<Object> get props => <Object>[
@@ -38,6 +40,7 @@ final class PortfolioGrowthChartLoadSuccess extends PortfolioGrowthState {
         totalBalance,
         totalChange24h,
         percentageChange24h,
+        isUpdating,
       ];
 }
 

--- a/lib/bloc/cex_market_data/profit_loss/profit_loss_bloc.dart
+++ b/lib/bloc/cex_market_data/profit_loss/profit_loss_bloc.dart
@@ -125,6 +125,7 @@ class ProfitLossBloc extends Bloc<ProfitLossEvent, ProfitLossState> {
         fiatCurrency: event.fiatCoinId,
         selectedPeriod: event.selectedPeriod,
         walletId: event.walletId,
+        isUpdating: false,
       );
     } catch (error, stackTrace) {
       _log.shout('Failed periodic profit/loss chart update', error, stackTrace);
@@ -161,6 +162,20 @@ class ProfitLossBloc extends Bloc<ProfitLossEvent, ProfitLossState> {
         ),
       );
     }
+
+    emit(
+      PortfolioProfitLossChartLoadSuccess(
+        profitLossChart: eventState.profitLossChart,
+        totalValue: eventState.totalValue,
+        percentageIncrease: eventState.percentageIncrease,
+        coins: eventState.coins,
+        fiatCurrency: eventState.fiatCurrency,
+        walletId: eventState.walletId,
+        selectedPeriod: event.selectedPeriod,
+        isUpdating: true,
+      ),
+    );
+
     add(
       ProfitLossPortfolioChartLoadRequested(
         coins: eventState.coins,

--- a/lib/bloc/cex_market_data/profit_loss/profit_loss_state.dart
+++ b/lib/bloc/cex_market_data/profit_loss/profit_loss_state.dart
@@ -26,6 +26,7 @@ final class PortfolioProfitLossChartLoadSuccess extends ProfitLossState {
     required this.fiatCurrency,
     required this.walletId,
     required super.selectedPeriod,
+    this.isUpdating = false,
   });
 
   final List<Point<double>> profitLossChart;
@@ -34,6 +35,7 @@ final class PortfolioProfitLossChartLoadSuccess extends ProfitLossState {
   final List<Coin> coins;
   final String fiatCurrency;
   final String walletId;
+  final bool isUpdating;
 
   @override
   List<Object> get props => [
@@ -44,6 +46,7 @@ final class PortfolioProfitLossChartLoadSuccess extends ProfitLossState {
         fiatCurrency,
         selectedPeriod,
         walletId,
+        isUpdating,
       ];
 }
 

--- a/lib/views/common/header/actions/header_actions.dart
+++ b/lib/views/common/header/actions/header_actions.dart
@@ -6,6 +6,7 @@ import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 import 'package:web_dex/app_config/app_config.dart';
 import 'package:web_dex/bloc/coins_bloc/asset_coin_extension.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_bloc.dart';
+import 'package:web_dex/bloc/cex_market_data/portfolio_growth/portfolio_growth_bloc.dart';
 import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/coin.dart';
@@ -35,12 +36,18 @@ List<Widget>? getHeaderActions(BuildContext context) {
       ),
     Padding(
       padding: headerActionsPadding,
-      child: BlocBuilder<CoinsBloc, CoinsState>(
-        builder: (context, state) {
+      child: BlocBuilder<PortfolioGrowthBloc, PortfolioGrowthState>(
+        builder: (context, pgState) {
+          final coins = context.select<CoinsBloc, Iterable<Coin>>(
+            (bloc) => bloc.state.walletCoins.values,
+          );
+          final totalBalance = pgState is PortfolioGrowthChartLoadSuccess
+              ? pgState.totalBalance
+              : _getTotalBalance(coins, context);
+
           return ActionTextButton(
             text: LocaleKeys.balance.tr(),
-            secondaryText:
-                '\$${formatAmt(_getTotalBalance(state.walletCoins.values, context))}',
+            secondaryText: '\$${formatAmt(totalBalance)}',
             onTap: null,
           );
         },

--- a/lib/views/wallet/coin_details/coin_details_info/charts/portfolio_growth_chart.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/charts/portfolio_growth_chart.dart
@@ -60,8 +60,9 @@ class _PortfolioGrowthChartState extends State<PortfolioGrowthChart> {
           state.selectedPeriod,
         );
 
-        final isChartLoading = state is! PortfolioGrowthChartLoadSuccess &&
-            state is! PortfolioGrowthChartUnsupported;
+        final isChartLoading = (state is! PortfolioGrowthChartLoadSuccess &&
+                state is! PortfolioGrowthChartUnsupported) ||
+            (state is PortfolioGrowthChartLoadSuccess && state.isUpdating);
 
         return Card(
           clipBehavior: Clip.antiAlias,

--- a/lib/views/wallet/coin_details/coin_details_info/charts/portfolio_profit_loss_chart.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/charts/portfolio_profit_loss_chart.dart
@@ -62,6 +62,8 @@ class PortfolioProfitLossChartState extends State<PortfolioProfitLossChart> {
         final maxChartExtent = DateTime.now().millisecondsSinceEpoch.toDouble();
 
         final isSuccess = state is PortfolioProfitLossChartLoadSuccess;
+        final isUpdating =
+            state is PortfolioProfitLossChartLoadSuccess && state.isUpdating;
         final List<ChartData> chartData = isSuccess
             ? state.profitLossChart
                 .map((point) => ChartData(x: point.x.toDouble(), y: point.y))
@@ -176,7 +178,7 @@ class PortfolioProfitLossChartState extends State<PortfolioProfitLossChart> {
                     ),
                   ),
                 ),
-                if (state is! PortfolioProfitLossChartLoadSuccess)
+                if (!isSuccess || isUpdating)
                   Container(
                     clipBehavior: Clip.none,
                     child: const LinearProgressIndicator(

--- a/lib/views/wallet/wallet_page/wallet_main/balance_summary_widget.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/balance_summary_widget.dart
@@ -8,6 +8,7 @@ class BalanceSummaryWidget extends StatelessWidget {
   final double changeAmount;
   final double changePercentage;
   final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
 
   const BalanceSummaryWidget({
     super.key,
@@ -15,6 +16,7 @@ class BalanceSummaryWidget extends StatelessWidget {
     required this.changeAmount,
     required this.changePercentage,
     this.onTap,
+    this.onLongPress,
   });
 
   @override
@@ -33,6 +35,7 @@ class BalanceSummaryWidget extends StatelessWidget {
 
     return GestureDetector(
       onTap: onTap,
+      onLongPress: onLongPress,
       child: GradientBorder(
         gradient: gradient,
         innerColor: theme.colorScheme.surface,

--- a/lib/views/wallet/wallet_page/wallet_main/wallet_overview.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/wallet_overview.dart
@@ -102,6 +102,11 @@ class _WalletOverviewState extends State<WalletOverview> {
                   changeAmount: totalChange24h,
                   changePercentage: percentageChange24h,
                   onTap: widget.onAssetsPressed,
+                  onLongPress: () {
+                    final formattedValue = NumberFormat.currency(symbol: '\$')
+                        .format(totalBalance);
+                    copyToClipBoard(context, formattedValue);
+                  },
                 );
               },
             ),
@@ -110,7 +115,12 @@ class _WalletOverviewState extends State<WalletOverview> {
               key: const Key('overview-current-value'),
               caption: Text(LocaleKeys.yourBalance.tr()),
               value: totalBalance,
-              onPressed: widget.onAssetsPressed,
+              onTap: widget.onAssetsPressed,
+              onLongPress: () {
+                final formattedValue =
+                    NumberFormat.currency(symbol: '\$').format(totalBalance);
+                copyToClipBoard(context, formattedValue);
+              },
               trendWidget:
                   BlocBuilder<PortfolioGrowthBloc, PortfolioGrowthState>(
                 builder: (context, state) {
@@ -136,7 +146,12 @@ class _WalletOverviewState extends State<WalletOverview> {
             key: const Key('overview-all-time-investment'),
             caption: Text(LocaleKeys.allTimeInvestment.tr()),
             value: stateWithData?.totalInvestment.value ?? 0,
-            onPressed: widget.onPortfolioGrowthPressed,
+            onTap: widget.onPortfolioGrowthPressed,
+            onLongPress: () {
+              final formattedValue = NumberFormat.currency(symbol: '\$')
+                  .format(stateWithData?.totalInvestment.value ?? 0);
+              copyToClipBoard(context, formattedValue);
+            },
             trendWidget: ActionChip(
               avatar: Icon(
                 Icons.pie_chart,
@@ -157,7 +172,12 @@ class _WalletOverviewState extends State<WalletOverview> {
             key: const Key('overview-all-time-profit'),
             caption: Text(LocaleKeys.allTimeProfit.tr()),
             value: stateWithData?.profitAmount.value ?? 0,
-            onPressed: widget.onPortfolioProfitLossPressed,
+            onTap: widget.onPortfolioProfitLossPressed,
+            onLongPress: () {
+              final formattedValue = NumberFormat.currency(symbol: '\$')
+                  .format(stateWithData?.profitAmount.value ?? 0);
+              copyToClipBoard(context, formattedValue);
+            },
             trendWidget: stateWithData != null
                 ? TrendPercentageText(
                     percentage: stateWithData.profitIncreasePercentage,

--- a/lib/views/wallet/wallet_page/wallet_main/wallet_overview.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/wallet_overview.dart
@@ -101,11 +101,7 @@ class _WalletOverviewState extends State<WalletOverview> {
                   totalBalance: totalBalance,
                   changeAmount: totalChange24h,
                   changePercentage: percentageChange24h,
-                  onTap: () {
-                    final formattedValue = NumberFormat.currency(symbol: '\$')
-                        .format(totalBalance);
-                    copyToClipBoard(context, formattedValue);
-                  },
+                  onTap: widget.onAssetsPressed,
                 );
               },
             ),
@@ -114,11 +110,7 @@ class _WalletOverviewState extends State<WalletOverview> {
               key: const Key('overview-current-value'),
               caption: Text(LocaleKeys.yourBalance.tr()),
               value: totalBalance,
-              onPressed: () {
-                final formattedValue =
-                    NumberFormat.currency(symbol: '\$').format(totalBalance);
-                copyToClipBoard(context, formattedValue);
-              },
+              onPressed: widget.onAssetsPressed,
               trendWidget:
                   BlocBuilder<PortfolioGrowthBloc, PortfolioGrowthState>(
                 builder: (context, state) {

--- a/packages/komodo_ui_kit/lib/src/display/statistic_card.dart
+++ b/packages/komodo_ui_kit/lib/src/display/statistic_card.dart
@@ -13,7 +13,9 @@ class StatisticCard extends StatelessWidget {
   // The formatter used to format the value for the title
   final NumberFormat _valueFormatter;
 
-  final VoidCallback? onPressed;
+  /// Callback when the card is tapped.
+  final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
 
   // Widget shown in the top right corner (typically TrendPercentageText)
   final Widget? trendWidget;
@@ -28,7 +30,8 @@ class StatisticCard extends StatelessWidget {
     this.trendWidget,
     this.actionWidget,
     NumberFormat? valueFormatter,
-    this.onPressed,
+    this.onTap,
+    this.onLongPress,
   }) : _valueFormatter = valueFormatter ?? NumberFormat.currency(symbol: '\$');
 
   @override
@@ -40,7 +43,8 @@ class StatisticCard extends StatelessWidget {
       color: isDarkMode ? Colors.black : Theme.of(context).cardColor,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: InkWell(
-        onTap: onPressed,
+        onTap: onTap,
+        onLongPress: onLongPress,
         borderRadius: BorderRadius.circular(12),
         child: Container(
           padding: const EdgeInsets.all(16.0),


### PR DESCRIPTION
Misc wallet page fixes reported by @mariocynicys 

This pull request introduces enhancements to the portfolio growth and profit/loss chart functionality, adds a new `isUpdating` state for better UI feedback during updates, and improves user interaction with wallet overview and statistic cards. Below are the key changes grouped by theme:

### Portfolio Growth and Profit/Loss State Management:
* Added a new `isUpdating` property to `PortfolioGrowthChartLoadSuccess` and `PortfolioProfitLossChartLoadSuccess` states to indicate ongoing updates. This property is initialized to `false` by default and updated during state transitions. (`lib/bloc/cex_market_data/portfolio_growth/portfolio_growth_bloc.dart` - [[1]](diffhunk://#diff-84b977166647d46c00f367dc56fdb1cac5df3d22ee3945636c0bf4d924357731R64) [[2]](diffhunk://#diff-84b977166647d46c00f367dc56fdb1cac5df3d22ee3945636c0bf4d924357731R209) [[3]](diffhunk://#diff-84b977166647d46c00f367dc56fdb1cac5df3d22ee3945636c0bf4d924357731R265); `lib/bloc/cex_market_data/portfolio_growth/portfolio_growth_state.dart` - [[4]](diffhunk://#diff-6891b2ea15aea55ce3148b116cd57326086beee81556e7b1e6bc87d847a5f455R25-R33) [[5]](diffhunk://#diff-6891b2ea15aea55ce3148b116cd57326086beee81556e7b1e6bc87d847a5f455R43); `lib/bloc/cex_market_data/profit_loss/profit_loss_bloc.dart` - [[6]](diffhunk://#diff-7b3ecb0c053e8b04261fdd04c3a0a3711c06540813f16ac831ca4d04855e002bR128) [[7]](diffhunk://#diff-7b3ecb0c053e8b04261fdd04c3a0a3711c06540813f16ac831ca4d04855e002bR165-R178); `lib/bloc/cex_market_data/profit_loss/profit_loss_state.dart` - [[8]](diffhunk://#diff-ecc0a7576cf5027230d71a6f6ef22234ffdd4a7da21e3d1accf9bac0e600727aR29) [[9]](diffhunk://#diff-ecc0a7576cf5027230d71a6f6ef22234ffdd4a7da21e3d1accf9bac0e600727aR38) [[10]](diffhunk://#diff-ecc0a7576cf5027230d71a6f6ef22234ffdd4a7da21e3d1accf9bac0e600727aR49)

### UI Updates for Charts:
* Updated the portfolio growth and profit/loss charts to show a loading indicator when `isUpdating` is `true`, ensuring smoother UI feedback during updates. (`lib/views/wallet/coin_details/coin_details_info/charts/portfolio_growth_chart.dart` - [[1]](diffhunk://#diff-53a48715562bbd609744e82f7af2cbde1508131572ee708d246b57f497a779b8L63-R65); `lib/views/wallet/coin_details/coin_details_info/charts/portfolio_profit_loss_chart.dart` - [[2]](diffhunk://#diff-fa4253127f1e1fbc5f70e7eab45d6bbc2f25e110fc430aff2e543df1ddeedf66R65-R66) [[3]](diffhunk://#diff-fa4253127f1e1fbc5f70e7eab45d6bbc2f25e110fc430aff2e543df1ddeedf66L179-R181)

### Wallet Overview Enhancements:
* Added `onLongPress` functionality to wallet overview components for copying values (e.g., total balance, all-time investment, and profit) to the clipboard, improving usability. (`lib/views/wallet/wallet_page/wallet_main/balance_summary_widget.dart` - [[1]](diffhunk://#diff-7948ee0d1096ee4adf52c5128a2b0bf2fa9e1e5fa0e70d4d11895085995f866fR11-R19) [[2]](diffhunk://#diff-7948ee0d1096ee4adf52c5128a2b0bf2fa9e1e5fa0e70d4d11895085995f866fR38); `lib/views/wallet/wallet_page/wallet_main/wallet_overview.dart` - [[3]](diffhunk://#diff-793550796fe17d54ffd1b01c5939f3081cdcf0908bbe6039e214f5c5b35f31caL104-R105) [[4]](diffhunk://#diff-793550796fe17d54ffd1b01c5939f3081cdcf0908bbe6039e214f5c5b35f31caL117-R119) [[5]](diffhunk://#diff-793550796fe17d54ffd1b01c5939f3081cdcf0908bbe6039e214f5c5b35f31caL147-R154) [[6]](diffhunk://#diff-793550796fe17d54ffd1b01c5939f3081cdcf0908bbe6039e214f5c5b35f31caL168-R180)

### Statistic Card Enhancements:
* Replaced the `onPressed` callback with `onTap` and added `onLongPress` support to `StatisticCard` for consistency and extended functionality. (`packages/komodo_ui_kit/lib/src/display/statistic_card.dart` - [[1]](diffhunk://#diff-de5289fc447922a7e7a47dce88fff353a2f527f1611cec712bc784488eb79c68L16-R18) [[2]](diffhunk://#diff-de5289fc447922a7e7a47dce88fff353a2f527f1611cec712bc784488eb79c68L31-R34) [[3]](diffhunk://#diff-de5289fc447922a7e7a47dce88fff353a2f527f1611cec712bc784488eb79c68L43-R47)

### Miscellaneous:
* Updated the header actions to use `PortfolioGrowthBloc` for displaying the total balance, aligning with the new state management approach. (`lib/views/common/header/actions/header_actions.dart` - [[1]](diffhunk://#diff-20e71b05a06fd960d39d1e67a662556166e4e518cfd465d47a7f4c3489ed9fd7R9) [[2]](diffhunk://#diff-20e71b05a06fd960d39d1e67a662556166e4e518cfd465d47a7f4c3489ed9fd7L38-R50)