### PR TITLE
fix(wallet): persist hd status and default to non-hd

### DIFF
--- a/lib/views/wallets_manager/wallets_manager_wrapper.dart
+++ b/lib/views/wallets_manager/wallets_manager_wrapper.dart
@@ -11,7 +11,7 @@ class WalletsManagerWrapper extends StatefulWidget {
     required this.eventType,
     this.onSuccess,
     this.selectedWallet,
-    this.initialHdMode = true,
+    this.initialHdMode = false,
     super.key = const Key('wallets-manager-wrapper'),
   });
 
@@ -59,7 +59,9 @@ class _WalletsManagerWrapperState extends State<WalletsManagerWrapper> {
       close: _closeWalletManager,
       onSuccess: widget.onSuccess ?? (_) {},
       selectedWallet: widget.selectedWallet,
-      initialHdMode: widget.initialHdMode,
+      initialHdMode: widget.selectedWallet?.config.type == WalletType.hdwallet
+          ? true
+          : widget.initialHdMode,
     );
   }
 

--- a/lib/views/wallets_manager/widgets/iguana_wallets_manager.dart
+++ b/lib/views/wallets_manager/widgets/iguana_wallets_manager.dart
@@ -25,7 +25,7 @@ class IguanaWalletsManager extends StatefulWidget {
     required this.close,
     required this.onSuccess,
     this.initialWallet,
-    this.initialHdMode = true,
+    this.initialHdMode = false,
     super.key,
   });
 
@@ -45,13 +45,15 @@ class _IguanaWalletsManagerState extends State<IguanaWalletsManager> {
   Wallet? _selectedWallet;
   WalletsManagerExistWalletAction _existWalletAction =
       WalletsManagerExistWalletAction.none;
-  bool _initialHdMode = true;
+  bool _initialHdMode = false;
 
   @override
   void initState() {
     super.initState();
     _selectedWallet = widget.initialWallet;
-    _initialHdMode = widget.initialHdMode;
+    _initialHdMode = widget.initialWallet?.config.type == WalletType.hdwallet
+        ? true
+        : widget.initialHdMode;
     if (_selectedWallet != null) {
       _existWalletAction = WalletsManagerExistWalletAction.logIn;
     }

--- a/lib/views/wallets_manager/widgets/wallet_creation.dart
+++ b/lib/views/wallets_manager/widgets/wallet_creation.dart
@@ -41,7 +41,7 @@ class _WalletCreationState extends State<WalletCreation> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   bool _eulaAndTosChecked = false;
   bool _inProgress = false;
-  bool _isHdMode = false;
+  bool _isHdMode = true;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/views/wallets_manager/widgets/wallet_creation.dart
+++ b/lib/views/wallets_manager/widgets/wallet_creation.dart
@@ -26,8 +26,7 @@ class WalletCreation extends StatefulWidget {
     required String name,
     required String password,
     WalletType? walletType,
-  })
-  onCreate;
+  }) onCreate;
   final void Function() onCancel;
 
   @override
@@ -42,7 +41,7 @@ class _WalletCreationState extends State<WalletCreation> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   bool _eulaAndTosChecked = false;
   bool _inProgress = false;
-  bool _isHdMode = true;
+  bool _isHdMode = false;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/views/wallets_manager/widgets/wallet_import_by_file.dart
+++ b/lib/views/wallets_manager/widgets/wallet_import_by_file.dart
@@ -46,7 +46,7 @@ class _WalletImportByFileState extends State<WalletImportByFile> {
       TextEditingController(text: '');
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   bool _isObscured = true;
-  bool _isHdMode = true;
+  bool _isHdMode = false;
   bool _eulaAndTosChecked = false;
   bool _allowCustomSeed = false;
 

--- a/lib/views/wallets_manager/widgets/wallet_login.dart
+++ b/lib/views/wallets_manager/widgets/wallet_login.dart
@@ -19,7 +19,7 @@ class WalletLogIn extends StatefulWidget {
     required this.wallet,
     required this.onLogin,
     required this.onCancel,
-    this.initialHdMode = true,
+    this.initialHdMode = false,
     super.key,
   });
 
