### PR TITLE
Show skeleton for assets list addresses

### DIFF
--- a/lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart
+++ b/lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart
@@ -88,7 +88,7 @@ class _ExpandableCoinListItemState extends State<ExpandableCoinListItem> {
               ),
             )
             .toList()
-        : List.generate(3, (_) => const SkeletonListTile());
+        : [SkeletonListTile()];
 
     // Match GroupedAssetTickerItem: 16 horizontal, 16 vertical for both (mobile)
     // For desktop, set vertical padding to achieve 78px height

--- a/lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart
+++ b/lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart
@@ -76,6 +76,19 @@ class _ExpandableCoinListItemState extends State<ExpandableCoinListItem> {
         ? (List.of(widget.pubkeys!.keys)
           ..sort((a, b) => b.balance.spendable.compareTo(a.balance.spendable)))
         : null;
+    final children = sortedAddresses != null
+        ? sortedAddresses
+            .map(
+              (pubkey) => _AddressRow(
+                pubkey: pubkey,
+                coin: widget.coin,
+                isSwapAddress: pubkey == sortedAddresses.first,
+                onTap: widget.onTap,
+                onCopy: () => copyToClipBoard(context, pubkey.address),
+              ),
+            )
+            .toList()
+        : List.generate(3, (_) => const SkeletonListTile());
 
     // Match GroupedAssetTickerItem: 16 horizontal, 16 vertical for both (mobile)
     // For desktop, set vertical padding to achieve 78px height
@@ -104,17 +117,7 @@ class _ExpandableCoinListItemState extends State<ExpandableCoinListItem> {
       maintainState: true,
       childrenDivider: const Divider(height: 1, indent: 16, endIndent: 16),
       trailing: CoinMoreActionsButton(coin: widget.coin),
-      children: sortedAddresses
-          ?.map(
-            (pubkey) => _AddressRow(
-              pubkey: pubkey,
-              coin: widget.coin,
-              isSwapAddress: pubkey == sortedAddresses.first,
-              onTap: widget.onTap,
-              onCopy: () => copyToClipBoard(context, pubkey.address),
-            ),
-          )
-          .toList(),
+      children: children,
     );
   }
 


### PR DESCRIPTION
## Summary
- keep addresses dropdown expanded by providing placeholder children
- show a `SkeletonListTile` list while addresses are loading

## Testing
- `flutter analyze`
- `flutter pub get --enforce-lockfile`


------
https://chatgpt.com/codex/tasks/task_e_6883762ac1f88326a39792a6a673ff11