### PR TITLE
feat(feedback): add cancel option and primary submit

### DIFF
--- a/lib/services/feedback/custom_feedback_form.dart
+++ b/lib/services/feedback/custom_feedback_form.dart
@@ -184,13 +184,22 @@ class CustomFeedbackForm extends StatelessWidget {
                           child: CircularProgressIndicator(strokeWidth: 2.0),
                         ),
                       ),
-                    TextButton(
+                    UiUnderlineTextButton(
+                      text: LocaleKeys.cancel.tr(),
+                      onPressed: isLoading
+                          ? null
+                          : () => BetterFeedback.of(context).hide(),
+                    ),
+                    const SizedBox(width: 16),
+                    UiPrimaryButton(
+                      width: 130,
+                      height: 40,
                       onPressed: formValid
                           ? () => context
                               .read<FeedbackFormBloc>()
                               .add(const FeedbackFormSubmitted())
                           : null,
-                      child: const Text('SUBMIT'),
+                      text: 'SUBMIT',
                     ),
                   ],
                 ),


### PR DESCRIPTION
## Summary
- convert Submit button in feedback form to `UiPrimaryButton`
- add Cancel text button to allow closing the form

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6888d57e96048326b8cc043ab3329e1a