### PR TITLE
feat(settings): hide log export when logged out

### DIFF
--- a/lib/views/settings/widgets/general_settings/general_settings.dart
+++ b/lib/views/settings/widgets/general_settings/general_settings.dart
@@ -37,7 +37,9 @@ class GeneralSettings extends StatelessWidget {
             child: SettingsManageTradingBot(),
           ),
         const SizedBox(height: 25),
-        const SettingsDownloadLogs(),
+        const HiddenWithoutWallet(
+          child: SettingsDownloadLogs(),
+        ),
         const SizedBox(height: 25),
         const HiddenWithWallet(
           child: SettingsResetActivatedCoins(),


### PR DESCRIPTION
## Summary
- hide the log export option for users who aren't signed in

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_687e18ddf4808326ac2c3822ea56eed5