### PR TITLE
feat(settings): persist hide zero balance assets

### DIFF
--- a/lib/bloc/settings/settings_bloc.dart
+++ b/lib/bloc/settings/settings_bloc.dart
@@ -19,6 +19,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     on<MarketMakerBotSettingsChanged>(_onMarketMakerBotSettingsChanged);
     on<TestCoinsEnabledChanged>(_onTestCoinsEnabledChanged);
     on<WeakPasswordsAllowedChanged>(_onWeakPasswordsAllowedChanged);
+    on<HideZeroBalanceAssetsChanged>(_onHideZeroBalanceAssetsChanged);
   }
 
   late StoredSettings _storedSettings;
@@ -67,5 +68,17 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
           weakPasswordsAllowed: event.weakPasswordsAllowed),
     );
     emitter(state.copyWith(weakPasswordsAllowed: event.weakPasswordsAllowed));
+  }
+
+  Future<void> _onHideZeroBalanceAssetsChanged(
+    HideZeroBalanceAssetsChanged event,
+    Emitter<SettingsState> emitter,
+  ) async {
+    await _settingsRepo.updateSettings(
+      _storedSettings.copyWith(
+        hideZeroBalanceAssets: event.hideZeroBalanceAssets,
+      ),
+    );
+    emitter(state.copyWith(hideZeroBalanceAssets: event.hideZeroBalanceAssets));
   }
 }

--- a/lib/bloc/settings/settings_event.dart
+++ b/lib/bloc/settings/settings_event.dart
@@ -35,3 +35,8 @@ class WeakPasswordsAllowedChanged extends SettingsEvent {
   @override
   List<Object> get props => [weakPasswordsAllowed];
 }
+
+class HideZeroBalanceAssetsChanged extends SettingsEvent {
+  const HideZeroBalanceAssetsChanged({required this.hideZeroBalanceAssets});
+  final bool hideZeroBalanceAssets;
+}

--- a/lib/bloc/settings/settings_state.dart
+++ b/lib/bloc/settings/settings_state.dart
@@ -9,6 +9,7 @@ class SettingsState extends Equatable {
     required this.mmBotSettings,
     required this.testCoinsEnabled,
     required this.weakPasswordsAllowed,
+    required this.hideZeroBalanceAssets,
   });
 
   factory SettingsState.fromStored(StoredSettings stored) {
@@ -17,6 +18,7 @@ class SettingsState extends Equatable {
       mmBotSettings: stored.marketMakerBotSettings,
       testCoinsEnabled: stored.testCoinsEnabled,
       weakPasswordsAllowed: stored.weakPasswordsAllowed,
+      hideZeroBalanceAssets: stored.hideZeroBalanceAssets,
     );
   }
 
@@ -24,6 +26,7 @@ class SettingsState extends Equatable {
   final MarketMakerBotSettings mmBotSettings;
   final bool testCoinsEnabled;
   final bool weakPasswordsAllowed;
+  final bool hideZeroBalanceAssets;
 
   @override
   List<Object?> get props => [
@@ -31,6 +34,7 @@ class SettingsState extends Equatable {
         mmBotSettings,
         testCoinsEnabled,
         weakPasswordsAllowed,
+        hideZeroBalanceAssets,
       ];
 
   SettingsState copyWith({
@@ -38,12 +42,15 @@ class SettingsState extends Equatable {
     MarketMakerBotSettings? marketMakerBotSettings,
     bool? testCoinsEnabled,
     bool? weakPasswordsAllowed,
+    bool? hideZeroBalanceAssets,
   }) {
     return SettingsState(
       themeMode: mode ?? themeMode,
       mmBotSettings: marketMakerBotSettings ?? mmBotSettings,
       testCoinsEnabled: testCoinsEnabled ?? this.testCoinsEnabled,
       weakPasswordsAllowed: weakPasswordsAllowed ?? this.weakPasswordsAllowed,
+      hideZeroBalanceAssets:
+          hideZeroBalanceAssets ?? this.hideZeroBalanceAssets,
     );
   }
 }

--- a/lib/model/stored_settings.dart
+++ b/lib/model/stored_settings.dart
@@ -10,6 +10,7 @@ class StoredSettings {
     required this.marketMakerBotSettings,
     required this.testCoinsEnabled,
     required this.weakPasswordsAllowed,
+    required this.hideZeroBalanceAssets,
   });
 
   final ThemeMode mode;
@@ -17,6 +18,7 @@ class StoredSettings {
   final MarketMakerBotSettings marketMakerBotSettings;
   final bool testCoinsEnabled;
   final bool weakPasswordsAllowed;
+  final bool hideZeroBalanceAssets;
 
   static StoredSettings initial() {
     return StoredSettings(
@@ -25,6 +27,7 @@ class StoredSettings {
       marketMakerBotSettings: MarketMakerBotSettings.initial(),
       testCoinsEnabled: true,
       weakPasswordsAllowed: false,
+      hideZeroBalanceAssets: false,
     );
   }
 
@@ -39,6 +42,7 @@ class StoredSettings {
       ),
       testCoinsEnabled: json['testCoinsEnabled'] ?? true,
       weakPasswordsAllowed: json['weakPasswordsAllowed'] ?? false,
+      hideZeroBalanceAssets: json['hideZeroBalanceAssets'] ?? false,
     );
   }
 
@@ -49,6 +53,7 @@ class StoredSettings {
       storedMarketMakerSettingsKey: marketMakerBotSettings.toJson(),
       'testCoinsEnabled': testCoinsEnabled,
       'weakPasswordsAllowed': weakPasswordsAllowed,
+      'hideZeroBalanceAssets': hideZeroBalanceAssets,
     };
   }
 
