### PR TITLE
fix(ui): position logout dropdown

### DIFF
--- a/packages/komodo_ui_kit/lib/src/buttons/ui_dropdown.dart
+++ b/packages/komodo_ui_kit/lib/src/buttons/ui_dropdown.dart
@@ -114,7 +114,7 @@ class _UiDropdownState extends State<UiDropdown> with WidgetsBindingObserver {
           ),
           Positioned(
             top: (_top ?? 0) + 10,
-            right: _right,
+            left: _left,
             child: Material(
               color: Colors.transparent,
               child: widget.dropdown,
@@ -155,15 +155,12 @@ class _UiDropdownState extends State<UiDropdown> with WidgetsBindingObserver {
     return switcherOffset.dy + switcherSize.height;
   }
 
-  double? get _right {
+  double? get _left {
     final Offset? switcherOffset = _switcherOffset;
-    final Size? switcherSize = _switcherSize;
-
-    if (switcherOffset == null || switcherSize == null) {
+    if (switcherOffset == null) {
       return null;
     }
-    final double windowWidth = MediaQuery.of(context).size.width;
 
-    return windowWidth - (switcherOffset.dx + switcherSize.width);
+    return switcherOffset.dx;
   }
 }


### PR DESCRIPTION
## Summary
- ensure UiDropdown dropdown is positioned below the switcher button

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_68768138e74883269c99ed5f09708603