### PR TITLE
fix(wallet): prefer utxo asset for stats

### DIFF
--- a/lib/views/wallet/wallet_page/wallet_main/wallet_main.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/wallet_main.dart
@@ -276,7 +276,7 @@ class _WalletMainState extends State<WalletMain> with TickerProviderStateMixin {
   void _onAssetStatisticsTap(AssetId assetId, Duration period) {
     context.read<PriceChartBloc>().add(
           PriceChartStarted(
-            symbols: [assetId.symbol.configSymbol],
+            symbols: [assetId.symbol.assetConfigId],
             period: period,
           ),
         );


### PR DESCRIPTION
## Summary
- allow grouped asset statistics to target the UTXO asset when available
- open price charts using asset config IDs
- disable statistics taps for unsupported assets

## Testing
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_68751f46e4988326971d71a3fef29072