### PR TITLE
feat(wallet): show skeleton loader in address dropdown

### DIFF
--- a/lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart
+++ b/lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart
@@ -71,11 +71,27 @@ class _ExpandableCoinListItemState extends State<ExpandableCoinListItem> {
 
   @override
   Widget build(BuildContext context) {
+    final isLoading = widget.pubkeys == null;
     final hasAddresses = widget.pubkeys?.keys.isNotEmpty ?? false;
     final sortedAddresses = hasAddresses
         ? (List.of(widget.pubkeys!.keys)
           ..sort((a, b) => b.balance.spendable.compareTo(a.balance.spendable)))
         : null;
+
+    final children = isLoading
+        ? List<Widget>.generate(2, (_) => const SkeletonListTile())
+        : sortedAddresses
+                ?.map(
+                  (pubkey) => _AddressRow(
+                    pubkey: pubkey,
+                    coin: widget.coin,
+                    isSwapAddress: pubkey == sortedAddresses.first,
+                    onTap: widget.onTap,
+                    onCopy: () => copyToClipBoard(context, pubkey.address),
+                  ),
+                )
+                .toList() ??
+            <Widget>[];
 
     // Match GroupedAssetTickerItem: 16 horizontal, 16 vertical for both (mobile)
     // For desktop, set vertical padding to achieve 78px height
@@ -104,17 +120,7 @@ class _ExpandableCoinListItemState extends State<ExpandableCoinListItem> {
       maintainState: true,
       childrenDivider: const Divider(height: 1, indent: 16, endIndent: 16),
       trailing: CoinMoreActionsButton(coin: widget.coin),
-      children: sortedAddresses
-          ?.map(
-            (pubkey) => _AddressRow(
-              pubkey: pubkey,
-              coin: widget.coin,
-              isSwapAddress: pubkey == sortedAddresses.first,
-              onTap: widget.onTap,
-              onCopy: () => copyToClipBoard(context, pubkey.address),
-            ),
-          )
-          .toList(),
+      children: children,
     );
   }
 


### PR DESCRIPTION
## Summary
- ensure address dropdown in assets list can always expand
- show loading placeholders when addresses haven't loaded

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6883762ac1f88326a39792a6a673ff11