### PR TITLE
Filter Trezor wallets by name

### DIFF
--- a/lib/blocs/wallets_repository.dart
+++ b/lib/blocs/wallets_repository.dart
@@ -36,7 +36,9 @@ class WalletsRepository {
     final legacyWallets = await _getLegacyWallets();
     _cachedWallets = (await _kdfSdk.wallets)
         .where(
-          (wallet) => wallet.config.type != WalletType.trezor,
+          (wallet) =>
+              wallet.config.type != WalletType.trezor &&
+              !wallet.name.toLowerCase().startsWith('my trezor'),
         )
         .toList();
     return [..._cachedWallets!, ...legacyWallets];


### PR DESCRIPTION
## Summary
- ignore wallets named `My Trezor*` when loading wallets

## Testing
- `dart format lib/blocs/wallets_repository.dart`
- `flutter analyze lib/blocs/wallets_repository.dart`
- `flutter build web` *(fails)*
- `flutter build web`

------
https://chatgpt.com/codex/tasks/task_e_687a096883f08331925e89039bbd6f61