### PR TITLE
chore(fiat-onramp): temporarily disable Ramp until API keys are regenerated

### DIFF
--- a/lib/bloc/fiat/models/fiat_payment_method.dart
+++ b/lib/bloc/fiat/models/fiat_payment_method.dart
@@ -120,26 +120,28 @@ class FiatPaymentMethod extends Equatable {
 }
 
 List<FiatPaymentMethod> defaultFiatPaymentMethods = [
-  FiatPaymentMethod(
-    id: 'CARD_PAYMENT',
-    name: 'Card Payment',
-    providerId: 'Ramp',
-    priceInfo: FiatPriceInfo.zero,
-    relativePercent: Decimal.zero,
-    providerIconAssetPath: 'assets/fiat/providers/ramp_icon.svg',
-    transactionLimits: const [],
-    transactionFees: const [],
-  ),
-  FiatPaymentMethod(
-    id: 'APPLE_PAY',
-    name: 'Apple Pay',
-    providerId: 'Ramp',
-    priceInfo: FiatPriceInfo.zero,
-    relativePercent: Decimal.parse('-0.04126038522159592'),
-    providerIconAssetPath: 'assets/fiat/providers/ramp_icon.svg',
-    transactionLimits: const [],
-    transactionFees: const [],
-  ),
+  // Ramp API keys unavailable for the time being
+  // TODO(takenagain): re-enable when API keys are available
+  // FiatPaymentMethod(
+  //   id: 'CARD_PAYMENT',
+  //   name: 'Card Payment',
+  //   providerId: 'Ramp',
+  //   priceInfo: FiatPriceInfo.zero,
+  //   relativePercent: Decimal.zero,
+  //   providerIconAssetPath: 'assets/fiat/providers/ramp_icon.svg',
+  //   transactionLimits: const [],
+  //   transactionFees: const [],
+  // ),
+  // FiatPaymentMethod(
+  //   id: 'APPLE_PAY',
+  //   name: 'Apple Pay',
+  //   providerId: 'Ramp',
+  //   priceInfo: FiatPriceInfo.zero,
+  //   relativePercent: Decimal.parse('-0.04126038522159592'),
+  //   providerIconAssetPath: 'assets/fiat/providers/ramp_icon.svg',
+  //   transactionLimits: const [],
+  //   transactionFees: const [],
+  // ),
   FiatPaymentMethod(
     id: '7554',
     name: 'Visa/Mastercard',

--- a/lib/views/fiat/fiat_page.dart
+++ b/lib/views/fiat/fiat_page.dart
@@ -48,7 +48,10 @@ class _FiatPageState extends State<FiatPage> with TickerProviderStateMixin {
   Widget build(BuildContext context) {
     final coinsRepository = RepositoryProvider.of<CoinsRepo>(context);
     final fiatRepository = FiatRepository(
-      [BanxaFiatProvider(), RampFiatProvider()],
+      // Ramp API keys unavailable for the time being
+      // TODO(takenagain): re-enable when API keys are available
+      // [BanxaFiatProvider(), RampFiatProvider()],
+      [BanxaFiatProvider()],
       coinsRepository,
     );
     final sdk = RepositoryProvider.of<KomodoDefiSdk>(context);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Temporarily disabled "Card Payment" and "Apple Pay" options with the Ramp provider due to unavailable API keys.
  * Removed Ramp as a fiat provider from the list of available options. Ramp-related options will be re-enabled once API keys are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->