### PR TITLE
feat(wallet): add hero transitions for coin icons

### DIFF
--- a/lib/shared/utils/hero_tags.dart
+++ b/lib/shared/utils/hero_tags.dart
@@ -1,0 +1,4 @@
+/// Utility helpers for Hero animation tags used across the app.
+
+/// Returns a unique hero tag for the given [abbr] coin abbreviation.
+String coinIconHeroTag(String abbr) => 'coinIcon-$abbr';

--- a/lib/shared/widgets/coin_item/coin_item.dart
+++ b/lib/shared/widgets/coin_item/coin_item.dart
@@ -12,12 +12,16 @@ class CoinItem extends StatelessWidget {
     this.size = CoinItemSize.medium,
     this.subtitleText,
     this.showNetworkLogo = true,
+    this.heroTag,
   });
 
   final Coin coin;
   final double? amount;
   final CoinItemSize size;
   final String? subtitleText;
+
+  /// Optional tag for hero animations wrapping the coin icon.
+  final String? heroTag;
 
   /// Controls which icon widget to use for displaying the coin.
   ///
@@ -30,17 +34,25 @@ class CoinItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Widget iconWidget;
+    if (showNetworkLogo) {
+      iconWidget = AssetLogo.ofId(
+        coin.id,
+        size: size.coinLogo,
+      );
+    } else {
+      iconWidget = AssetIcon.ofTicker(coin.id.id, size: size.coinLogo);
+    }
+
+    if (heroTag != null) {
+      iconWidget = Hero(tag: heroTag!, child: iconWidget);
+    }
+
     return Row(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (showNetworkLogo)
-          AssetLogo.ofId(
-            coin.id,
-            size: size.coinLogo,
-          ),
-        if (!showNetworkLogo)
-          AssetIcon.ofTicker(coin.id.id, size: size.coinLogo),
+        iconWidget,
         SizedBox(width: size.spacer),
         Flexible(
           child: CoinItemBody(

--- a/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
@@ -31,6 +31,7 @@ import 'package:web_dex/shared/widgets/segwit_icon.dart';
 import 'package:web_dex/views/common/page_header/disable_coin_button.dart';
 import 'package:web_dex/views/common/page_header/page_header.dart';
 import 'package:web_dex/views/common/pages/page_layout.dart';
+import 'package:web_dex/shared/utils/hero_tags.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_details_info/charts/portfolio_growth_chart.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_details_info/charts/portfolio_profit_loss_chart.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_details_info/coin_addresses.dart';
@@ -254,9 +255,12 @@ class _DesktopCoinDetails extends StatelessWidget {
             children: [
               Padding(
                 padding: const EdgeInsets.fromLTRB(0, 5, 12, 0),
-                child: AssetLogo.ofId(
-                  coin.id,
-                  size: 50,
+                child: Hero(
+                  tag: coinIconHeroTag(coin.abbr),
+                  child: AssetLogo.ofId(
+                    coin.id,
+                    size: 50,
+                  ),
                 ),
               ),
               _Balance(coin: coin),

--- a/lib/views/wallet/wallet_page/common/coin_list_item_desktop.dart
+++ b/lib/views/wallet/wallet_page/common/coin_list_item_desktop.dart
@@ -10,6 +10,7 @@ import 'package:web_dex/shared/ui/ui_simple_border_button.dart';
 import 'package:web_dex/shared/widgets/coin_fiat_price.dart';
 import 'package:web_dex/shared/widgets/coin_item/coin_item.dart';
 import 'package:web_dex/shared/widgets/coin_item/coin_item_size.dart';
+import 'package:web_dex/shared/utils/hero_tags.dart';
 import 'package:web_dex/shared/widgets/need_attention_mark.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_details_info/charts/coin_sparkline.dart';
 
@@ -54,7 +55,11 @@ class CoinListItemDesktop extends StatelessWidget {
                       Stack(
                         clipBehavior: Clip.none,
                         children: [
-                          CoinItem(coin: coin, size: CoinItemSize.large),
+                          CoinItem(
+                            coin: coin,
+                            size: CoinItemSize.large,
+                            heroTag: coinIconHeroTag(coin.abbr),
+                          ),
                           if (coin.isActivating)
                             const Positioned(
                               top: 4,

--- a/lib/views/wallet/wallet_page/common/coin_list_item_mobile.dart
+++ b/lib/views/wallet/wallet_page/common/coin_list_item_mobile.dart
@@ -7,6 +7,7 @@ import 'package:web_dex/shared/widgets/coin_fiat_balance.dart';
 import 'package:web_dex/shared/widgets/coin_fiat_change.dart';
 import 'package:web_dex/shared/widgets/coin_item/coin_item.dart';
 import 'package:web_dex/shared/widgets/coin_item/coin_item_size.dart';
+import 'package:web_dex/shared/utils/hero_tags.dart';
 import 'package:web_dex/shared/widgets/need_attention_mark.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_details_info/charts/coin_sparkline.dart';
 
@@ -47,7 +48,11 @@ class CoinListItemMobile extends StatelessWidget {
                   Stack(
                     clipBehavior: Clip.none,
                     children: [
-                      CoinItem(coin: coin, size: CoinItemSize.large),
+                      CoinItem(
+                        coin: coin,
+                        size: CoinItemSize.large,
+                        heroTag: coinIconHeroTag(coin.abbr),
+                      ),
                       if (coin.isActivating)
                         const Positioned(
                           top: 4,

--- a/lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart
+++ b/lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart
@@ -16,6 +16,7 @@ import 'package:web_dex/shared/widgets/coin_balance.dart';
 import 'package:web_dex/shared/widgets/coin_fiat_balance.dart';
 import 'package:web_dex/shared/widgets/coin_item/coin_item.dart';
 import 'package:web_dex/shared/widgets/coin_item/coin_item_size.dart';
+import 'package:web_dex/shared/utils/hero_tags.dart';
 import 'package:app_theme/src/dark/theme_custom_dark.dart';
 import 'package:app_theme/src/light/theme_custom_light.dart';
 
@@ -138,7 +139,10 @@ class _ExpandableCoinListItemState extends State<ExpandableCoinListItem> {
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           // Use CoinItem with large size for mobile, matching GroupedAssetTickerItem
-          AssetIcon(widget.coin.id, size: CoinItemSize.large.coinLogo),
+          Hero(
+            tag: coinIconHeroTag(widget.coin.abbr),
+            child: AssetIcon(widget.coin.id, size: CoinItemSize.large.coinLogo),
+          ),
           const SizedBox(width: 8),
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -212,7 +216,11 @@ class _ExpandableCoinListItemState extends State<ExpandableCoinListItem> {
           Container(
             width: double.infinity,
             constraints: const BoxConstraints(maxWidth: 180),
-            child: CoinItem(coin: widget.coin, size: CoinItemSize.large),
+            child: CoinItem(
+              coin: widget.coin,
+              size: CoinItemSize.large,
+              heroTag: coinIconHeroTag(widget.coin.abbr),
+            ),
           ),
           const Spacer(),
           CoinBalance(coin: widget.coin),


### PR DESCRIPTION
## Summary
- introduce helper for hero tags
- add optional heroTag to `CoinItem` widget
- wrap coin icons in `CoinListItemMobile`, `CoinListItemDesktop`, and
  `ExpandableCoinListItem` with hero animations
- wrap coin icon on coin details page with matching hero tag

## Testing
- `flutter pub get --offline`
- `flutter analyze`
- `dart format -o write lib/shared/utils/hero_tags.dart lib/shared/widgets/coin_item/coin_item.dart lib/views/wallet/wallet_page/common/coin_list_item_mobile.dart lib/views/wallet/wallet_page/common/coin_list_item_desktop.dart lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart`

------
https://chatgpt.com/codex/tasks/task_e_688580a88ee08326a26d5a33d8438bb7