### PR TITLE
feat(wallet): enable asset statistics chart navigation

### DIFF
--- a/lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart
+++ b/lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart
@@ -27,6 +27,7 @@ class ExpandableCoinListItem extends StatefulWidget {
   final bool isSelected;
   final Color? backgroundColor;
   final VoidCallback? onTap;
+  final void Function(AssetId, Duration period)? onStatisticsTap;
 
   const ExpandableCoinListItem({
     super.key,
@@ -35,6 +36,7 @@ class ExpandableCoinListItem extends StatefulWidget {
     required this.isSelected,
     this.onTap,
     this.backgroundColor,
+    this.onStatisticsTap,
   });
 
   @override
@@ -179,7 +181,7 @@ class _ExpandableCoinListItemState extends State<ExpandableCoinListItem> {
                       Theme.of(context).brightness == Brightness.dark
                           ? Theme.of(context).extension<ThemeCustomDark>()!
                           : Theme.of(context).extension<ThemeCustomLight>()!;
-                  return TrendPercentageText(
+                  final trendWidget = TrendPercentageText(
                     percentage: change24hPercent ?? 0.0,
                     upColor: themeCustom.increaseColor,
                     downColor: themeCustom.decreaseColor,
@@ -189,6 +191,16 @@ class _ExpandableCoinListItemState extends State<ExpandableCoinListItem> {
                     iconSize: 12,
                     spacing: 2,
                     textStyle: theme.textTheme.bodySmall,
+                  );
+
+                  return InkWell(
+                    onTap: widget.onStatisticsTap == null
+                        ? null
+                        : () => widget.onStatisticsTap!(
+                              widget.coin.id,
+                              const Duration(days: 1),
+                            ),
+                    child: trendWidget,
                   );
                 },
               ),
@@ -230,13 +242,23 @@ class _ExpandableCoinListItemState extends State<ExpandableCoinListItem> {
                   Theme.of(context).brightness == Brightness.dark
                       ? Theme.of(context).extension<ThemeCustomDark>()!
                       : Theme.of(context).extension<ThemeCustomLight>()!;
-              return TrendPercentageText(
+              final trendWidget = TrendPercentageText(
                 percentage: change24hPercent,
                 upColor: themeCustom.increaseColor,
                 downColor: themeCustom.decreaseColor,
                 value: change24hValue,
                 valueFormatter: (value) =>
                     NumberFormat.currency(symbol: '\$').format(value),
+              );
+
+              return InkWell(
+                onTap: widget.onStatisticsTap == null
+                    ? null
+                    : () => widget.onStatisticsTap!(
+                          widget.coin.id,
+                          const Duration(days: 1),
+                        ),
+                child: trendWidget,
               );
             },
           ),

--- a/lib/views/wallet/wallet_page/wallet_main/active_coins_list.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/active_coins_list.dart
@@ -24,11 +24,13 @@ class ActiveCoinsList extends StatelessWidget {
     required this.searchPhrase,
     required this.withBalance,
     required this.onCoinItemTap,
+    this.onStatisticsTap,
   });
 
   final String searchPhrase;
   final bool withBalance;
   final Function(Coin) onCoinItemTap;
+  final void Function(AssetId, Duration period)? onStatisticsTap;
 
   @override
   Widget build(BuildContext context) {
@@ -76,6 +78,7 @@ class ActiveCoinsList extends StatelessWidget {
                 pubkeys: state.pubkeys[coin.abbr],
                 isSelected: false,
                 onTap: () => onCoinItemTap(coin),
+                onStatisticsTap: onStatisticsTap,
               ),
             );
           },

--- a/lib/views/wallet/wallet_page/wallet_main/wallet_main.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/wallet_main.dart
@@ -418,6 +418,7 @@ class CoinListView extends StatelessWidget {
           searchPhrase: searchPhrase,
           withBalance: withBalance,
           onCoinItemTap: onActiveCoinItemTap,
+          onStatisticsTap: onAssetStatisticsTap,
         );
       case AuthorizeMode.hiddenLogin:
       case AuthorizeMode.noLogin:


### PR DESCRIPTION
## Summary
- add onStatisticsTap param to `ExpandableCoinListItem`
- let `ActiveCoinsList` forward statistics taps
- open relevant chart when tapping asset statistics

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_68766c0f1fe88326a0307c7bcd5bca9c