### PR TITLE
Tag parent coins as native

### DIFF
--- a/lib/bloc/fiat/models/i_currency.dart
+++ b/lib/bloc/fiat/models/i_currency.dart
@@ -143,12 +143,12 @@ class CryptoCurrency extends ICurrency {
       return symbol;
     }
 
-    return '$symbol-${getCoinTypeName(chainType).replaceAll('-', '')}';
+    return '$symbol-${getCoinTypeName(chainType, symbol).replaceAll('-', '')}';
   }
 
   @override
   String formatNameShort() {
-    final coinType = ' (${getCoinTypeName(chainType)})';
+    final coinType = ' (${getCoinTypeName(chainType, symbol)})';
     return '$name$coinType';
   }
 

--- a/lib/model/coin.dart
+++ b/lib/model/coin.dart
@@ -78,6 +78,9 @@ class Coin {
   final CoinMode mode;
   CoinState state;
 
+  // Cache for expensive computed properties
+  String? _cachedTypeName;
+
   bool get walletOnly => _walletOnly || appWalletOnlyAssetList.contains(abbr);
 
   String? get swapContractAddress =>
@@ -91,7 +94,9 @@ class Coin {
       '$_urgentDeprecationNotice Use the SDK\'s Asset.sendableBalance instead. This value is not updated after initial load and may be inaccurate.')
   double sendableBalance = 0;
 
-  String get typeName => getCoinTypeName(type);
+  String get typeName {
+    return _cachedTypeName ??= getCoinTypeName(type, abbr);
+  }
   String get typeNameWithTestnet => typeName + (isTestCoin ? ' (TESTNET)' : '');
 
   bool get isIrisToken => protocolType == 'TENDERMINTTOKEN';

--- a/lib/model/coin.dart
+++ b/lib/model/coin.dart
@@ -80,6 +80,7 @@ class Coin {
 
   // Cache for expensive computed properties
   String? _cachedTypeName;
+  bool? _cachedisParent;
 
   bool get walletOnly => _walletOnly || appWalletOnlyAssetList.contains(abbr);
 
@@ -97,6 +98,11 @@ class Coin {
   String get typeName {
     return _cachedTypeName ??= getCoinTypeName(type, abbr);
   }
+  
+  bool get isParent {
+    return _cachedisParent ??= isParentCoin(type, abbr);
+  }
+  
   String get typeNameWithTestnet => typeName + (isTestCoin ? ' (TESTNET)' : '');
 
   bool get isIrisToken => protocolType == 'TENDERMINTTOKEN';

--- a/lib/model/coin_utils.dart
+++ b/lib/model/coin_utils.dart
@@ -208,7 +208,7 @@ bool isParentCoin(CoinType type, String symbol) {
     case CoinType.ftm20:
       return symbol == 'FTM';
     case CoinType.arb20:
-      return symbol == 'ARB';
+      return symbol == 'ARB' || symbol.startsWith('ARB') ;
     case CoinType.hrc20:
       return symbol == 'ONE';
     case CoinType.plg20:

--- a/lib/model/coin_utils.dart
+++ b/lib/model/coin_utils.dart
@@ -145,7 +145,11 @@ bool compareCoinByPhrase(Coin coin, String phrase) {
       compareAbbr.contains(lowerCasePhrase);
 }
 
-String getCoinTypeName(CoinType type) {
+String getCoinTypeName(CoinType type, [String? symbol]) {
+  // Override for parent chain coins like ETH, AVAX etc.
+  if (symbol != null && isParentCoin(type, symbol)) {
+    return 'Native';
+  }
   switch (type) {
     case CoinType.erc20:
       return 'ERC-20';
@@ -185,6 +189,36 @@ String getCoinTypeName(CoinType type) {
       return 'Tendermint Token';
     case CoinType.slp:
       return 'SLP';
+  }
+}
+
+bool isParentCoin(CoinType type, String symbol) {
+  switch (type) {
+    case CoinType.utxo:
+    case CoinType.tendermint:
+      return true;
+    case CoinType.erc20:
+      return symbol == 'ETH';
+    case CoinType.bep20:
+      return symbol == 'BNB';
+    case CoinType.avx20:
+      return symbol == 'AVAX';
+    case CoinType.etc:
+      return symbol == 'ETC';
+    case CoinType.ftm20:
+      return symbol == 'FTM';
+    case CoinType.arb20:
+      return symbol == 'ARB';
+    case CoinType.hrc20:
+      return symbol == 'ONE';
+    case CoinType.plg20:
+      return symbol == 'MATIC';
+    case CoinType.mvr20:
+      return symbol == 'MOVR';
+    case CoinType.krc20:
+      return symbol == 'KCS';
+    default:
+      return false;
   }
 }
 

--- a/lib/services/logger/universal_logger.dart
+++ b/lib/services/logger/universal_logger.dart
@@ -45,6 +45,13 @@ class UniversalLogger with LoggerMetadataMixin implements LoggerInterface {
 
   @override
   Future<void> write(String message, [String? path]) async {
+    // If logger is not initialized, fall back to simple print
+    if (!_isInitialized) {
+      // ignore: avoid_print
+      print('[$path] $message');
+      return;
+    }
+
     final date = DateTime.now();
 
     final LogMessage logMessage = LogMessage(
@@ -73,6 +80,12 @@ class UniversalLogger with LoggerMetadataMixin implements LoggerInterface {
 
   @override
   Future<void> getLogFile() async {
+    if (!_isInitialized) {
+      // ignore: avoid_print
+      print('Logger not initialized, cannot export log file');
+      return;
+    }
+
     final String date =
         DateFormat('dd.MM.yyyy_HH-mm-ss').format(DateTime.now());
     final String filename = 'komodo_wallet_log_$date';

--- a/lib/views/bridge/bridge_protocol_label.dart
+++ b/lib/views/bridge/bridge_protocol_label.dart
@@ -1,10 +1,8 @@
 import 'package:app_theme/app_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:komodo_ui/komodo_ui.dart' show AssetIcon;
-import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 import 'package:web_dex/model/coin.dart';
 import 'package:web_dex/model/coin_type.dart';
-import 'package:web_dex/model/coin_utils.dart';
 import 'package:web_dex/shared/utils/utils.dart';
 
 class BridgeProtocolLabel extends StatelessWidget {
@@ -49,7 +47,7 @@ class BridgeProtocolLabel extends StatelessWidget {
     return Text(
       coin.type == CoinType.utxo
           ? coin.abbr
-          : getCoinTypeName(coin.type).toUpperCase(),
+          : coin.typeName.toUpperCase(),
       style: TextStyle(
         color: ThemeData.estimateBrightnessForColor(protocolColor) ==
                 Brightness.dark

--- a/lib/views/fiat/fiat_currency_list_tile.dart
+++ b/lib/views/fiat/fiat_currency_list_tile.dart
@@ -21,7 +21,9 @@ class FiatCurrencyListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final coinType = currency.isCrypto
-        ? getCoinTypeName((currency as CryptoCurrency).chainType)
+        ? getCoinTypeName(
+            (currency as CryptoCurrency).chainType,
+            (currency as CryptoCurrency).symbol)
         : '';
 
     return ListTile(

--- a/lib/views/fiat/fiat_select_button.dart
+++ b/lib/views/fiat/fiat_select_button.dart
@@ -34,36 +34,36 @@ class FiatSelectButton extends StatelessWidget {
       label: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          if (isFiat)
-            Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
+          Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                (isFiat ? currency?.getAbbr() : currency?.name) ??
+                    (isFiat
+                        ? LocaleKeys.selectFiat.tr()
+                        : LocaleKeys.selectCoin.tr()),
+                style: DefaultTextStyle.of(context).style.copyWith(
+                      fontWeight: FontWeight.w500,
+                      color: enabled
+                          ? foregroundColor
+                          : foregroundColor.withValues(alpha: 0.5),
+                    ),
+              ),
+              if (!isFiat && currency != null)
                 Text(
-                  (isFiat ? currency?.getAbbr() : currency?.name) ??
-                      (isFiat
-                          ? LocaleKeys.selectFiat.tr()
-                          : LocaleKeys.selectCoin.tr()),
+                  (currency! as CryptoCurrency).isCrypto
+                      ? getCoinTypeName(
+                          (currency! as CryptoCurrency).chainType,
+                          (currency! as CryptoCurrency).symbol)
+                      : '',
                   style: DefaultTextStyle.of(context).style.copyWith(
-                        fontWeight: FontWeight.w500,
                         color: enabled
-                            ? foregroundColor
-                            : foregroundColor.withValues(alpha: 0.5),
+                            ? foregroundColor.withValues(alpha: 0.5)
+                            : foregroundColor.withValues(alpha: 0.25),
                       ),
                 ),
-                if (!isFiat && currency != null)
-                  Text(
-                    (currency! as CryptoCurrency).isCrypto
-                        ? getCoinTypeName(
-                            (currency! as CryptoCurrency).chainType)
-                        : '',
-                    style: DefaultTextStyle.of(context).style.copyWith(
-                          color: enabled
-                              ? foregroundColor.withValues(alpha: 0.5)
-                              : foregroundColor.withValues(alpha: 0.25),
-                        ),
-                  ),
-              ],
-            ),
+            ],
+          ),
           const SizedBox(width: 4),
           Icon(
             Icons.keyboard_arrow_down,

--- a/lib/views/wallet/coins_manager/coins_manager_list_item.dart
+++ b/lib/views/wallet/coins_manager/coins_manager_list_item.dart
@@ -2,7 +2,6 @@ import 'package:app_theme/app_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:web_dex/model/coin.dart';
 import 'package:web_dex/model/coin_type.dart';
-import 'package:web_dex/model/coin_utils.dart';
 import 'package:web_dex/shared/utils/formatters.dart';
 import 'package:web_dex/shared/utils/utils.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
@@ -47,7 +46,7 @@ class CoinsManagerListItem extends StatelessWidget {
           );
   }
 
-  String get _protocolText => getCoinTypeName(coin.type);
+  String get _protocolText => coin.typeName;
 }
 
 class _CoinsManagerListItemDesktop extends StatelessWidget {


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/komodo-wallet/issues/2537

To Test:
- login
- go to coin menu
- search for ARB, ETH, ATOM, AVAX etc (any tendermint or evm parent)
- it should be tagged as native.
- Check other views to confirm tag is consistently applied.

This PR also includes a slight performance boost via cached `typeName` and `isParent` props for the Coin model, and some unrelated error handling improvements which arose to be slain during this campaign.