@@ -54,6 +54,7 @@ class _WalletLogInState extends State<WalletLogIn> {
     if (user != null) {
       setState(() {
         _user = user;
+        _isHdMode = user.wallet.config.type == WalletType.hdwallet;
       });
     }
   }

--- a/lib/views/wallets_manager/widgets/wallet_simple_import.dart
+++ b/lib/views/wallets_manager/widgets/wallet_simple_import.dart
@@ -31,13 +31,12 @@ class WalletSimpleImport extends StatefulWidget {
     required String name,
     required String password,
     required WalletConfig walletConfig,
-  })
-  onImport;
+  }) onImport;
 
   final void Function() onCancel;
 
   final void Function({required String fileName, required String fileData})
-  onUploadFiles;
+      onUploadFiles;
 
   @override
   State<WalletSimpleImport> createState() => _WalletImportWrapperState();
@@ -57,7 +56,7 @@ class _WalletImportWrapperState extends State<WalletSimpleImport> {
   bool _eulaAndTosChecked = false;
   bool _inProgress = false;
   bool _allowCustomSeed = false;
-  bool _isHdMode = true;
+  bool _isHdMode = false;
 
   bool get _isButtonEnabled {
     final isFormValid = _refreshFormValidationState();
@@ -338,16 +337,14 @@ class _WalletImportWrapperState extends State<WalletSimpleImport> {
       return null;
     }
 
-    final maybeFailedReason = context
-        .read<KomodoDefiSdk>()
-        .mnemonicValidator
-        .validateMnemonic(
-          seed ?? '',
-          minWordCount: 12,
-          maxWordCount: 24,
-          isHd: _isHdMode,
-          allowCustomSeed: _allowCustomSeed,
-        );
+    final maybeFailedReason =
+        context.read<KomodoDefiSdk>().mnemonicValidator.validateMnemonic(
+              seed ?? '',
+              minWordCount: 12,
+              maxWordCount: 24,
+              isHd: _isHdMode,
+              allowCustomSeed: _allowCustomSeed,
+            );
 
     if (maybeFailedReason == null) {
       return null;
@@ -356,10 +353,9 @@ class _WalletImportWrapperState extends State<WalletSimpleImport> {
     return switch (maybeFailedReason) {
       MnemonicFailedReason.empty =>
         LocaleKeys.walletCreationEmptySeedError.tr(),
-      MnemonicFailedReason.customNotSupportedForHd =>
-        _isHdMode
-            ? LocaleKeys.walletCreationHdBip39SeedError.tr()
-            : LocaleKeys.walletCreationBip39SeedError.tr(),
+      MnemonicFailedReason.customNotSupportedForHd => _isHdMode
+          ? LocaleKeys.walletCreationHdBip39SeedError.tr()
+          : LocaleKeys.walletCreationBip39SeedError.tr(),
       MnemonicFailedReason.customNotAllowed =>
         LocaleKeys.customSeedWarningText.tr(),
       MnemonicFailedReason.invalidLength =>

--- a/lib/views/wallets_manager/widgets/wallets_manager.dart
+++ b/lib/views/wallets_manager/widgets/wallets_manager.dart
@@ -12,7 +12,7 @@ class WalletsManager extends StatelessWidget {
     required this.close,
     required this.onSuccess,
     this.selectedWallet,
-    this.initialHdMode = true,
+    this.initialHdMode = false,
   }) : super(key: key);
   final WalletsManagerEventType eventType;
   final WalletType walletType;


### PR DESCRIPTION
## Summary
- persist HD wallet mode when logging in
- default wallet manager UI to non-HD

## Testing
- `dart format lib/views/wallets_manager/wallets_manager_wrapper.dart lib/views/wallets_manager/widgets/iguana_wallets_manager.dart lib/views/wallets_manager/widgets/wallet_creation.dart lib/views/wallets_manager/widgets/wallet_import_by_file.dart lib/views/wallets_manager/widgets/wallet_login.dart lib/views/wallets_manager/widgets/wallet_simple_import.dart lib/views/wallets_manager/widgets/wallets_manager.dart`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6879067a40d48326b9654dade1880ab6