### PR TITLE
Disable Trezor login on unsupported browsers

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -353,6 +353,7 @@
   "trezorErrorInvalidPin": "Invalid PIN code",
   "trezorSelectTitle": "Connect a hardware wallet",
   "trezorSelectSubTitle": "Select a hardware wallet you'd like to use with Komodo Wallet",
+  "trezorBrowserUnsupported": "Browser is not supported. Please use Chrome for Trezor login",
   "mixedCaseError": "If you are using non mixed case address, please try to convert to mixed case one.",
   "addressConvertedToMixedCase": "Address automatically converted to mixed-case for checksum validation.",
   "invalidAddressChecksum": "Invalid address checksum",

--- a/lib/generated/codegen_loader.g.dart
+++ b/lib/generated/codegen_loader.g.dart
@@ -2,7 +2,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-abstract class  LocaleKeys {
+abstract class LocaleKeys {
   static const plsActivateKmd = 'plsActivateKmd';
   static const rewardClaiming = 'rewardClaiming';
   static const noKmdAddress = 'noKmdAddress';
@@ -106,39 +106,50 @@ abstract class  LocaleKeys {
   static const seedPhrase = 'seedPhrase';
   static const assetNumber = 'assetNumber';
   static const clipBoard = 'clipBoard';
-  static const walletsManagerCreateWalletButton = 'walletsManagerCreateWalletButton';
-  static const walletsManagerImportWalletButton = 'walletsManagerImportWalletButton';
-  static const walletsManagerStepBuilderCreationWalletError = 'walletsManagerStepBuilderCreationWalletError';
+  static const walletsManagerCreateWalletButton =
+      'walletsManagerCreateWalletButton';
+  static const walletsManagerImportWalletButton =
+      'walletsManagerImportWalletButton';
+  static const walletsManagerStepBuilderCreationWalletError =
+      'walletsManagerStepBuilderCreationWalletError';
   static const walletCreationTitle = 'walletCreationTitle';
   static const walletImportTitle = 'walletImportTitle';
   static const walletImportByFileTitle = 'walletImportByFileTitle';
-  static const walletImportCreatePasswordTitle = 'walletImportCreatePasswordTitle';
+  static const walletImportCreatePasswordTitle =
+      'walletImportCreatePasswordTitle';
   static const walletImportByFileDescription = 'walletImportByFileDescription';
   static const walletLogInTitle = 'walletLogInTitle';
   static const walletCreationNameHint = 'walletCreationNameHint';
   static const walletCreationPasswordHint = 'walletCreationPasswordHint';
-  static const walletCreationConfirmPasswordHint = 'walletCreationConfirmPasswordHint';
+  static const walletCreationConfirmPasswordHint =
+      'walletCreationConfirmPasswordHint';
   static const walletCreationConfirmPassword = 'walletCreationConfirmPassword';
   static const walletCreationUploadFile = 'walletCreationUploadFile';
   static const walletCreationEmptySeedError = 'walletCreationEmptySeedError';
   static const walletCreationExistNameError = 'walletCreationExistNameError';
   static const walletCreationNameLengthError = 'walletCreationNameLengthError';
-  static const walletCreationFormatPasswordError = 'walletCreationFormatPasswordError';
-  static const walletCreationConfirmPasswordError = 'walletCreationConfirmPasswordError';
+  static const walletCreationFormatPasswordError =
+      'walletCreationFormatPasswordError';
+  static const walletCreationConfirmPasswordError =
+      'walletCreationConfirmPasswordError';
   static const incorrectPassword = 'incorrectPassword';
   static const importSeedEnterSeedPhraseHint = 'importSeedEnterSeedPhraseHint';
   static const passphraseCheckingTitle = 'passphraseCheckingTitle';
   static const passphraseCheckingDescription = 'passphraseCheckingDescription';
   static const passphraseCheckingEnterWord = 'passphraseCheckingEnterWord';
-  static const passphraseCheckingEnterWordHint = 'passphraseCheckingEnterWordHint';
+  static const passphraseCheckingEnterWordHint =
+      'passphraseCheckingEnterWordHint';
   static const back = 'back';
   static const settingsMenuGeneral = 'settingsMenuGeneral';
   static const settingsMenuLanguage = 'settingsMenuLanguage';
   static const settingsMenuSecurity = 'settingsMenuSecurity';
   static const settingsMenuAbout = 'settingsMenuAbout';
-  static const seedPhraseSettingControlsViewSeed = 'seedPhraseSettingControlsViewSeed';
-  static const seedPhraseSettingControlsDownloadSeed = 'seedPhraseSettingControlsDownloadSeed';
-  static const debugSettingsResetActivatedCoins = 'debugSettingsResetActivatedCoins';
+  static const seedPhraseSettingControlsViewSeed =
+      'seedPhraseSettingControlsViewSeed';
+  static const seedPhraseSettingControlsDownloadSeed =
+      'seedPhraseSettingControlsDownloadSeed';
+  static const debugSettingsResetActivatedCoins =
+      'debugSettingsResetActivatedCoins';
   static const debugSettingsDownloadButton = 'debugSettingsDownloadButton';
   static const or = 'or';
   static const passwordTitle = 'passwordTitle';
@@ -148,16 +159,19 @@ abstract class  LocaleKeys {
   static const changePasswordSpan1 = 'changePasswordSpan1';
   static const updatePassword = 'updatePassword';
   static const passwordHasChanged = 'passwordHasChanged';
-  static const confirmationForShowingSeedPhraseTitle = 'confirmationForShowingSeedPhraseTitle';
+  static const confirmationForShowingSeedPhraseTitle =
+      'confirmationForShowingSeedPhraseTitle';
   static const saveAndRemember = 'saveAndRemember';
   static const seedPhraseShowingTitle = 'seedPhraseShowingTitle';
   static const seedPhraseShowingWarning = 'seedPhraseShowingWarning';
   static const seedPhraseShowingShowPhrase = 'seedPhraseShowingShowPhrase';
   static const seedPhraseShowingCopySeed = 'seedPhraseShowingCopySeed';
-  static const seedPhraseShowingSavedPhraseButton = 'seedPhraseShowingSavedPhraseButton';
+  static const seedPhraseShowingSavedPhraseButton =
+      'seedPhraseShowingSavedPhraseButton';
   static const seedAccessSpan1 = 'seedAccessSpan1';
   static const backupSeedNotificationTitle = 'backupSeedNotificationTitle';
-  static const backupSeedNotificationDescription = 'backupSeedNotificationDescription';
+  static const backupSeedNotificationDescription =
+      'backupSeedNotificationDescription';
   static const backupSeedNotificationButton = 'backupSeedNotificationButton';
   static const swapConfirmationTitle = 'swapConfirmationTitle';
   static const swapConfirmationYouReceive = 'swapConfirmationYouReceive';
@@ -165,41 +179,54 @@ abstract class  LocaleKeys {
   static const tradingDetailsTitleFailed = 'tradingDetailsTitleFailed';
   static const tradingDetailsTitleCompleted = 'tradingDetailsTitleCompleted';
   static const tradingDetailsTitleInProgress = 'tradingDetailsTitleInProgress';
-  static const tradingDetailsTitleOrderMatching = 'tradingDetailsTitleOrderMatching';
+  static const tradingDetailsTitleOrderMatching =
+      'tradingDetailsTitleOrderMatching';
   static const tradingDetailsTotalSpentTime = 'tradingDetailsTotalSpentTime';
-  static const tradingDetailsTotalSpentTimeWithHours = 'tradingDetailsTotalSpentTimeWithHours';
+  static const tradingDetailsTotalSpentTimeWithHours =
+      'tradingDetailsTotalSpentTimeWithHours';
   static const swapRecoverButtonTitle = 'swapRecoverButtonTitle';
   static const swapRecoverButtonText = 'swapRecoverButtonText';
   static const swapRecoverButtonErrorMessage = 'swapRecoverButtonErrorMessage';
-  static const swapRecoverButtonSuccessMessage = 'swapRecoverButtonSuccessMessage';
+  static const swapRecoverButtonSuccessMessage =
+      'swapRecoverButtonSuccessMessage';
   static const swapProgressStatusFailed = 'swapProgressStatusFailed';
   static const swapDetailsStepStatusFailed = 'swapDetailsStepStatusFailed';
   static const disclaimerAcceptEulaCheckbox = 'disclaimerAcceptEulaCheckbox';
-  static const disclaimerAcceptTermsAndConditionsCheckbox = 'disclaimerAcceptTermsAndConditionsCheckbox';
+  static const disclaimerAcceptTermsAndConditionsCheckbox =
+      'disclaimerAcceptTermsAndConditionsCheckbox';
   static const disclaimerAcceptDescription = 'disclaimerAcceptDescription';
-  static const swapDetailsStepStatusInProcess = 'swapDetailsStepStatusInProcess';
-  static const swapDetailsStepStatusTimeSpent = 'swapDetailsStepStatusTimeSpent';
+  static const swapDetailsStepStatusInProcess =
+      'swapDetailsStepStatusInProcess';
+  static const swapDetailsStepStatusTimeSpent =
+      'swapDetailsStepStatusTimeSpent';
   static const milliseconds = 'milliseconds';
   static const seconds = 'seconds';
   static const minutes = 'minutes';
   static const hours = 'hours';
-  static const coinAddressDetailsNotificationTitle = 'coinAddressDetailsNotificationTitle';
-  static const coinAddressDetailsNotificationDescription = 'coinAddressDetailsNotificationDescription';
+  static const coinAddressDetailsNotificationTitle =
+      'coinAddressDetailsNotificationTitle';
+  static const coinAddressDetailsNotificationDescription =
+      'coinAddressDetailsNotificationDescription';
   static const swapFeeDetailsPaidFromBalance = 'swapFeeDetailsPaidFromBalance';
   static const swapFeeDetailsSendCoinTxFee = 'swapFeeDetailsSendCoinTxFee';
-  static const swapFeeDetailsReceiveCoinTxFee = 'swapFeeDetailsReceiveCoinTxFee';
+  static const swapFeeDetailsReceiveCoinTxFee =
+      'swapFeeDetailsReceiveCoinTxFee';
   static const swapFeeDetailsTradingFee = 'swapFeeDetailsTradingFee';
-  static const swapFeeDetailsSendTradingFeeTxFee = 'swapFeeDetailsSendTradingFeeTxFee';
+  static const swapFeeDetailsSendTradingFeeTxFee =
+      'swapFeeDetailsSendTradingFeeTxFee';
   static const swapFeeDetailsNone = 'swapFeeDetailsNone';
-  static const swapFeeDetailsPaidFromReceivedVolume = 'swapFeeDetailsPaidFromReceivedVolume';
+  static const swapFeeDetailsPaidFromReceivedVolume =
+      'swapFeeDetailsPaidFromReceivedVolume';
   static const logoutPopupTitle = 'logoutPopupTitle';
-  static const logoutPopupDescriptionWalletOnly = 'logoutPopupDescriptionWalletOnly';
+  static const logoutPopupDescriptionWalletOnly =
+      'logoutPopupDescriptionWalletOnly';
   static const logoutPopupDescription = 'logoutPopupDescription';
   static const transactionDetailsTitle = 'transactionDetailsTitle';
   static const customSeedWarningText = 'customSeedWarningText';
   static const customSeedIUnderstand = 'customSeedIUnderstand';
   static const walletCreationBip39SeedError = 'walletCreationBip39SeedError';
-  static const walletCreationHdBip39SeedError = 'walletCreationHdBip39SeedError';
+  static const walletCreationHdBip39SeedError =
+      'walletCreationHdBip39SeedError';
   static const walletPageNoSuchAsset = 'walletPageNoSuchAsset';
   static const swapCoin = 'swapCoin';
   static const fiatBalance = 'fiatBalance';
@@ -275,7 +302,8 @@ abstract class  LocaleKeys {
   static const sellCryptoDescription = 'sellCryptoDescription';
   static const buy = 'buy';
   static const changingWalletPassword = 'changingWalletPassword';
-  static const changingWalletPasswordDescription = 'changingWalletPasswordDescription';
+  static const changingWalletPasswordDescription =
+      'changingWalletPasswordDescription';
   static const dark = 'dark';
   static const darkMode = 'darkMode';
   static const light = 'light';
@@ -300,7 +328,8 @@ abstract class  LocaleKeys {
   static const contactRequiredError = 'contactRequiredError';
   static const contactDetailsMaxLengthError = 'contactDetailsMaxLengthError';
   static const discordUsernameValidatorError = 'discordUsernameValidatorError';
-  static const telegramUsernameValidatorError = 'telegramUsernameValidatorError';
+  static const telegramUsernameValidatorError =
+      'telegramUsernameValidatorError';
   static const matrixIdValidatorError = 'matrixIdValidatorError';
   static const myCoinsMissing = 'myCoinsMissing';
   static const myCoinsMissingReassurance = 'myCoinsMissingReassurance';
@@ -310,7 +339,8 @@ abstract class  LocaleKeys {
   static const myCoinsMissingHelp = 'myCoinsMissingHelp';
   static const myCoinsMissingSignIn = 'myCoinsMissingSignIn';
   static const feedbackValidatorEmptyError = 'feedbackValidatorEmptyError';
-  static const feedbackValidatorMaxLengthError = 'feedbackValidatorMaxLengthError';
+  static const feedbackValidatorMaxLengthError =
+      'feedbackValidatorMaxLengthError';
   static const yourFeedback = 'yourFeedback';
   static const sendFeedback = 'sendFeedback';
   static const sendFeedbackError = 'sendFeedbackError';
@@ -350,6 +380,7 @@ abstract class  LocaleKeys {
   static const trezorErrorInvalidPin = 'trezorErrorInvalidPin';
   static const trezorSelectTitle = 'trezorSelectTitle';
   static const trezorSelectSubTitle = 'trezorSelectSubTitle';
+  static const trezorBrowserUnsupported = 'trezorBrowserUnsupported';
   static const mixedCaseError = 'mixedCaseError';
   static const addressConvertedToMixedCase = 'addressConvertedToMixedCase';
   static const invalidAddressChecksum = 'invalidAddressChecksum';
@@ -359,7 +390,8 @@ abstract class  LocaleKeys {
   static const noSenderAddress = 'noSenderAddress';
   static const confirmOnTrezor = 'confirmOnTrezor';
   static const alphaVersionWarningTitle = 'alphaVersionWarningTitle';
-  static const alphaVersionWarningDescription = 'alphaVersionWarningDescription';
+  static const alphaVersionWarningDescription =
+      'alphaVersionWarningDescription';
   static const sendToAnalytics = 'sendToAnalytics';
   static const backToWallet = 'backToWallet';
   static const backToDex = 'backToDex';
@@ -381,12 +413,14 @@ abstract class  LocaleKeys {
   static const currentPassword = 'currentPassword';
   static const walletNotFound = 'walletNotFound';
   static const passwordIsEmpty = 'passwordIsEmpty';
-  static const passwordContainsTheWordPassword = 'passwordContainsTheWordPassword';
+  static const passwordContainsTheWordPassword =
+      'passwordContainsTheWordPassword';
   static const passwordTooShort = 'passwordTooShort';
   static const passwordMissingDigit = 'passwordMissingDigit';
   static const passwordMissingLowercase = 'passwordMissingLowercase';
   static const passwordMissingUppercase = 'passwordMissingUppercase';
-  static const passwordMissingSpecialCharacter = 'passwordMissingSpecialCharacter';
+  static const passwordMissingSpecialCharacter =
+      'passwordMissingSpecialCharacter';
   static const passwordConsecutiveCharacters = 'passwordConsecutiveCharacters';
   static const passwordSecurity = 'passwordSecurity';
   static const allowWeakPassword = 'allowWeakPassword';
@@ -415,13 +449,16 @@ abstract class  LocaleKeys {
   static const bridgeMaxSendAmountError = 'bridgeMaxSendAmountError';
   static const bridgeMinOrderAmountError = 'bridgeMinOrderAmountError';
   static const bridgeMaxOrderAmountError = 'bridgeMaxOrderAmountError';
-  static const bridgeInsufficientBalanceError = 'bridgeInsufficientBalanceError';
+  static const bridgeInsufficientBalanceError =
+      'bridgeInsufficientBalanceError';
   static const lowTradeVolumeError = 'lowTradeVolumeError';
   static const bridgeSelectReceiveCoinError = 'bridgeSelectReceiveCoinError';
   static const withdrawNoParentCoinError = 'withdrawNoParentCoinError';
   static const withdrawTopUpBalanceError = 'withdrawTopUpBalanceError';
-  static const withdrawNotEnoughBalanceForGasError = 'withdrawNotEnoughBalanceForGasError';
-  static const withdrawNotSufficientBalanceError = 'withdrawNotSufficientBalanceError';
+  static const withdrawNotEnoughBalanceForGasError =
+      'withdrawNotEnoughBalanceForGasError';
+  static const withdrawNotSufficientBalanceError =
+      'withdrawNotSufficientBalanceError';
   static const withdrawZeroBalanceError = 'withdrawZeroBalanceError';
   static const withdrawAmountTooLowError = 'withdrawAmountTooLowError';
   static const withdrawNoSuchCoinError = 'withdrawNoSuchCoinError';
@@ -493,8 +530,10 @@ abstract class  LocaleKeys {
   static const availableForSwaps = 'availableForSwaps';
   static const swapNow = 'swapNow';
   static const passphrase = 'passphrase';
-  static const enterPassphraseHiddenWalletTitle = 'enterPassphraseHiddenWalletTitle';
-  static const enterPassphraseHiddenWalletDescription = 'enterPassphraseHiddenWalletDescription';
+  static const enterPassphraseHiddenWalletTitle =
+      'enterPassphraseHiddenWalletTitle';
+  static const enterPassphraseHiddenWalletDescription =
+      'enterPassphraseHiddenWalletDescription';
   static const skip = 'skip';
   static const activateToSeeFunds = 'activateToSeeFunds';
   static const allowCustomFee = 'allowCustomFee';
@@ -558,8 +597,10 @@ abstract class  LocaleKeys {
   static const collectibles = 'collectibles';
   static const sendingProcess = 'sendingProcess';
   static const ercStandardDisclaimer = 'ercStandardDisclaimer';
-  static const nftReceiveNonSwapAddressWarning = 'nftReceiveNonSwapAddressWarning';
-  static const nftReceiveNonSwapWalletDetails = 'nftReceiveNonSwapWalletDetails';
+  static const nftReceiveNonSwapAddressWarning =
+      'nftReceiveNonSwapAddressWarning';
+  static const nftReceiveNonSwapWalletDetails =
+      'nftReceiveNonSwapWalletDetails';
   static const nftMainLoggedOut = 'nftMainLoggedOut';
   static const confirmLogoutOnAnotherTab = 'confirmLogoutOnAnotherTab';
   static const refreshList = 'refreshList';
@@ -573,8 +614,10 @@ abstract class  LocaleKeys {
   static const noWalletsAvailable = 'noWalletsAvailable';
   static const selectWalletToReset = 'selectWalletToReset';
   static const qrScannerTitle = 'qrScannerTitle';
-  static const qrScannerErrorControllerUninitialized = 'qrScannerErrorControllerUninitialized';
-  static const qrScannerErrorPermissionDenied = 'qrScannerErrorPermissionDenied';
+  static const qrScannerErrorControllerUninitialized =
+      'qrScannerErrorControllerUninitialized';
+  static const qrScannerErrorPermissionDenied =
+      'qrScannerErrorPermissionDenied';
   static const qrScannerErrorGenericError = 'qrScannerErrorGenericError';
   static const qrScannerErrorTitle = 'qrScannerErrorTitle';
   static const spend = 'spend';
@@ -619,7 +662,8 @@ abstract class  LocaleKeys {
   static const fiatPaymentInProgressMessage = 'fiatPaymentInProgressMessage';
   static const pleaseWait = 'pleaseWait';
   static const bitrefillPaymentSuccessfull = 'bitrefillPaymentSuccessfull';
-  static const bitrefillPaymentSuccessfullInstruction = 'bitrefillPaymentSuccessfullInstruction';
+  static const bitrefillPaymentSuccessfullInstruction =
+      'bitrefillPaymentSuccessfullInstruction';
   static const tradingBot = 'tradingBot';
   static const margin = 'margin';
   static const updateInterval = 'updateInterval';
@@ -694,5 +738,4 @@ abstract class  LocaleKeys {
   static const trend7d = 'trend7d';
   static const tradingDisabledTooltip = 'tradingDisabledTooltip';
   static const tradingDisabled = 'tradingDisabled';
-
 }

--- a/lib/shared/utils/browser_helpers.dart
+++ b/lib/shared/utils/browser_helpers.dart
@@ -1,4 +1,5 @@
-import 'package:universal_html/html.dart';
+import 'package:web/web.dart';
+import 'dart:ui_web' as ui_web;
 
 class BrowserInfo {
   final String browserName;
@@ -91,10 +92,23 @@ class BrowserInfoParser {
   }
 
   static String _getScreenSize() {
-    final BodyElement? body = document.body;
+    final HTMLBodyElement? body = document.body as HTMLBodyElement?;
     final width = document.documentElement?.clientWidth ?? body?.clientWidth;
     final height = document.documentElement?.clientHeight ?? body?.clientHeight;
 
     return '${width ?? ''}:${height ?? ''}';
   }
+}
+
+bool isChromeBrowser() {
+  final vendor = window.navigator.vendor;
+  final userAgent = window.navigator.userAgent.toLowerCase();
+  final engine =
+      ui_web.browser.detectBrowserEngineByVendorAgent(vendor, userAgent);
+  final bool isBlink = engine == ui_web.BrowserEngine.blink;
+  final bool isEdge = userAgent.contains('edg/');
+  return isBlink &&
+      !isEdge &&
+      vendor == 'Google Inc.' &&
+      userAgent.contains('chrome');
 }

--- a/lib/views/common/hw_wallet_dialog/hw_dialog_wallet_select.dart
+++ b/lib/views/common/hw_wallet_dialog/hw_dialog_wallet_select.dart
@@ -9,6 +9,7 @@ import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/hw_wallet/hw_wallet.dart';
 import 'package:web_dex/views/common/hw_wallet_dialog/constants.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
+import 'package:web_dex/shared/utils/browser_helpers.dart';
 
 class HwDialogWalletSelect extends StatefulWidget {
   const HwDialogWalletSelect({
@@ -24,6 +25,13 @@ class HwDialogWalletSelect extends StatefulWidget {
 
 class _HwDialogWalletSelectState extends State<HwDialogWalletSelect> {
   WalletBrand? _selectedBrand;
+  late final bool _isChrome;
+
+  @override
+  void initState() {
+    super.initState();
+    _isChrome = isChromeBrowser();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -43,6 +51,7 @@ class _HwDialogWalletSelectState extends State<HwDialogWalletSelect> {
         ),
         const SizedBox(height: 24),
         _HwWalletTile(
+            disabled: !_isChrome,
             selected: _selectedBrand == WalletBrand.trezor,
             onSelect: () {
               setState(() => _selectedBrand = WalletBrand.trezor);
@@ -52,6 +61,15 @@ class _HwDialogWalletSelectState extends State<HwDialogWalletSelect> {
                   ? '$assetsPath/others/trezor_logo_light.svg'
                   : '$assetsPath/others/trezor_logo.svg'),
             )),
+        if (!_isChrome)
+          Padding(
+            padding: const EdgeInsets.only(top: 8.0),
+            child: Text(
+              LocaleKeys.trezorBrowserUnsupported.tr(),
+              style: theme.currentGlobal.textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+          ),
         const SizedBox(height: 12),
         _HwWalletTile(
             disabled: true,

--- a/lib/views/wallets_manager/wallets_manager_wrapper.dart
+++ b/lib/views/wallets_manager/wallets_manager_wrapper.dart
@@ -5,6 +5,7 @@ import 'package:web_dex/model/wallet.dart';
 import 'package:web_dex/views/wallets_manager/wallets_manager_events_factory.dart';
 import 'package:web_dex/views/wallets_manager/widgets/wallets_manager.dart';
 import 'package:web_dex/views/wallets_manager/widgets/wallets_type_list.dart';
+import 'package:web_dex/shared/utils/browser_helpers.dart';
 
 class WalletsManagerWrapper extends StatefulWidget {
   const WalletsManagerWrapper({
@@ -36,6 +37,7 @@ class _WalletsManagerWrapperState extends State<WalletsManagerWrapper> {
   Widget build(BuildContext context) {
     final WalletType? selectedWalletType = _selectedWalletType;
     if (selectedWalletType == null) {
+      final bool isChrome = isChromeBrowser();
       return Column(
         children: [
           Text(
@@ -49,6 +51,18 @@ class _WalletsManagerWrapperState extends State<WalletsManagerWrapper> {
               onWalletTypeClick: _onWalletTypeClick,
             ),
           ),
+          if (!isChrome)
+            Padding(
+              padding: const EdgeInsets.only(top: 12.0),
+              child: Text(
+                LocaleKeys.trezorBrowserUnsupported.tr(),
+                style: Theme.of(context)
+                    .textTheme
+                    .bodySmall
+                    ?.copyWith(color: Theme.of(context).colorScheme.error),
+                textAlign: TextAlign.center,
+              ),
+            ),
         ],
       );
     }

--- a/lib/views/wallets_manager/widgets/wallet_type_list_item.dart
+++ b/lib/views/wallets_manager/widgets/wallet_type_list_item.dart
@@ -6,6 +6,7 @@ import 'package:web_dex/app_config/app_config.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/wallet.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
+import 'package:web_dex/shared/utils/browser_helpers.dart';
 
 class WalletTypeListItem extends StatelessWidget {
   const WalletTypeListItem({
@@ -21,6 +22,8 @@ class WalletTypeListItem extends StatelessWidget {
     final bool needAttractAttention =
         type == WalletType.iguana || type == WalletType.hdwallet;
     final bool isSupported = _checkWalletSupport(type);
+    final bool showBrowserWarning =
+        type == WalletType.trezor && !isChromeBrowser();
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.end,
@@ -55,12 +58,16 @@ class WalletTypeListItem extends StatelessWidget {
                       ),
                     ),
                     if (!isSupported)
-                      Text(LocaleKeys.comingSoon.tr(),
-                          textAlign: TextAlign.right,
-                          style: const TextStyle(
-                            fontSize: 11,
-                            fontWeight: FontWeight.w500,
-                          )),
+                      Text(
+                        showBrowserWarning
+                            ? LocaleKeys.trezorBrowserUnsupported.tr()
+                            : LocaleKeys.comingSoon.tr(),
+                        textAlign: TextAlign.right,
+                        style: const TextStyle(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
                   ],
                 ),
               )
@@ -108,7 +115,7 @@ class WalletTypeListItem extends StatelessWidget {
       case WalletType.iguana:
       case WalletType.hdwallet:
       case WalletType.trezor:
-        return true;
+        return isChromeBrowser();
       case WalletType.keplr:
       case WalletType.metamask:
         return false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -108,6 +108,7 @@ dependencies:
 
   # Approved via https://github.com/KomodoPlatform/komodo-wallet/pull/1106 (Outdated)
   universal_html: 2.2.4
+  web: 1.1.1
 
   # Approved via https://github.com/KomodoPlatform/komodo-wallet/pull/1106
   hive: ^2.2.3 # Changed from git to pub.dev because git dependencies are not allowed in published packages


### PR DESCRIPTION
## Summary
- disable Trezor wallet options when browser isn't Chrome
- show localized warning about using Chrome
- migrate browser helpers to `package:web`
- add `web` dependency

## Testing
- `dart format lib/shared/utils/browser_helpers.dart lib/views/common/hw_wallet_dialog/hw_dialog_wallet_select.dart lib/views/wallets_manager/wallets_manager_wrapper.dart lib/views/wallets_manager/widgets/wallet_type_list_item.dart lib/generated/codegen_loader.g.dart`
- `flutter analyze`
- `flutter build web --dry-run` *(fails: Could not find an option named "--dry-run")*
- `flutter build web` *(fails: coin assets updated)*

------
https://chatgpt.com/codex/tasks/task_e_687a0d8f3bb88331996c2419935614af