### PR TITLE
feat: store hide zero balance per wallet

### DIFF
--- a/lib/bloc/settings/settings_bloc.dart
+++ b/lib/bloc/settings/settings_bloc.dart
@@ -74,11 +74,10 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     HideZeroBalanceAssetsChanged event,
     Emitter<SettingsState> emitter,
   ) async {
-    await _settingsRepo.updateSettings(
-      _storedSettings.copyWith(
-        hideZeroBalanceAssets: event.hideZeroBalanceAssets,
-      ),
-    );
+    final updated = _storedSettings.copyWith(
+        hideZeroBalanceAssets: event.hideZeroBalanceAssets);
+    await _settingsRepo.updateSettings(updated);
+    _storedSettings = updated;
     emitter(state.copyWith(hideZeroBalanceAssets: event.hideZeroBalanceAssets));
   }
 }

--- a/lib/bloc/settings/settings_repository.dart
+++ b/lib/bloc/settings/settings_repository.dart
@@ -1,31 +1,41 @@
 import 'dart:convert';
 
+import 'package:get_it/get_it.dart';
+import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
+import 'package:web_dex/model/kdf_auth_metadata_extension.dart';
 import 'package:web_dex/model/stored_settings.dart';
 import 'package:web_dex/services/storage/base_storage.dart';
 import 'package:web_dex/services/storage/get_storage.dart';
 import 'package:web_dex/shared/constants.dart';
 
 class SettingsRepository {
-  SettingsRepository({BaseStorage? storage})
-      : _storage = storage ?? getStorage();
+  SettingsRepository({BaseStorage? storage, KomodoDefiSdk? sdk})
+      : _storage = storage ?? getStorage(),
+        _kdfSdk = sdk ?? GetIt.I<KomodoDefiSdk>();
 
   final BaseStorage _storage;
+  final KomodoDefiSdk _kdfSdk;
 
   Future<StoredSettings> loadSettings() async {
     final dynamic storedAppPrefs = await _storage.read(storedSettingsKey);
-
-    return StoredSettings.fromJson(storedAppPrefs);
+    final stored = StoredSettings.fromJson(storedAppPrefs);
+    final hideZeroBalance = await _kdfSdk.getHideZeroBalanceAssets();
+    return stored.copyWith(hideZeroBalanceAssets: hideZeroBalance);
   }
 
   Future<void> updateSettings(StoredSettings settings) async {
-    final String encodedData = jsonEncode(settings.toJson());
+    final data = settings.toJson()..remove('hideZeroBalanceAssets');
+    await _kdfSdk.setHideZeroBalanceAssets(settings.hideZeroBalanceAssets);
+    final String encodedData = jsonEncode(data);
     await _storage.write(storedSettingsKey, encodedData);
   }
 
   static Future<StoredSettings> loadStoredSettings() async {
     final storage = getStorage();
     final dynamic storedAppPrefs = await storage.read(storedSettingsKey);
-
-    return StoredSettings.fromJson(storedAppPrefs);
+    final stored = StoredSettings.fromJson(storedAppPrefs);
+    final kdf = GetIt.I<KomodoDefiSdk>();
+    final hideZeroBalance = await kdf.getHideZeroBalanceAssets();
+    return stored.copyWith(hideZeroBalanceAssets: hideZeroBalance);
   }
 }

--- a/lib/model/kdf_auth_metadata_extension.dart
+++ b/lib/model/kdf_auth_metadata_extension.dart
@@ -57,4 +57,17 @@ extension KdfAuthMetadataExtension on KomodoDefiSdk {
   Future<void> setWalletType(WalletType type) async {
     await auth.setOrRemoveActiveUserKeyValue('type', type.name);
   }
+
+  Future<bool> getHideZeroBalanceAssets() async {
+    final user = await auth.currentUser;
+    return user?.metadata.valueOrNull<bool>('hide_zero_balance_assets') ??
+        false;
+  }
+
+  Future<void> setHideZeroBalanceAssets(bool value) async {
+    await auth.setOrRemoveActiveUserKeyValue(
+      'hide_zero_balance_assets',
+      value,
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- persist hide zero balance setting in the wallet metadata using the SDK
- update SettingsRepository to read and write per-wallet metadata
- track updated setting in SettingsBloc

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_687a6bee4d208326aaffe0099448ee21