### PR TITLE
fix(ui): ensure unique hero tags

### DIFF
--- a/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
@@ -257,7 +257,7 @@ class _DesktopCoinDetails extends StatelessWidget {
                 child: AssetLogo.ofId(
                   coin.id,
                   size: 50,
-                  heroTag: coin.id.id,
+                  heroTag: coin.id,
                 ),
               ),
               _Balance(coin: coin),
@@ -366,7 +366,7 @@ class _CoinDetailsInfoHeader extends StatelessWidget {
           AssetIcon.ofTicker(
             coin.abbr,
             size: 35,
-            heroTag: coin.id.id,
+            heroTag: coin.id,
           ),
           const SizedBox(height: 8),
           _Balance(coin: coin),

--- a/lib/views/wallet/coins_manager/coins_manager_list_item.dart
+++ b/lib/views/wallet/coins_manager/coins_manager_list_item.dart
@@ -101,7 +101,7 @@ class _CoinsManagerListItemDesktop extends StatelessWidget {
               child: CoinItem(
                 coin: coin,
                 size: CoinItemSize.large,
-                heroTag: coin.id.id,
+                heroTag: coin.id,
               ),
             ),
             Expanded(
@@ -261,7 +261,7 @@ class _CoinsManagerListItemMobile extends StatelessWidget {
               child: CoinItem(
                 coin: coin,
                 size: CoinItemSize.large,
-                heroTag: coin.id.id,
+                heroTag: coin.id,
               ),
             ),
             if (!isAddAssets)

--- a/lib/views/wallet/wallet_page/common/asset_list_item_desktop.dart
+++ b/lib/views/wallet/wallet_page/common/asset_list_item_desktop.dart
@@ -55,7 +55,7 @@ class AssetListItemDesktop extends StatelessWidget {
                     child: AssetItem(
                       assetId: assetId,
                       size: AssetItemSize.large,
-                      heroTag: assetId.id,
+                      heroTag: assetId,
                     ),
                   ),
                 ),

--- a/lib/views/wallet/wallet_page/common/asset_list_item_mobile.dart
+++ b/lib/views/wallet/wallet_page/common/asset_list_item_mobile.dart
@@ -34,7 +34,7 @@ class AssetListItemMobile extends StatelessWidget {
               child: AssetItem(
                 assetId: assetId,
                 size: AssetItemSize.medium,
-                heroTag: assetId.id,
+                heroTag: assetId,
               ),
             ),
             const Icon(Icons.chevron_right),

--- a/lib/views/wallet/wallet_page/common/coin_list_item_desktop.dart
+++ b/lib/views/wallet/wallet_page/common/coin_list_item_desktop.dart
@@ -57,7 +57,7 @@ class CoinListItemDesktop extends StatelessWidget {
                           CoinItem(
                             coin: coin,
                             size: CoinItemSize.large,
-                            heroTag: coin.id.id,
+                            heroTag: coin.id,
                           ),
                           if (coin.isActivating)
                             const Positioned(

--- a/lib/views/wallet/wallet_page/common/coin_list_item_mobile.dart
+++ b/lib/views/wallet/wallet_page/common/coin_list_item_mobile.dart
@@ -50,7 +50,7 @@ class CoinListItemMobile extends StatelessWidget {
                       CoinItem(
                         coin: coin,
                         size: CoinItemSize.large,
-                        heroTag: coin.id.id,
+                        heroTag: coin.id,
                       ),
                       if (coin.isActivating)
                         const Positioned(

--- a/lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart
+++ b/lib/views/wallet/wallet_page/common/expandable_coin_list_item.dart
@@ -141,7 +141,7 @@ class _ExpandableCoinListItemState extends State<ExpandableCoinListItem> {
           AssetIcon(
             widget.coin.id,
             size: CoinItemSize.large.coinLogo,
-            heroTag: widget.coin.id.id,
+            heroTag: widget.coin.id,
           ),
           const SizedBox(width: 8),
           Column(
@@ -219,7 +219,7 @@ class _ExpandableCoinListItemState extends State<ExpandableCoinListItem> {
             child: CoinItem(
               coin: widget.coin,
               size: CoinItemSize.large,
-              heroTag: widget.coin.id.id,
+              heroTag: widget.coin.id,
             ),
           ),
           const Spacer(),

--- a/lib/views/wallet/wallet_page/common/grouped_asset_ticker_item.dart
+++ b/lib/views/wallet/wallet_page/common/grouped_asset_ticker_item.dart
@@ -111,7 +111,7 @@ class _GroupedAssetTickerItemState extends State<GroupedAssetTickerItem> {
                       child: AssetItem(
                         assetId: _primaryAsset,
                         size: AssetItemSize.large,
-                        heroTag: _primaryAsset.id,
+                        heroTag: _primaryAsset,
                       ),
                     ),
                     if (!isMobile)


### PR DESCRIPTION
## Summary
- ensure hero widgets use a unique tag per asset or coin

## Testing
- `flutter pub get --offline`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_68879a033e1083269814edee29e3a1cf