### PR TITLE
feat(analytics): include durations for trading events

### DIFF
--- a/lib/analytics/analytics_factory.dart
+++ b/lib/analytics/analytics_factory.dart
@@ -231,12 +231,14 @@ class AnalyticsEvents {
     required String toChain,
     required String asset,
     required double amount,
+    int? durationMs,
   }) {
     return BridgeSuccessEvent(
       fromChain: fromChain,
       toChain: toChain,
       asset: asset,
       amount: amount,
+      durationMs: durationMs,
     );
   }
 
@@ -245,11 +247,13 @@ class AnalyticsEvents {
     required String fromChain,
     required String toChain,
     required String failError,
+    int? durationMs,
   }) {
     return BridgeFailureEvent(
       fromChain: fromChain,
       toChain: toChain,
       failError: failError,
+      durationMs: durationMs,
     );
   }
 
@@ -482,6 +486,7 @@ class BridgeSuccessEvent extends AnalyticsEventData {
     required this.toChain,
     required this.asset,
     required this.amount,
+    this.durationMs,
   });
 
   @override
@@ -491,6 +496,7 @@ class BridgeSuccessEvent extends AnalyticsEventData {
   final String toChain;
   final String asset;
   final double amount;
+  final int? durationMs;
 
   @override
   JsonMap get parameters => {
@@ -498,6 +504,7 @@ class BridgeSuccessEvent extends AnalyticsEventData {
         'to_chain': toChain,
         'asset': asset,
         'amount': amount,
+        if (durationMs != null) 'duration_ms': durationMs,
       };
 }
 
@@ -506,6 +513,7 @@ class BridgeFailureEvent extends AnalyticsEventData {
     required this.fromChain,
     required this.toChain,
     required this.failError,
+    this.durationMs,
   });
 
   @override
@@ -514,12 +522,14 @@ class BridgeFailureEvent extends AnalyticsEventData {
   final String fromChain;
   final String toChain;
   final String failError;
+  final int? durationMs;
 
   @override
   JsonMap get parameters => {
         'from_chain': fromChain,
         'to_chain': toChain,
         'fail_error': failError,
+        if (durationMs != null) 'duration_ms': durationMs,
       };
 }
 

--- a/lib/analytics/events/transaction_events.dart
+++ b/lib/analytics/events/transaction_events.dart
@@ -200,6 +200,7 @@ class SwapSucceededEventData implements AnalyticsEventData {
     required this.amount,
     required this.fee,
     required this.walletType,
+    this.durationMs,
   });
 
   final String fromAsset;
@@ -207,6 +208,7 @@ class SwapSucceededEventData implements AnalyticsEventData {
   final double amount;
   final double fee;
   final String walletType;
+  final int? durationMs;
 
   @override
   String get name => 'swap_success';
@@ -218,6 +220,7 @@ class SwapSucceededEventData implements AnalyticsEventData {
         'amount': amount,
         'fee': fee,
         'wallet_type': walletType,
+        if (durationMs != null) 'duration_ms': durationMs,
       };
 }
 
@@ -229,12 +232,14 @@ class AnalyticsSwapSucceededEvent extends AnalyticsSendDataEvent {
     required double amount,
     required double fee,
     required String walletType,
+    int? durationMs,
   }) : super(SwapSucceededEventData(
           fromAsset: fromAsset,
           toAsset: toAsset,
           amount: amount,
           fee: fee,
           walletType: walletType,
+          durationMs: durationMs,
         ));
 }
 
@@ -250,12 +255,14 @@ class SwapFailedEventData implements AnalyticsEventData {
     required this.toAsset,
     required this.failStage,
     required this.walletType,
+    this.durationMs,
   });
 
   final String fromAsset;
   final String toAsset;
   final String failStage;
   final String walletType;
+  final int? durationMs;
 
   @override
   String get name => 'swap_failure';
@@ -266,6 +273,7 @@ class SwapFailedEventData implements AnalyticsEventData {
         'to_asset': toAsset,
         'fail_stage': failStage,
         'wallet_type': walletType,
+        if (durationMs != null) 'duration_ms': durationMs,
       };
 }
 
@@ -276,10 +284,12 @@ class AnalyticsSwapFailedEvent extends AnalyticsSendDataEvent {
     required String toAsset,
     required String failStage,
     required String walletType,
+    int? durationMs,
   }) : super(SwapFailedEventData(
           fromAsset: fromAsset,
           toAsset: toAsset,
           failStage: failStage,
           walletType: walletType,
+          durationMs: durationMs,
         ));
 }

