### PR TITLE
feat(ui): add hero animations for coin icons

### DIFF
--- a/lib/shared/widgets/asset_item/asset_item.dart
+++ b/lib/shared/widgets/asset_item/asset_item.dart
@@ -14,12 +14,16 @@ class AssetItem extends StatelessWidget {
     this.amount,
     this.size = AssetItemSize.medium,
     this.subtitleText,
+    this.heroTag,
   });
 
   final AssetId assetId;
   final double? amount;
   final AssetItemSize size;
   final String? subtitleText;
+
+  /// Optional tag used to animate the asset logo between routes.
+  final Object? heroTag;
 
   @override
   Widget build(BuildContext context) {
@@ -30,6 +34,7 @@ class AssetItem extends StatelessWidget {
         AssetLogo.ofId(
           assetId,
           size: size.assetLogo,
+          heroTag: heroTag,
         ),
         SizedBox(width: 8),
         Flexible(

--- a/lib/shared/widgets/coin_item/coin_item.dart
+++ b/lib/shared/widgets/coin_item/coin_item.dart
@@ -12,12 +12,16 @@ class CoinItem extends StatelessWidget {
     this.size = CoinItemSize.medium,
     this.subtitleText,
     this.showNetworkLogo = true,
+    this.heroTag,
   });
 
   final Coin coin;
   final double? amount;
   final CoinItemSize size;
   final String? subtitleText;
+
+  /// Optional tag used to animate the coin icon between routes.
+  final Object? heroTag;
 
   /// Controls which icon widget to use for displaying the coin.
   ///
@@ -38,9 +42,14 @@ class CoinItem extends StatelessWidget {
           AssetLogo.ofId(
             coin.id,
             size: size.coinLogo,
+            heroTag: heroTag,
           ),
         if (!showNetworkLogo)
-          AssetIcon.ofTicker(coin.id.id, size: size.coinLogo),
+          AssetIcon.ofTicker(
+            coin.id.id,
+            size: size.coinLogo,
+            heroTag: heroTag,
+          ),
         SizedBox(width: size.spacer),
         Flexible(
           child: CoinItemBody(

--- a/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
@@ -257,6 +257,7 @@ class _DesktopCoinDetails extends StatelessWidget {
                 child: AssetLogo.ofId(
                   coin.id,
                   size: 50,
+                  heroTag: coin.id.id,
                 ),
               ),
               _Balance(coin: coin),
@@ -365,6 +366,7 @@ class _CoinDetailsInfoHeader extends StatelessWidget {
           AssetIcon.ofTicker(
             coin.abbr,
             size: 35,
+            heroTag: coin.id.id,
           ),
           const SizedBox(height: 8),
           _Balance(coin: coin),

--- a/lib/views/wallet/coins_manager/coins_manager_list_item.dart
+++ b/lib/views/wallet/coins_manager/coins_manager_list_item.dart
@@ -98,7 +98,11 @@ class _CoinsManagerListItemDesktop extends StatelessWidget {
             ),
             Expanded(
               flex: 2,
-              child: CoinItem(coin: coin, size: CoinItemSize.large),
+              child: CoinItem(
+                coin: coin,
+                size: CoinItemSize.large,
+                heroTag: coin.id.id,
+              ),
             ),
             Expanded(
               flex: isAddAssets ? 2 : 1,
@@ -253,7 +257,13 @@ class _CoinsManagerListItemMobile extends StatelessWidget {
               onChanged: (_) => onSelect(),
             ),
             const SizedBox(width: 8),
-            Expanded(child: CoinItem(coin: coin, size: CoinItemSize.large)),
+            Expanded(
+              child: CoinItem(
+                coin: coin,
+                size: CoinItemSize.large,
+                heroTag: coin.id.id,
+              ),
+            ),
             if (!isAddAssets)
               Column(
                 mainAxisSize: MainAxisSize.min,

--- a/lib/views/wallet/wallet_page/common/asset_list_item_desktop.dart
+++ b/lib/views/wallet/wallet_page/common/asset_list_item_desktop.dart
@@ -55,6 +55,7 @@ class AssetListItemDesktop extends StatelessWidget {
                     child: AssetItem(
                       assetId: assetId,
                       size: AssetItemSize.large,
+                      heroTag: assetId.id,
                     ),
                   ),
                 ),

--- a/lib/views/wallet/wallet_page/common/asset_list_item_mobile.dart
+++ b/lib/views/wallet/wallet_page/common/asset_list_item_mobile.dart
@@ -34,6 +34,7 @@ class AssetListItemMobile extends StatelessWidget {
               child: AssetItem(
                 assetId: assetId,
                 size: AssetItemSize.medium,
+                heroTag: assetId.id,
               ),
             ),
             const Icon(Icons.chevron_right),

--- a/lib/views/wallet/wallet_page/common/coin_list_item_desktop.dart
+++ b/lib/views/wallet/wallet_page/common/coin_list_item_desktop.dart
@@ -54,7 +54,11 @@ class CoinListItemDesktop extends StatelessWidget {
                       Stack(
                         clipBehavior: Clip.none,
                         children: [
-                          CoinItem(coin: coin, size: CoinItemSize.large),
+                          CoinItem(
+                            coin: coin,
+                            size: CoinItemSize.large,
+                            heroTag: coin.id.id,
+                          ),
                           if (coin.isActivating)
                             const Positioned(
                               top: 4,

--- a/lib/views/wallet/wallet_page/common/coin_list_item_mobile.dart
+++ b/lib/views/wallet/wallet_page/common/coin_list_item_mobile.dart
@@ -47,7 +47,11 @@ class CoinListItemMobile extends StatelessWidget {
                   Stack(
                     clipBehavior: Clip.none,
                     children: [
-                      CoinItem(coin: coin, size: CoinItemSize.large),
+                      CoinItem(
+                        coin: coin,
+                        size: CoinItemSize.large,
+                        heroTag: coin.id.id,
+                      ),
                       if (coin.isActivating)
                         const Positioned(
                           top: 4,

--- a/lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart
+++ b/lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart
@@ -138,7 +138,11 @@ class _ExpandableCoinListItemState extends State<ExpandableCoinListItem> {
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           // Use CoinItem with large size for mobile, matching GroupedAssetTickerItem
-          AssetIcon(widget.coin.id, size: CoinItemSize.large.coinLogo),
+          AssetIcon(
+            widget.coin.id,
+            size: CoinItemSize.large.coinLogo,
+            heroTag: widget.coin.id.id,
+          ),
           const SizedBox(width: 8),
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -212,7 +216,11 @@ class _ExpandableCoinListItemState extends State<ExpandableCoinListItem> {
           Container(
             width: double.infinity,
             constraints: const BoxConstraints(maxWidth: 180),
-            child: CoinItem(coin: widget.coin, size: CoinItemSize.large),
+            child: CoinItem(
+              coin: widget.coin,
+              size: CoinItemSize.large,
+              heroTag: widget.coin.id.id,
+            ),
           ),
           const Spacer(),
           CoinBalance(coin: widget.coin),

--- a/lib/views/wallet/wallet_page/common/grouped_asset_ticker_item.dart
+++ b/lib/views/wallet/wallet_page/common/grouped_asset_ticker_item.dart
@@ -111,6 +111,7 @@ class _GroupedAssetTickerItemState extends State<GroupedAssetTickerItem> {
                       child: AssetItem(
                         assetId: _primaryAsset,
                         size: AssetItemSize.large,
+                        heroTag: _primaryAsset.id,
                       ),
                     ),
                     if (!isMobile)


### PR DESCRIPTION
## Summary
- enable hero animations by passing `heroTag` to `AssetLogo` and `AssetIcon`
- forward `heroTag` through `CoinItem` and `AssetItem`
- supply hero tags from coin and asset list items
- use matching hero tags on coin details pages

## Testing
- `flutter analyze`
- `dart format -o none --set-exit-if-changed lib/shared/widgets/coin_item/coin_item.dart lib/shared/widgets/asset_item/asset_item.dart lib/views/wallet/wallet_page/common/asset_list_item_desktop.dart lib/views/wallet/wallet_page/common/asset_list_item_mobile.dart lib/views/wallet/wallet_page/common/grouped_asset_ticker_item.dart lib/views/wallet/wallet_page/common/coin_list_item_desktop.dart lib/views/wallet/wallet_page/common/coin_list_item_mobile.dart lib/views/wallet/coins_manager/coins_manager_list_item.dart lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart`

------
https://chatgpt.com/codex/tasks/task_e_688643c7ec18832691934eb28a48b9ca