### PR TITLE
Copy swap order uuids

### DIFF
--- a/lib/shared/widgets/copied_text.dart
+++ b/lib/shared/widgets/copied_text.dart
@@ -36,7 +36,7 @@ class CopiedText extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final softWrap = (maxLines ?? 0) > 1;
-    final String? showingText = text;
+    final String showingText = text ?? copiedValue;
     final Color? background =
         backgroundColor ?? Theme.of(context).inputDecorationTheme.fillColor;
 
@@ -54,48 +54,40 @@ class CopiedText extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              if (isCopiedValueShown) ...[
-                Container(
-                  key: const Key('coin-details-address-field'),
-                  child: isTruncated
-                      ? Flexible(
-                          child: TruncatedMiddleText(
-                            copiedValue,
-                            style: TextStyle(
-                              fontSize: fontSize,
-                              fontWeight: fontWeight,
-                              color: fontColor,
-                              height: height,
-                            ),
-                          ),
-                        )
-                      : Flexible(
-                          child: AutoScrollText(
-                            text: copiedValue,
-                            style: TextStyle(
-                              fontSize: fontSize,
-                              fontWeight: fontWeight,
-                              color: fontColor,
-                              height: height,
-                            ),
-                          ),
+              Container(
+                key: const Key('coin-details-address-field'),
+                child: isTruncated
+                  ? Flexible(
+                      child: TruncatedMiddleText(
+                        showingText,
+                        style: TextStyle(
+                          fontSize: fontSize,
+                          fontWeight: fontWeight,
+                          color: fontColor,
+                          height: height,
                         ),
-                ),
-                const SizedBox(
-                  width: 16,
-                ),
-              ],
+                      ),
+                    )
+                  : Flexible(
+                      child: AutoScrollText(
+                        text: showingText,
+                        style: TextStyle(
+                          fontSize: fontSize,
+                          fontWeight: fontWeight,
+                          color: fontColor,
+                          height: height,
+                        ),
+                      ),
+                    ),
+              ),
+              const SizedBox(
+                width: 16,
+              ),
               Icon(
                 Icons.copy_rounded,
                 color: Theme.of(context).textTheme.labelLarge?.color,
                 size: iconSize,
               ),
-              if (showingText != null) ...[
-                const SizedBox(
-                  width: 10,
-                ),
-                Text(showingText),
-              ]
             ],
           ),
         ),

--- a/lib/views/dex/entity_details/maker_order/maker_order_details_page.dart
+++ b/lib/views/dex/entity_details/maker_order/maker_order_details_page.dart
@@ -51,6 +51,8 @@ class _MakerOrderDetailsPageState extends State<MakerOrderDetailsPage> {
                   baseAmount: order.baseAmountAvailable ?? order.baseAmount,
                   relCoin: order.rel,
                   relAmount: order.relAmountAvailable ?? order.relAmount,
+                  isOrder: true,
+                  swapId: order.uuid,
                 ),
                 const SizedBox(height: 30),
                 _buildDetails(),
@@ -72,7 +74,6 @@ class _MakerOrderDetailsPageState extends State<MakerOrderDetailsPage> {
         children: [
           _buildPrice(),
           _buildCreatedAt(),
-          _buildOrderId(),
           _buildStatus(),
         ],
       ),
@@ -148,31 +149,6 @@ class _MakerOrderDetailsPageState extends State<MakerOrderDetailsPage> {
           ),
         ),
         Text(status),
