### PR TITLE
fix: propagate auth error to login form

### DIFF
--- a/lib/bloc/auth_bloc/auth_bloc_state.dart
+++ b/lib/bloc/auth_bloc/auth_bloc_state.dart
@@ -18,6 +18,7 @@ class AuthBlocState extends Equatable {
   factory AuthBlocState.error(AuthException authError) => AuthBlocState(
         mode: AuthorizeMode.noLogin,
         authenticationState: AuthenticationState.error(authError.toString()),
+        authError: authError,
       );
   factory AuthBlocState.loggedIn(KdfUser user) => AuthBlocState(
         mode: AuthorizeMode.logIn,

--- a/lib/views/wallets_manager/widgets/iguana_wallets_manager.dart
+++ b/lib/views/wallets_manager/widgets/iguana_wallets_manager.dart
@@ -53,14 +53,15 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
         if (state.isError) {
           setState(() => _isLoading = false);
 
+          // Don't show a snackbar when the error is shown on the form.
+          if (state.authError != null) return;
+
           final theme = Theme.of(context);
-          final message =
-              state.authError?.message ?? LocaleKeys.somethingWrong.tr();
 
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text(
-                message,
+                LocaleKeys.somethingWrong.tr(),
                 style: theme.textTheme.bodyLarge?.copyWith(
                   color: theme.colorScheme.onErrorContainer,
                 ),
@@ -82,16 +83,15 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
                 children: [
                   WalletsList(
                     walletType: WalletType.iguana,
-                    onWalletClick:
-                        (
-                          Wallet wallet,
-                          WalletsManagerExistWalletAction existWalletAction,
-                        ) {
-                          setState(() {
-                            _selectedWallet = wallet;
-                            _existWalletAction = existWalletAction;
-                          });
-                        },
+                    onWalletClick: (
+                      Wallet wallet,
+                      WalletsManagerExistWalletAction existWalletAction,
+                    ) {
+                      setState(() {
+                        _selectedWallet = wallet;
+                        _existWalletAction = existWalletAction;
+                      });
+                    },
                   ),
                   Padding(
                     padding: const EdgeInsets.only(top: 15.0),
@@ -105,11 +105,11 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
                             ? 'create'
                             : 'import';
                         context.read<AnalyticsBloc>().logEvent(
-                          OnboardingStartedEventData(
-                            method: method,
-                            referralSource: widget.eventType.name,
-                          ),
-                        );
+                              OnboardingStartedEventData(
+                                method: method,
+                                referralSource: widget.eventType.name,
+                              ),
+                            );
                       },
                     ),
                   ),
@@ -227,8 +227,8 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
     );
 
     context.read<AuthBloc>().add(
-      AuthRegisterRequested(wallet: newWallet, password: password),
-    );
+          AuthRegisterRequested(wallet: newWallet, password: password),
+        );
   }
 
   void _importWallet({
@@ -245,12 +245,12 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
     );
 
     context.read<AuthBloc>().add(
-      AuthRestoreRequested(
-        wallet: newWallet,
-        password: password,
-        seed: walletConfig.seedPhrase,
-      ),
-    );
+          AuthRestoreRequested(
+            wallet: newWallet,
+            password: password,
+            seed: walletConfig.seedPhrase,
+          ),
+        );
   }
 
   Future<void> _logInToWallet(String password, Wallet wallet) async {
@@ -266,8 +266,8 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
     analyticsBloc.logEvent(analyticsEvent);
 
     context.read<AuthBloc>().add(
-      AuthSignInRequested(wallet: wallet, password: password),
-    );
+          AuthSignInRequested(wallet: wallet, password: password),
+        );
 
     if (mounted) {
       setState(() {


### PR DESCRIPTION
## Summary
- include the `AuthException` in `AuthBlocState.error` so login errors show correctly in the form

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_68713b1daec48326a107bbb77b48e2d4