### PR TITLE
feat(charts): show updated period immediately

### DIFF
--- a/lib/bloc/cex_market_data/portfolio_growth/portfolio_growth_bloc.dart
+++ b/lib/bloc/cex_market_data/portfolio_growth/portfolio_growth_bloc.dart
@@ -61,6 +61,7 @@ class PortfolioGrowthBloc
           totalBalance: currentState.totalBalance,
           totalChange24h: currentState.totalChange24h,
           percentageChange24h: currentState.percentageChange24h,
+          isUpdating: true,
         ),
       );
     } else if (currentState is GrowthChartLoadFailure) {
@@ -205,6 +206,7 @@ class PortfolioGrowthBloc
       totalBalance: totalBalance,
       totalChange24h: totalChange24h,
       percentageChange24h: percentageChange24h,
+      isUpdating: false,
     );
   }
 
@@ -260,6 +262,7 @@ class PortfolioGrowthBloc
       totalBalance: totalBalance,
       totalChange24h: totalChange24h,
       percentageChange24h: percentageChange24h,
+      isUpdating: false,
     );
   }
 

--- a/lib/bloc/cex_market_data/portfolio_growth/portfolio_growth_state.dart
+++ b/lib/bloc/cex_market_data/portfolio_growth/portfolio_growth_state.dart
@@ -22,6 +22,7 @@ final class PortfolioGrowthChartLoadSuccess extends PortfolioGrowthState {
     required this.totalBalance,
     required this.totalChange24h,
     required this.percentageChange24h,
+    this.isUpdating = false,
   });
 
   final ChartData portfolioGrowth;
@@ -29,6 +30,7 @@ final class PortfolioGrowthChartLoadSuccess extends PortfolioGrowthState {
   final double totalBalance;
   final double totalChange24h;
   final double percentageChange24h;
+  final bool isUpdating;
 
   @override
   List<Object> get props => <Object>[
@@ -38,6 +40,7 @@ final class PortfolioGrowthChartLoadSuccess extends PortfolioGrowthState {
         totalBalance,
         totalChange24h,
         percentageChange24h,
+        isUpdating,
       ];
 }
 

--- a/lib/bloc/cex_market_data/profit_loss/profit_loss_bloc.dart
+++ b/lib/bloc/cex_market_data/profit_loss/profit_loss_bloc.dart
@@ -125,6 +125,7 @@ class ProfitLossBloc extends Bloc<ProfitLossEvent, ProfitLossState> {
         fiatCurrency: event.fiatCoinId,
         selectedPeriod: event.selectedPeriod,
         walletId: event.walletId,
+        isUpdating: false,
       );
     } catch (error, stackTrace) {
       _log.shout('Failed periodic profit/loss chart update', error, stackTrace);
@@ -161,6 +162,20 @@ class ProfitLossBloc extends Bloc<ProfitLossEvent, ProfitLossState> {
         ),
       );
     }
+
+    emit(
+      PortfolioProfitLossChartLoadSuccess(
+        profitLossChart: eventState.profitLossChart,
+        totalValue: eventState.totalValue,
+        percentageIncrease: eventState.percentageIncrease,
+        coins: eventState.coins,
+        fiatCurrency: eventState.fiatCurrency,
+        walletId: eventState.walletId,
+        selectedPeriod: event.selectedPeriod,
+        isUpdating: true,
+      ),
+    );
+
     add(
       ProfitLossPortfolioChartLoadRequested(
         coins: eventState.coins,

--- a/lib/bloc/cex_market_data/profit_loss/profit_loss_state.dart
+++ b/lib/bloc/cex_market_data/profit_loss/profit_loss_state.dart
@@ -26,6 +26,7 @@ final class PortfolioProfitLossChartLoadSuccess extends ProfitLossState {
     required this.fiatCurrency,
     required this.walletId,
     required super.selectedPeriod,
+    this.isUpdating = false,
   });
 
   final List<Point<double>> profitLossChart;
@@ -34,6 +35,7 @@ final class PortfolioProfitLossChartLoadSuccess extends ProfitLossState {
   final List<Coin> coins;
   final String fiatCurrency;
   final String walletId;
+  final bool isUpdating;
 
   @override
   List<Object> get props => [
@@ -44,6 +46,7 @@ final class PortfolioProfitLossChartLoadSuccess extends ProfitLossState {
         fiatCurrency,
         selectedPeriod,
         walletId,
+        isUpdating,
       ];
 }
 

--- a/lib/views/wallet/coin_details/coin_details_info/charts/portfolio_growth_chart.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/charts/portfolio_growth_chart.dart
@@ -60,8 +60,9 @@ class _PortfolioGrowthChartState extends State<PortfolioGrowthChart> {
           state.selectedPeriod,
         );
 
-        final isChartLoading = state is! PortfolioGrowthChartLoadSuccess &&
-            state is! PortfolioGrowthChartUnsupported;
+        final isChartLoading = (state is! PortfolioGrowthChartLoadSuccess &&
+                state is! PortfolioGrowthChartUnsupported) ||
+            (state is PortfolioGrowthChartLoadSuccess && state.isUpdating);
 
         return Card(
           clipBehavior: Clip.antiAlias,

--- a/lib/views/wallet/coin_details/coin_details_info/charts/portfolio_profit_loss_chart.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/charts/portfolio_profit_loss_chart.dart
@@ -62,6 +62,8 @@ class PortfolioProfitLossChartState extends State<PortfolioProfitLossChart> {
         final maxChartExtent = DateTime.now().millisecondsSinceEpoch.toDouble();
 
         final isSuccess = state is PortfolioProfitLossChartLoadSuccess;
+        final isUpdating =
+            state is PortfolioProfitLossChartLoadSuccess && state.isUpdating;
         final List<ChartData> chartData = isSuccess
             ? state.profitLossChart
                 .map((point) => ChartData(x: point.x.toDouble(), y: point.y))
@@ -176,7 +178,7 @@ class PortfolioProfitLossChartState extends State<PortfolioProfitLossChart> {
                     ),
                   ),
                 ),
-                if (state is! PortfolioProfitLossChartLoadSuccess)
+                if (!isSuccess || isUpdating)
                   Container(
                     clipBehavior: Clip.none,
                     child: const LinearProgressIndicator(


### PR DESCRIPTION
## Summary
- instantly change period when selecting a new timeframe for portfolio profit/loss and growth charts
- expose `isUpdating` in success state so the UI can show progress while data refreshes

## Testing
- `flutter analyze` *(fails: 485 issues)*

------
https://chatgpt.com/codex/tasks/task_e_686f99a587448326b24603fc4095d262