### PR TITLE
Ride if mounted, die if not

### DIFF
--- a/lib/shared/widgets/connect_wallet/connect_wallet_button.dart
+++ b/lib/shared/widgets/connect_wallet/connect_wallet_button.dart
@@ -97,8 +97,6 @@ class _ConnectWalletButtonState extends State<ConnectWalletButton> {
   }
 
   PopupDispatcher _createPopupDispatcher() {
-    final TakerBloc takerBloc = context.read<TakerBloc>();
-    final BridgeBloc bridgeBloc = context.read<BridgeBloc>();
 
     return PopupDispatcher(
       borderColor: theme.custom.specificButtonBorderColor,
@@ -108,6 +106,10 @@ class _ConnectWalletButtonState extends State<ConnectWalletButton> {
       popupContent: WalletsManagerWrapper(
         eventType: widget.eventType,
         onSuccess: (_) async {
+          if (!mounted) return;
+
+          final TakerBloc takerBloc = context.read<TakerBloc>();
+          final BridgeBloc bridgeBloc = context.read<BridgeBloc>();
           takerBloc.add(TakerReInit());
           bridgeBloc.add(const BridgeReInit());
           await reInitTradingForms(context);


### PR DESCRIPTION
An error was sighted in logs:

```
[ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: Null check operator used on a null value
#0      State.context (package:flutter/src/widgets/framework.dart:959)
#1      _ConnectWalletButtonState._createPopupDispatcher.<anonymous closure> (package:web_dex/shared/widgets/connect_wallet/connect_wallet_button.dart:113)
#2      _IguanaWalletsManagerState._onLogIn (package:web_dex/views/wallets_manager/widgets/iguana_wallets_manager.dart:318)
#3      _IguanaWalletsManagerState.build.<anonymous closure> (package:web_dex/views/wallets_manager/widgets/iguana_wallets_manager.dart:67)
#4      _BlocListenerBaseState._subscribe.<anonymous closure> (package:flutter_bloc/src/bloc_listener.dart:216)
#5      _rootRunUnary (dart:async/zone.dart:1538)
#6      _CustomZone.runUnary (dart:async/zone.dart:1429)
#7      _CustomZone.runUnaryGuarded (dart:async/zone.dart:1329)
#8      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:381)
#9      _DelayedData.perform (dart:async/stream_impl.dart:573)
#10     _PendingEvents.handleNext (dart:async/stream_impl.dart:678)
#11     _PendingEvents.schedule.<anonymous closure> (dart:async/stream_impl.dart:649)
#12     _rootRun (dart:async/zone.dart:1517)
#13     _CustomZone.run (dart:async/zone.dart:1422)
#14     _CustomZone.runGuarded (dart:async/zone.dart:1321)
#15     _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1362)
#16     _rootRun (dart:async/zone.dart:1525)
#17     _CustomZone.run (dart:async/zone.dart:1422)
#18     _CustomZone.runGuarded (dart:async/zone.dart:1321)
#19     _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1362)
#20     _microtaskLoop (dart:async/schedule_microtask.dart:40)
#21     _startMicrotaskLoop (dart:async/schedule_microtask.dart:49)
```

An agent was consulted:

<img width="789" height="1130" alt="image" src="https://github.com/user-attachments/assets/be87f146-955f-43af-ba67-b269ebb1b219" />

A PR was submitted, and peace was restored.