### PR TITLE
fix(nft): implement parent coin activation for NFTs

### DIFF
--- a/lib/bloc/coins_bloc/coins_repo.dart
+++ b/lib/bloc/coins_bloc/coins_repo.dart
@@ -289,7 +289,7 @@ class CoinsRepo {
     Exception? lastActivationException;
 
     for (final asset in assets) {
-      final coin = asset.toCoin();
+      final coin = _assetToCoinWithoutAddress(asset);
       try {
         if (notify) _broadcastAsset(coin.copyWith(state: CoinState.activating));
 
@@ -416,7 +416,10 @@ class CoinsRepo {
   }) async {
     final assets = coins
         .map((coin) => _kdfSdk.assets.available[coin.id])
-        .whereType<Asset>()
+        // use cast instead of `whereType` to ensure an exception is thrown
+        // if the provided asset is not found in the SDK. An explicit
+        // argument error might be more apt here.
+        .cast<Asset>()
         .toList();
 
     return activateAssetsSync(

--- a/lib/bloc/nfts/nft_main_repo.dart
+++ b/lib/bloc/nfts/nft_main_repo.dart
@@ -27,8 +27,12 @@ class NftsRepo {
     final parentCoins = chains
         .map(
           (chain) =>
-              knownCoins.firstWhere((coin) => coin.id.id == chain.coinAbbr()),
+              knownCoins.firstWhere(
+                (coin) => coin.id.id == chain.coinAbbr(),
+                orElse: () => null,
+              ),
         )
+        .where((coin) => coin != null)
         .toList();
 
     if (parentCoins.isEmpty) return;

--- a/lib/bloc/nfts/nft_main_repo.dart
+++ b/lib/bloc/nfts/nft_main_repo.dart
@@ -86,7 +86,7 @@ class NftsRepo {
     }
 
     try {
-      await _coinsRepo.activateCoinsSync(parentCoins);
+      await _coinsRepo.activateCoinsSync(parentCoins, maxRetryAttempts: 10);
     } catch (e, s) {
       _log.shout('Failed to activate parent coins', e, s);
     }

--- a/lib/mm2/mm2_api/mm2_api_nft.dart
+++ b/lib/mm2/mm2_api/mm2_api_nft.dart
@@ -104,12 +104,6 @@ class Mm2ApiNft {
       }
     }
 
-    if (nfts.isEmpty) {
-      return {
-        'error': 'Failed to fetch NFTs for the provided chains',
-      };
-    }
-
     return {
       'result': {
         'nfts': nfts,

--- a/lib/mm2/mm2_api/mm2_api_nft.dart
+++ b/lib/mm2/mm2_api/mm2_api_nft.dart
@@ -29,23 +29,28 @@ class Mm2ApiNft {
   Future<Map<String, dynamic>> updateNftList(
     List<NftBlockchains> chains,
   ) async {
-    try {
-      final List<String> nftChains = await getActiveNftChains(chains);
-      if (nftChains.isEmpty) {
-        return {
-          'error':
-              'Please ensure an NFT chain is activated and patiently await '
-                  'while your NFTs are loaded.',
-        };
+    bool hasSuccess = false;
+    for (final chain in chains) {
+      try {
+        await _enableNftChains([chain]);
+        final List<String> nftChains = await getActiveNftChains([chain]);
+        if (nftChains.isEmpty) continue;
+        final request = UpdateNftRequest(chains: nftChains);
+        await call(request);
+        hasSuccess = true;
+      } catch (e, s) {
+        _log.shout(
+            'Error updating nft for chain ${chain.toApiRequest()}', e, s);
       }
-      await _enableNftChains(chains);
-      final request = UpdateNftRequest(chains: nftChains);
-
-      return await call(request);
-    } catch (e, s) {
-      _log.shout('Error updating nfts', e, s);
-      throw TransportError(message: e.toString());
     }
+
+    if (!hasSuccess) {
+      return {
+        'error': 'Failed to update NFTs for the provided chains',
+      };
+    }
+
+    return {'result': 'ok'};
   }
 
   Future<Map<String, dynamic>> refreshNftMetadata({
@@ -67,23 +72,49 @@ class Mm2ApiNft {
   }
 
   Future<Map<String, dynamic>> getNftList(List<NftBlockchains> chains) async {
-    try {
-      final List<String> nftChains = await getActiveNftChains(chains);
-      if (nftChains.isEmpty) {
-        return {
-          'error':
-              'Please ensure the NFT chain is activated and patiently await '
-                  'while your NFTs are loaded.',
-        };
+    final List<NftBlockchains> enabledChains = [];
+    for (final chain in chains) {
+      try {
+        await _enableNftChains([chain]);
+        enabledChains.add(chain);
+      } catch (e, s) {
+        _log.shout('Failed to enable nft chain ${chain.toApiRequest()}', e, s);
       }
-
-      final request = GetNftListRequest(chains: nftChains);
-      final JsonMap json = await call(request);
-      return json;
-    } catch (e, s) {
-      _log.shout('Error getting nft list', e, s);
-      throw TransportError(message: e.toString());
     }
+
+    final List<String> nftChains = await getActiveNftChains(enabledChains);
+    if (nftChains.isEmpty) {
+      return {
+        'error': 'Please ensure the NFT chain is activated and patiently await '
+            'while your NFTs are loaded.',
+      };
+    }
+
+    final List<dynamic> nfts = [];
+    for (final chain in nftChains) {
+      try {
+        final request = GetNftListRequest(chains: [chain]);
+        final JsonMap res = await call(request);
+        final chainNfts = res['result'] != null
+            ? List<dynamic>.from(res['result']['nfts'] as List? ?? [])
+            : <dynamic>[];
+        nfts.addAll(chainNfts);
+      } catch (e, s) {
+        _log.shout('Error getting nft list for chain $chain', e, s);
+      }
+    }
+
+    if (nfts.isEmpty) {
+      return {
+        'error': 'Failed to fetch NFTs for the provided chains',
+      };
+    }
+
+    return {
+      'result': {
+        'nfts': nfts,
+      },
+    };
   }
 
   Future<Map<String, dynamic>> withdraw(WithdrawNftRequest request) async {

--- a/lib/mm2/mm2_api/mm2_api_nft.dart
+++ b/lib/mm2/mm2_api/mm2_api_nft.dart
@@ -146,11 +146,16 @@ class Mm2ApiNft {
   }
 
   Future<void> enableNft(Asset asset) async {
-    final configSymbol = asset.id.symbol.configSymbol;
+    final configSymbol = asset.id.symbol.assetConfigId;
     final activationParams =
         NftActivationParams(provider: NftProvider.moralis());
-    await _sdk.client.rpc.nft
-        .enableNft(ticker: configSymbol, activationParams: activationParams);
+    await retry<void>(
+      () async => await _sdk.client.rpc.nft
+          .enableNft(ticker: configSymbol, activationParams: activationParams),
+      maxAttempts: 3,
+      backoffStrategy:
+          ExponentialBackoff(initialDelay: const Duration(seconds: 1)),
+    );
   }
 
   Future<void> enableNftChains(

--- a/packages/komodo_ui_kit/lib/src/skeleton_loaders/skeleton_loader_list_tile.dart
+++ b/packages/komodo_ui_kit/lib/src/skeleton_loaders/skeleton_loader_list_tile.dart
@@ -1,7 +1,12 @@
 import 'package:flutter/material.dart';
 
 class SkeletonListTile extends StatefulWidget {
-  const SkeletonListTile({super.key});
+  const SkeletonListTile({
+    super.key,
+    this.height = 122,
+  });
+
+  final double height;
 
   @override
   State<SkeletonListTile> createState() => _SkeletonListTileState();
@@ -49,6 +54,7 @@ class _SkeletonListTileState extends State<SkeletonListTile>
   @override
   Widget build(BuildContext context) {
     return Container(
+      height: widget.height,
       padding: const EdgeInsets.all(16),
       child: Row(
         children: <Widget>[


### PR DESCRIPTION
Fixes: 

- The NFT page for a fresh wallet remaining in the loading state indefinitely due to the required parent coins not being active. This can also be reproduced by disabling AVAX, MATIC, FTM, BNB, or ETH in an existing wallet after login.
- a bug when quickly deactivating and reactivating the same coin in the same session. Skips the `disable_coin` RPC call for now, leaving the coin enabled in the background. Encountered with background NFT refresh tasks that try to activate the required parent and NFT coins before making requests.
- skeleton loader list tile RenderBox assertion error in debug mode due to unconstrained height in list/sliver.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of NFT operations by ensuring required parent coins are activated before proceeding.
  * Enhanced error handling for NFT updates and retrievals, allowing partial successes even if some chains fail.
  * Prevented errors when deactivating coins by adjusting the deactivation process to avoid disabling coins directly.

* **New Features**
  * Added a method to retrieve only active NFT chains from the SDK.
  * Introduced retry logic with exponential backoff for enabling NFT chains and updating NFTs.
  * Added an optional height parameter to the skeleton loader list tile widget for customizable UI appearance.

* **Refactor**
  * Streamlined the process for updating and fetching NFTs by handling each blockchain individually and logging errors without interrupting the entire operation.
  * Standardized error logging for NFT operations for clearer diagnostics.
  * Improved event handling in NFT management with restartable event processing and enhanced logging for user state checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->