### PR TITLE
feat: display complete addresses in transaction details

### DIFF
--- a/lib/views/wallet/coin_details/transactions/transaction_details.dart
+++ b/lib/views/wallet/coin_details/transactions/transaction_details.dart
@@ -146,6 +146,7 @@ class TransactionDetails extends StatelessWidget {
             child: CopiedText(
               copiedValue: address,
               isTruncated: false,
+              maxLines: 2,
               padding: const EdgeInsets.symmetric(
                 vertical: 8,
                 horizontal: 16,

--- a/lib/views/wallet/coin_details/transactions/transaction_details.dart
+++ b/lib/views/wallet/coin_details/transactions/transaction_details.dart
@@ -142,11 +142,10 @@ class TransactionDetails extends StatelessWidget {
                 Theme.of(context).textTheme.bodyLarge?.copyWith(fontSize: 14),
           ),
           const SizedBox(width: 8),
-          ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 200),
+          Flexible(
             child: CopiedText(
               copiedValue: address,
-              isTruncated: true,
+              isTruncated: false,
               padding: const EdgeInsets.symmetric(
                 vertical: 8,
                 horizontal: 16,

--- a/lib/views/wallet/coin_details/transactions/transaction_list_item.dart
+++ b/lib/views/wallet/coin_details/transactions/transaction_list_item.dart
@@ -298,9 +298,12 @@ class _TransactionAddress extends StatelessWidget {
         const SizedBox(width: 8),
         AddressIcon(address: myAddress),
         const SizedBox(width: 8),
-        AddressText(
-          address: myAddress,
-          isTruncated: false,
+        Expanded(
+          child: AddressText(
+            address: myAddress,
+            isTruncated: false,
+            maxLines: 2,
+          ),
         ),
         AddressCopyButton(address: myAddress),
       ],

--- a/lib/views/wallet/coin_details/transactions/transaction_list_item.dart
+++ b/lib/views/wallet/coin_details/transactions/transaction_list_item.dart
@@ -298,7 +298,10 @@ class _TransactionAddress extends StatelessWidget {
         const SizedBox(width: 8),
         AddressIcon(address: myAddress),
         const SizedBox(width: 8),
-        AddressText(address: myAddress),
+        AddressText(
+          address: myAddress,
+          isTruncated: false,
+        ),
         AddressCopyButton(address: myAddress),
       ],
     );

--- a/lib/views/wallet/common/address_text.dart
+++ b/lib/views/wallet/common/address_text.dart
@@ -5,17 +5,22 @@ class AddressText extends StatelessWidget {
   const AddressText({
     required this.address,
     this.isTruncated = true,
+    this.maxLines,
   });
 
   final String address;
   final bool isTruncated;
+  final int? maxLines;
 
   @override
   Widget build(BuildContext context) {
     final String display =
         isTruncated ? truncateMiddleSymbols(address, 5, 4) : address;
+    final bool softWrap = maxLines == null || maxLines! > 1;
     return Text(
       display,
+      maxLines: maxLines,
+      softWrap: softWrap,
       style: const TextStyle(fontSize: 14),
     );
   }

--- a/lib/views/wallet/common/address_text.dart
+++ b/lib/views/wallet/common/address_text.dart
@@ -4,14 +4,18 @@ import 'package:web_dex/shared/utils/formatters.dart';
 class AddressText extends StatelessWidget {
   const AddressText({
     required this.address,
+    this.isTruncated = true,
   });
 
   final String address;
+  final bool isTruncated;
 
   @override
   Widget build(BuildContext context) {
+    final String display =
+        isTruncated ? truncateMiddleSymbols(address, 5, 4) : address;
     return Text(
-      truncateMiddleSymbols(address, 5, 4),
+      display,
       style: const TextStyle(fontSize: 14),
     );
   }


### PR DESCRIPTION
## Summary
- stop truncating addresses in the transaction details screen

## Testing
- `dart format lib/views/wallet/coin_details/transactions/transaction_details.dart`
- `flutter analyze` *(fails: 514 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_6879376d90e483269575c407502dcb26