### PR TITLE
feat(activation): show enabled assets in Add Assets page

### DIFF
--- a/lib/bloc/coins_manager/coins_manager_bloc.dart
+++ b/lib/bloc/coins_manager/coins_manager_bloc.dart
@@ -265,12 +265,11 @@ Future<List<Coin>> _getOriginalCoinList(
   CoinsManagerAction action,
   KomodoDefiSdk sdk,
 ) async {
-  final WalletType? walletType = (await sdk.currentWallet())?.config.type;
-  if (walletType == null) return [];
+  if (await sdk.currentWallet() == null) return [];
 
   switch (action) {
     case CoinsManagerAction.add:
-      return _getAllCoins(coinsRepo, sdk, walletType);
+      return _getAllCoins(coinsRepo);
     case CoinsManagerAction.remove:
       return coinsRepo.getWalletCoins();
     case CoinsManagerAction.none:
@@ -280,24 +279,14 @@ Future<List<Coin>> _getOriginalCoinList(
 
 Future<List<Coin>> _getAllCoins(
   CoinsRepo coinsRepo,
-  KomodoDefiSdk sdk,
-  WalletType walletType,
 ) async {
-  switch (walletType) {
-    case WalletType.metamask:
-    case WalletType.keplr:
-      return [];
-    case WalletType.iguana:
-    case WalletType.trezor:
-    case WalletType.hdwallet:
-      final Map<String, Coin> coins =
-          coinsRepo.getKnownCoinsMap(excludeExcludedAssets: true);
-      final List<Coin> enabledCoins = await coinsRepo.getEnabledCoins();
-      for (final coin in enabledCoins) {
-        coins[coin.abbr] = coin;
-      }
-      return coins.values.toList();
+  final Map<String, Coin> coins =
+      coinsRepo.getKnownCoinsMap(excludeExcludedAssets: true);
+  final List<Coin> enabledCoins = await coinsRepo.getWalletCoins();
+  for (final coin in enabledCoins) {
+    coins[coin.abbr] = coin;
   }
+  return coins.values.toList();
 }
 
 typedef FilterFunction = List<Coin> Function(List<Coin>);


### PR DESCRIPTION
## Summary
- show active coins while adding assets
- sort active coins to bottom and mark them as selected

## Testing
- `flutter analyze lib/bloc/coins_manager lib/views/wallet/coins_manager`
- `flutter build web --release`
- `flutter build web --release`

------
https://chatgpt.com/codex/tasks/task_e_687f440496c483319dc5e8801f3598b6