@@ -58,6 +63,7 @@ class StoredSettings {
     MarketMakerBotSettings? marketMakerBotSettings,
     bool? testCoinsEnabled,
     bool? weakPasswordsAllowed,
+    bool? hideZeroBalanceAssets,
   }) {
     return StoredSettings(
       mode: mode ?? this.mode,
@@ -66,6 +72,8 @@ class StoredSettings {
           marketMakerBotSettings ?? this.marketMakerBotSettings,
       testCoinsEnabled: testCoinsEnabled ?? this.testCoinsEnabled,
       weakPasswordsAllowed: weakPasswordsAllowed ?? this.weakPasswordsAllowed,
+      hideZeroBalanceAssets:
+          hideZeroBalanceAssets ?? this.hideZeroBalanceAssets,
     );
   }
 }

--- a/lib/views/wallet/wallet_page/wallet_main/wallet_main.dart
+++ b/lib/views/wallet/wallet_page/wallet_main/wallet_main.dart
@@ -21,6 +21,7 @@ import 'package:web_dex/bloc/cex_market_data/price_chart/price_chart_bloc.dart';
 import 'package:web_dex/bloc/cex_market_data/price_chart/price_chart_event.dart';
 import 'package:web_dex/bloc/cex_market_data/profit_loss/profit_loss_bloc.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_bloc.dart';
+import 'package:web_dex/bloc/settings/settings_bloc.dart';
 import 'package:web_dex/bloc/taker_form/taker_bloc.dart';
 import 'package:web_dex/bloc/taker_form/taker_event.dart';
 import 'package:web_dex/common/screen.dart';
@@ -53,7 +54,6 @@ class WalletMain extends StatefulWidget {
 }
 
 class _WalletMainState extends State<WalletMain> with TickerProviderStateMixin {
-  bool _showCoinWithBalance = false;
   String _searchKey = '';
   PopupDispatcher? _popupDispatcher;
   StreamSubscription<Wallet?>? _walletSubscription;
@@ -251,10 +251,10 @@ class _WalletMainState extends State<WalletMain> with TickerProviderStateMixin {
     assetOverviewBloc.add(const AssetOverviewClearRequested());
   }
 
-  void _onShowCoinsWithBalanceClick(bool? value) {
-    setState(() {
-      _showCoinWithBalance = value ?? false;
-    });
+  void _onShowCoinsWithBalanceClick(bool value) {
+    context
+        .read<SettingsBloc>()
+        .add(HideZeroBalanceAssetsChanged(hideZeroBalanceAssets: value));
   }
 
   void _onSearchChange(String searchKey) {
@@ -290,7 +290,8 @@ class _WalletMainState extends State<WalletMain> with TickerProviderStateMixin {
           SliverPersistentHeader(
             pinned: true,
             delegate: _SliverSearchBarDelegate(
-              withBalance: _showCoinWithBalance,
+              withBalance:
+                  context.watch<SettingsBloc>().state.hideZeroBalanceAssets,
               onSearchChange: _onSearchChange,
               onWithBalanceChange: _onShowCoinsWithBalanceClick,
               mode: mode,
@@ -300,7 +301,8 @@ class _WalletMainState extends State<WalletMain> with TickerProviderStateMixin {
           CoinListView(
             mode: mode,
             searchPhrase: _searchKey,
-            withBalance: _showCoinWithBalance,
+            withBalance:
+                context.watch<SettingsBloc>().state.hideZeroBalanceAssets,
             onActiveCoinItemTap: _onActiveCoinItemTap,
             onAssetItemTap: _onAssetItemTap,
             onAssetStatisticsTap: _onAssetStatisticsTap,


### PR DESCRIPTION
## Summary
- store the hide zero balance assets toggle in stored settings
- expose the setting in state and bloc events
- update wallet to use the persisted value

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_68792bd9c88883268186b34ef8e1294a