### PR TITLE
fix: show mobile app bar on tablet

### DIFF
--- a/lib/views/common/page_header/page_header.dart
+++ b/lib/views/common/page_header/page_header.dart
@@ -26,7 +26,7 @@ class PageHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (isMobile) {
+    if (isMobile || isTablet) {
       return _MobileHeader(
         onBackButtonPressed: onBackButtonPressed,
         title: title,

--- a/lib/views/wallet/wallet_page/wallet_main/wallet_main.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/wallet_main.dart
@@ -134,7 +134,7 @@ class _WalletMainState extends State<WalletMain> with TickerProviderStateMixin {
 
             return PageLayout(
               noBackground: true,
-              header: (isMobile && !isLoggedIn)
+              header: ((isMobile || isTablet) && !isLoggedIn)
                   ? PageHeader(title: LocaleKeys.wallet.tr())
                   : null,
               padding: EdgeInsets.zero,


### PR DESCRIPTION
As reported by @mariocynicys 

## Summary
- ensure `PageHeader` uses the mobile header for tablet devices

## Testing
- `flutter analyze`
- `dart format .`

------
https://chatgpt.com/codex/tasks/task_e_6874f81e6b108326b4da501178d18dfd