--- a/lib/analytics/required_analytics_events.csv
+++ b/lib/analytics/required_analytics_events.csv
@@ -15,12 +15,12 @@ Token toggled off / hidden,asset_disabled,Asset Mgmt,"asset_symbol, asset_networ
 Send flow started,send_initiated,Transactions,"asset_symbol, network, amount","Tx funnel start, popular send assets",High (v0.9.0),FALSE,Send form start,Log when user opens send flow with asset and amount.
 On-chain send completed,send_success,Transactions,"asset_symbol, network, amount","Successful sends, volume, avg size",High (v0.9.0),FALSE,Send confirmation,Fire after a transaction broadcast succeeds.
 Send failed / cancelled,send_failure,Transactions,"asset_symbol, network, fail_reason","Error hotspots, UX / network issues",High (v0.9.0),FALSE,Send error handling,Emit when send flow fails or is cancelled.
-Swap order submitted,swap_initiated,Trading (DEX),"from_asset, to_asset, networks","DEX funnel start, pair demand",High (v0.9.0),FALSE,Swap order submit,Dispatch when atomic swap order created.
-Atomic swap succeeded,swap_success,Trading (DEX),"from_asset, to_asset, amount, fee","Trading volume, fee revenue",High (v0.9.0),FALSE,Swap completion,Send on successful atomic swap completion.
-Swap failed,swap_failure,Trading (DEX),"from_asset, to_asset, fail_stage","Liquidity gaps, tech/UX blockers",High (v0.9.0),FALSE,Swap error,Log when swap fails at any stage.
-Bridge transfer started,bridge_initiated,Cross-Chain,"from_chain, to_chain, asset","Bridge demand, chain pairs",Medium (v0.9.1),FALSE,Bridge transfer start,Emit when cross-chain bridge initiated.
-Bridge completed,bridge_success,Cross-Chain,"from_chain, to_chain, asset, amount","Cross-chain volume, success rate",Medium (v0.9.1),FALSE,Bridge completion,Send when bridge transfer succeeds.
-Bridge failed,bridge_failure,Cross-Chain,"from_chain, to_chain, fail_error","Reliability issues, risk analysis",Medium (v0.9.1),FALSE,Bridge error,Fire when bridge transfer fails.
+Swap order submitted,swap_initiated,Trading (DEX),"from_asset, to_asset, networks","DEX funnel start, pair demand",High (v0.9.0),TRUE,Swap order submit,Dispatch when atomic swap order created.
+Atomic swap succeeded,swap_success,Trading (DEX),"from_asset, to_asset, amount, fee","Trading volume, fee revenue",High (v0.9.0),TRUE,Swap completion,Send on successful atomic swap completion.
+Swap failed,swap_failure,Trading (DEX),"from_asset, to_asset, fail_stage","Liquidity gaps, tech/UX blockers",High (v0.9.0),TRUE,Swap error,Log when swap fails at any stage.
+Bridge transfer started,bridge_initiated,Cross-Chain,"from_chain, to_chain, asset","Bridge demand, chain pairs",Medium (v0.9.1),TRUE,Bridge transfer start,Emit when cross-chain bridge initiated.
+Bridge completed,bridge_success,Cross-Chain,"from_chain, to_chain, asset, amount","Cross-chain volume, success rate",Medium (v0.9.1),TRUE,Bridge completion,Send when bridge transfer succeeds.
+Bridge failed,bridge_failure,Cross-Chain,"from_chain, to_chain, fail_error","Reliability issues, risk analysis",Medium (v0.9.1),TRUE,Bridge error,Fire when bridge transfer fails.
 NFT gallery opened (measure load perf),nft_gallery_opened,NFT Wallet,"nft_count, load_time_ms","NFT engagement, gallery performance",Medium (v0.9.1),FALSE,NFT gallery screen,Record load time and count when gallery opened.
 NFT send flow started,nft_transfer_initiated,NFT Wallet,"collection_name, token_id, hd_type","NFT tx funnel start, collection popularity",Medium (v0.9.1),FALSE,NFT send screen,Trigger when user opens NFT transfer flow.
 NFT sent successfully,nft_transfer_success,NFT Wallet,"collection_name, token_id, fee, hd_type","NFT volume, user confidence",Medium (v0.9.1),FALSE,NFT send confirmation,Log when NFT transfer completes successfully.