-      ],
-    );
-  }
-
-  TableRow _buildOrderId() {
-    final MyOrder order = widget.makerOrderStatus.order;
-    return TableRow(
-      children: [
-        SizedBox(
-          height: 30,
-          child: Text(
-            '${LocaleKeys.orderId.tr()}:',
-            style: Theme.of(context).textTheme.bodyLarge,
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.only(bottom: 8.0),
-          child: InkWell(
-            onTap: () => copyToClipBoard(context, order.uuid),
-            child: Text(
-              order.uuid,
-              key: const Key('maker-order-uuid'),
-            ),
-          ),
-        ),
       ],
     );
   }

--- a/lib/views/dex/entity_details/swap/swap_details.dart
+++ b/lib/views/dex/entity_details/swap/swap_details.dart
@@ -42,6 +42,7 @@ class SwapDetails extends StatelessWidget {
             relAmount: swapStatus.isTaker
                 ? swapStatus.makerAmount
                 : swapStatus.takerAmount,
+            swapId: swapStatus.uuid,
           ),
           const SizedBox(height: 20),
           Column(

--- a/lib/views/dex/entity_details/trading_details_coin_pair.dart
+++ b/lib/views/dex/entity_details/trading_details_coin_pair.dart
@@ -8,6 +8,7 @@ import 'package:web_dex/bloc/coins_bloc/coins_repo.dart';
 import 'package:web_dex/model/coin.dart';
 import 'package:web_dex/shared/widgets/coin_item/coin_item.dart';
 import 'package:web_dex/shared/widgets/coin_item/coin_item_size.dart';
+import 'package:web_dex/shared/widgets/copied_text.dart';
 
 class TradingDetailsCoinPair extends StatelessWidget {
   const TradingDetailsCoinPair({
@@ -16,48 +17,80 @@ class TradingDetailsCoinPair extends StatelessWidget {
     required this.baseAmount,
     required this.relCoin,
     required this.relAmount,
+    this.swapId,
+    this.isOrder = false,
   }) : super(key: key);
   final String baseCoin;
   final Rational baseAmount;
   final String relCoin;
   final Rational relAmount;
+  final String? swapId;
+  final bool isOrder;
+
   @override
   Widget build(BuildContext context) {
     final coinsRepository = RepositoryProvider.of<CoinsRepo>(context);
     final Coin? coinBase = coinsRepository.getCoin(baseCoin);
     final Coin? coinRel = coinsRepository.getCoin(relCoin);
+    final String? swapId = this.swapId;
+    final bool isOrder = this.isOrder;
+
+    
 
     if (coinBase == null || coinRel == null) return const SizedBox.shrink();
 
     return Container(
-      padding: const EdgeInsets.fromLTRB(10, 20, 10, 20),
+      padding: const EdgeInsets.fromLTRB(10, 20, 10, 10),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(18),
         color: theme.currentGlobal.colorScheme.surface,
       ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceAround,
+      child: Column(
         children: [
-          Flexible(
-            child: CoinItem(
-              coin: coinBase,
-              amount: baseAmount.toDouble(),
-              size: CoinItemSize.large,
-            ),
-          ),
-          Column(
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
             children: [
-              SvgPicture.asset(
-                '$assetsPath/ui_icons/arrows.svg',
+              Flexible(
+                child: CoinItem(
+                  coin: coinBase,
+                  amount: baseAmount.toDouble(),
+                  size: CoinItemSize.large,
+                ),
+              ),
+              Column(
+                children: [
+                  SvgPicture.asset(
+                    '$assetsPath/ui_icons/arrows.svg',
+                  ),
+                ],
+              ),
+              Flexible(
+                child: CoinItem(
+                  coin: coinRel,
+                  amount: relAmount.toDouble(),
+                  size: CoinItemSize.large,
+                ),
               ),
             ],
           ),
-          Flexible(
-            child: CoinItem(
-              coin: coinRel,
-              amount: relAmount.toDouble(),
-              size: CoinItemSize.large,
-            ),
+          const SizedBox(height: 10),
+          if (swapId != null)
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+              Flexible(
+                child: CopiedText(
+                  key: Key('uuid-${swapId}'),
+                  text: isOrder ? 'Order UUID: ${swapId}' : 'Swap UUID: ${swapId}',
+                  copiedValue: swapId,
+                  isCopiedValueShown: false,
+                  padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+                  fontSize: 11,
+                  iconSize: 14,
+                  backgroundColor: theme.custom.subCardBackgroundColor,
+                ),
+              ),
+            ],
           ),
         ],
       ),


### PR DESCRIPTION
Partially solves https://github.com/KomodoPlatform/komodo-wallet/issues/2891

To test:
- Start a swap, check the details in progress, copy the uuid
- Create maker order, check the order details, copy the uuid
- Wait for a swap to complete, check the details in history, copy the uuid

**Screenshots:**

In progress:
<img width="570" height="539" alt="image" src="https://github.com/user-attachments/assets/7803b6b8-5d58-4e1c-a165-753f36d725c7" />

In  history:
<img width="504" height="310" alt="image" src="https://github.com/user-attachments/assets/2925c8ba-ddd5-46b2-85ee-75c5ed749a44" />

In orderbook (maker order)
<img width="495" height="415" alt="image" src="https://github.com/user-attachments/assets/9933ed94-d652-49db-9f41-a3d2c3b447d4" />
