### PR TITLE
fix: show full address in transaction details

### DIFF
--- a/lib/views/wallet/coin_details/transactions/transaction_details.dart
+++ b/lib/views/wallet/coin_details/transactions/transaction_details.dart
@@ -146,7 +146,7 @@ class TransactionDetails extends StatelessWidget {
             constraints: const BoxConstraints(maxWidth: 200),
             child: CopiedText(
               copiedValue: address,
-              isTruncated: true,
+              isTruncated: false,
               padding: const EdgeInsets.symmetric(
                 vertical: 8,
                 horizontal: 16,


### PR DESCRIPTION
## Summary
- display the complete address in the transaction details panel

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6879376d90e483269575c407502dcb26