### PR TITLE
fix(theme): correct switch gradient stops

### DIFF
--- a/app_theme/lib/src/dark/theme_custom_dark.dart
+++ b/app_theme/lib/src/dark/theme_custom_dark.dart
@@ -95,7 +95,7 @@ class ThemeCustomDark extends ThemeExtension<ThemeCustomDark>
   final Color defaultCheckboxColor = const Color.fromRGBO(81, 121, 233, 1);
   @override
   final Gradient defaultSwitchColor = const LinearGradient(
-    stops: [0, 93],
+    stops: [0, 0.93],
     colors: [Color(0xFF00C3AA), Color(0xFF00D4FF)],
   );
   @override

--- a/app_theme/lib/src/light/theme_custom_dark.dart
+++ b/app_theme/lib/src/light/theme_custom_dark.dart
@@ -95,7 +95,7 @@ class ThemeCustomDark extends ThemeExtension<ThemeCustomDark>
   final Color defaultCheckboxColor = const Color(0xFF00D4FF);
   @override
   final Gradient defaultSwitchColor = const LinearGradient(
-    stops: [0, 93],
+    stops: [0, 0.93],
     colors: [Color(0xFF00C3AA), Color(0xFF00D4FF)],
   );
   @override

--- a/app_theme/lib/src/light/theme_custom_light.dart
+++ b/app_theme/lib/src/light/theme_custom_light.dart
@@ -96,7 +96,7 @@ class ThemeCustomLight extends ThemeExtension<ThemeCustomLight>
   final Color defaultCheckboxColor = const Color(0xFF00D4FF);
   @override
   final Gradient defaultSwitchColor = const LinearGradient(
-    stops: [0, 93],
+    stops: [0, 0.93],
     colors: [Color(0xFF00C3AA), Color(0xFF00D4FF)],
   );
   @override


### PR DESCRIPTION
## Summary
- correct gradient stop values for toggle track in `defaultSwitchColor`

## Testing
- `dart format app_theme/lib/src/dark/theme_custom_dark.dart app_theme/lib/src/light/theme_custom_light.dart app_theme/lib/src/light/theme_custom_dark.dart`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6874fa21492083269b93080ebf4968f7