--- a/lib/views/dex/entity_details/trading_details.dart
+++ b/lib/views/dex/entity_details/trading_details.dart
@@ -130,6 +130,11 @@ class _TradingDetailsState extends State<TradingDetails> {
       final walletType = authBloc.state.currentUser?.wallet.config.type.name;
       final fromAsset = swapStatus.sellCoin;
       final toAsset = swapStatus.buyCoin;
+      final int? durationMs =
+          swapStatus.events.isNotEmpty && swapStatus.myInfo != null
+              ? swapStatus.events.last.timestamp -
+                  swapStatus.myInfo!.startedAt * 1000
+              : null;
       if (swapStatus.isSuccessful && !_loggedSuccess) {
         _loggedSuccess = true;
         // Find trade fee from events
@@ -153,6 +158,7 @@ class _TradingDetailsState extends State<TradingDetails> {
                 amount: swapStatus.sellAmount.toDouble(),
                 fee: fee,
                 walletType: walletType ?? 'unknown',
+                durationMs: durationMs,
               ),
             );
 
@@ -162,11 +168,12 @@ class _TradingDetailsState extends State<TradingDetails> {
               coinsRepo.getCoin(fromAsset)?.protocolType ?? 'unknown';
           final toChain = coinsRepo.getCoin(toAsset)?.protocolType ?? 'unknown';
           context.read<AnalyticsBloc>().logEvent(
-                BridgeSuccessEvent(
+                AnalyticsEvents.bridgeSuccess(
                   fromChain: fromChain,
                   toChain: toChain,
                   asset: fromAsset,
                   amount: swapStatus.sellAmount.toDouble(),
+                  durationMs: durationMs,
                 ),
               );
         }
@@ -178,6 +185,7 @@ class _TradingDetailsState extends State<TradingDetails> {
                 toAsset: toAsset,
                 failStage: swapStatus.status.name,
                 walletType: walletType ?? 'unknown',
+                durationMs: durationMs,
               ),
             );
 
@@ -187,10 +195,11 @@ class _TradingDetailsState extends State<TradingDetails> {
               coinsRepo.getCoin(fromAsset)?.protocolType ?? 'unknown';
           final toChain = coinsRepo.getCoin(toAsset)?.protocolType ?? 'unknown';
           context.read<AnalyticsBloc>().logEvent(
-                BridgeFailureEvent(
+                AnalyticsEvents.bridgeFailure(
                   fromChain: fromChain,
                   toChain: toChain,
                   failError: swapStatus.status.name,
+                  durationMs: durationMs,
                 ),
               );
         }

--- a/lib/views/dex/simple/confirm/maker_order_confirmation.dart
+++ b/lib/views/dex/simple/confirm/maker_order_confirmation.dart
@@ -327,7 +327,9 @@ class _MakerOrderConfirmationState extends State<MakerOrderConfirmation> {
           ),
         );
 
+    final int callStart = DateTime.now().millisecondsSinceEpoch;
     final TextError? error = await makerFormBloc.makeOrder();
+    final int durationMs = DateTime.now().millisecondsSinceEpoch - callStart;
 
     final tradingEntitiesBloc =
         // ignore: use_build_context_synchronously
@@ -346,6 +348,7 @@ class _MakerOrderConfirmationState extends State<MakerOrderConfirmation> {
               toAsset: buyCoin,
               failStage: 'order_submission',
               walletType: walletType,
+              durationMs: durationMs,
             ),
           );
       setState(() => _errorMessage = error.error);
@@ -359,6 +362,7 @@ class _MakerOrderConfirmationState extends State<MakerOrderConfirmation> {
             amount: makerFormBloc.sellAmount!.toDouble(),
             fee: 0, // Fee data not available
             walletType: walletType,
+            durationMs: durationMs,
           ),
         );
     makerFormBloc.clear();


### PR DESCRIPTION
## Summary
- add duration fields to swap success/failure analytics events
- add duration fields to bridge success/failure events
- report timing information from trading details and maker order screens
- mark trading analytics events as implemented in CSV

## Testing
- `flutter analyze` *(fails: 503 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68767548706083268346f380683f5bda