### PR TITLE
Removes duplicate `CircularProgressIndicator` on address creation

### DIFF
--- a/lib/views/wallet/coin_details/coin_details_info/coin_addresses.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/coin_addresses.dart
@@ -120,11 +120,6 @@ class _CoinAddressesState extends State<CoinAddresses> {
                               padding: EdgeInsets.symmetric(vertical: 20.0),
                               child: Center(child: CircularProgressIndicator()),
                             ),
-                          if (state.status == FormStatus.submitting)
-                            const Padding(
-                              padding: EdgeInsets.symmetric(vertical: 20.0),
-                              child: Center(child: CircularProgressIndicator()),
-                            ),
                           if (state.status == FormStatus.failure ||
                               state.createAddressStatus == FormStatus.failure)
                             Padding(


### PR DESCRIPTION
closes https://github.com/KomodoPlatform/komodo-wallet/issues/2698

Before:

https://github.com/user-attachments/assets/0af6c7f5-a569-4921-8b30-da5a269659ff




After:

https://github.com/user-attachments/assets/0b002898-b6aa-4d3a-8298-fb70f592f519




To test:
- login in HD mode
- go to coin page
- create an address
- see only a single spinner