### PR TITLE
fix(fiat-onramp): improve fiat provider fault tolerance

### DIFF
--- a/lib/bloc/fiat/ramp/models/host_assets_config.dart
+++ b/lib/bloc/fiat/ramp/models/host_assets_config.dart
@@ -1,5 +1,6 @@
 import 'package:decimal/decimal.dart';
 import 'package:web_dex/bloc/fiat/ramp/models/ramp_asset_info.dart';
+import 'package:web_dex/bloc/fiat/ramp/ramp_api_utils.dart';
 
 /// Configuration for on/off ramp provider assets and fees
 ///
@@ -33,23 +34,23 @@ class HostAssetsConfig {
   /// Creates a new [HostAssetsConfig] instance
   HostAssetsConfig({
     required this.assets,
-    this.enabledFeatures,
     required this.currencyCode,
     required this.minPurchaseAmount,
     required this.maxPurchaseAmount,
     required this.minFeeAmount,
     required this.minFeePercent,
     required this.maxFeePercent,
+    this.enabledFeatures,
   });
 
   /// Creates a [HostAssetsConfig] from a JSON map
   ///
   /// Throws [FormatException] if required fields are missing or have invalid format
   factory HostAssetsConfig.fromJson(Map<String, dynamic> json) {
-    if (json['name'] == 'ValidationException' || json['status'] == 400) {
-      final message = json['response'] ?? json['message'];
-      throw FormatException('Ramp validation error: $message');
-    }
+    RampApiUtils.validateResponse<Map<String, dynamic>>(
+      json,
+      context: 'HostAssetsConfig.fromJson',
+    );
 
     // Validate required fields
     _validateRequiredField(json, 'assets');
@@ -62,13 +63,13 @@ class HostAssetsConfig {
 
     // Validate assets is a list
     if (json['assets'] is! List) {
-      throw FormatException('Field "assets" must be a list');
+      throw const FormatException('Field "assets" must be a list');
     }
 
     return HostAssetsConfig(
       assets: (json['assets'] as List<dynamic>).map((assetJson) {
         if (assetJson is! Map<String, dynamic>) {
-          throw FormatException('Each asset must be a valid JSON object');
+          throw const FormatException('Each asset must be a valid JSON object');
         }
         return RampAssetInfo.fromJson(assetJson);
       }).toList(),
@@ -86,7 +87,9 @@ class HostAssetsConfig {
 
   /// Helper method to validate required fields in JSON
   static void _validateRequiredField(
-      Map<String, dynamic> json, String fieldName) {
+    Map<String, dynamic> json,
+    String fieldName,
+  ) {
     if (!json.containsKey(fieldName) || json[fieldName] == null) {
       throw FormatException('Required field "$fieldName" is missing or null');
     }
@@ -103,7 +106,8 @@ class HostAssetsConfig {
       return Decimal.parse(value.toString());
     } catch (e) {
       throw FormatException(
-          'Field "$fieldName" has invalid decimal format: $value');
+        'Field "$fieldName" has invalid decimal format: $value',
+      );
     }
   }
 }

--- a/lib/bloc/fiat/ramp/models/host_assets_config.dart
+++ b/lib/bloc/fiat/ramp/models/host_assets_config.dart
@@ -46,6 +46,11 @@ class HostAssetsConfig {
   ///
   /// Throws [FormatException] if required fields are missing or have invalid format
   factory HostAssetsConfig.fromJson(Map<String, dynamic> json) {
+    if (json['name'] == 'ValidationException' || json['status'] == 400) {
+      final message = json['response'] ?? json['message'];
+      throw FormatException('Ramp validation error: $message');
+    }
+
     // Validate required fields
     _validateRequiredField(json, 'assets');
     _validateRequiredField(json, 'currencyCode');

--- a/lib/bloc/fiat/ramp/ramp_api_utils.dart
+++ b/lib/bloc/fiat/ramp/ramp_api_utils.dart
@@ -22,7 +22,8 @@ class RampApiUtils {
     if (response is! T) {
       _log.warning(
           'Unexpected response${context != null ? ' for $context' : ''}: $response');
-      throw FormatException('Unexpected response type from Ramp');
+      final contextInfo = context != null ? ' for $context' : '';
+      throw FormatException('Unexpected response type$contextInfo from Ramp');
     }
     return response;
   }

--- a/lib/bloc/fiat/ramp/ramp_api_utils.dart
+++ b/lib/bloc/fiat/ramp/ramp_api_utils.dart
@@ -1,0 +1,29 @@
+import 'package:logging/logging.dart';
+
+/// Utility for validating Ramp API responses.
+class RampApiUtils {
+  static final Logger _log = Logger('RampApiUtils');
+
+  /// Validates [response] for standard Ramp API errors and ensures it is of
+  /// the expected type [T].
+  ///
+  /// Throws a [FormatException] if the response indicates a validation error
+  /// or if it is not of type [T].
+  static T validateResponse<T>(dynamic response, {String? context}) {
+    if (response is Map<String, dynamic>) {
+      final name = response['name'];
+      final status = response['status'];
+      if (name == 'ValidationException' || status == 400) {
+        final message = response['response'] ?? response['message'];
+        throw FormatException('Ramp validation error: $message');
+      }
+    }
+
+    if (response is! T) {
+      _log.warning(
+          'Unexpected response${context != null ? ' for $context' : ''}: $response');
+      throw FormatException('Unexpected response type from Ramp');
+    }
+    return response;
+  }
+}

--- a/lib/bloc/fiat/ramp/ramp_fiat_provider.dart
+++ b/lib/bloc/fiat/ramp/ramp_fiat_provider.dart
@@ -99,10 +99,10 @@ class RampFiatProvider extends BaseFiatProvider {
   @override
   Future<List<FiatCurrency>> getFiatList() async {
     final raw = await _getFiats();
-    final response =
-        RampApiUtils.validateResponse<List>(raw, context: '_getFiats');
-
-    final data = response.cast<Map<String, dynamic>>();
+    final data = RampApiUtils.validateResponse<List<Map<String, dynamic>>>(
+      raw,
+      context: '_getFiats',
+    );
 
     return data
         .where((item) => item['onrampAvailable'] as bool? ?? false)

--- a/lib/bloc/fiat/ramp/ramp_fiat_provider.dart
+++ b/lib/bloc/fiat/ramp/ramp_fiat_provider.dart
@@ -9,6 +9,7 @@ import 'package:web_dex/bloc/fiat/base_fiat_provider.dart';
 import 'package:web_dex/bloc/fiat/fiat_order_status.dart';
 import 'package:web_dex/bloc/fiat/models/models.dart';
 import 'package:web_dex/bloc/fiat/ramp/models/host_assets_config.dart';
+import 'package:web_dex/bloc/fiat/ramp/ramp_api_utils.dart';
 import 'package:web_dex/bloc/fiat/ramp/models/onramp_purchase_quotation/onramp_purchase_quotation.dart';
 
 const komodoLogoUrl = 'https://app.komodoplatform.com/icons/logo_icon.png';
@@ -97,10 +98,14 @@ class RampFiatProvider extends BaseFiatProvider {
 
   @override
   Future<List<FiatCurrency>> getFiatList() async {
-    final response = await _getFiats();
-    final data = response as List<dynamic>;
+    final raw = await _getFiats();
+    final response =
+        RampApiUtils.validateResponse<List>(raw, context: '_getFiats');
+
+    final data = response.cast<Map<String, dynamic>>();
+
     return data
-        .where((item) => item['onrampAvailable'] as bool)
+        .where((item) => item['onrampAvailable'] as bool? ?? false)
         .map(
           (item) => FiatCurrency(
             symbol: item['fiatCurrency'] as String,
@@ -114,9 +119,11 @@ class RampFiatProvider extends BaseFiatProvider {
   @override
   Future<List<CryptoCurrency>> getCoinList() async {
     try {
-      final response = await _getCoins();
-      final config =
-          HostAssetsConfig.fromJson(response as Map<String, dynamic>);
+      final raw = await _getCoins();
+      final response = RampApiUtils.validateResponse<Map<String, dynamic>>(raw,
+          context: '_getCoins');
+
+      final config = HostAssetsConfig.fromJson(response);
 
       return config.assets
           .map((asset) {


### PR DESCRIPTION
## Summary
- handle provider exceptions gracefully in `FiatRepository`
- centralize Ramp API response validation
- ensure Ramp models detect API validation errors

## Testing
- `dart format lib/bloc/fiat/ramp/ramp_api_utils.dart lib/bloc/fiat/ramp/ramp_fiat_provider.dart lib/bloc/fiat/ramp/models/host_assets_config.dart lib/bloc/fiat/fiat_repository.dart`
- `flutter analyze lib/bloc/fiat`
- `flutter build web` *(fails: Coin assets have been updated)*
- `flutter build web`


------
https://chatgpt.com/codex/tasks/task_e_6874f00f80b0833185788700fecd02b4