### PR TITLE
feat(analytics): add searchbar and theme events

### DIFF
--- a/lib/bloc/coins_manager/coins_manager_bloc.dart
+++ b/lib/bloc/coins_manager/coins_manager_bloc.dart
@@ -7,6 +7,7 @@ import 'package:web_dex/app_config/app_config.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_repo.dart';
 import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
 import 'package:web_dex/analytics/events/portfolio_events.dart';
+import 'package:web_dex/analytics/events/misc_events.dart';
 import 'package:web_dex/model/coin.dart';
 import 'package:web_dex/model/coin_type.dart';
 import 'package:web_dex/model/coin_utils.dart';
@@ -204,6 +205,14 @@ class CoinsManagerBloc extends Bloc<CoinsManagerEvent, CoinsManagerState> {
     Emitter<CoinsManagerState> emit,
   ) {
     emit(state.copyWith(searchPhrase: event.text));
+    final query = event.text.trim();
+    final matchedCoin = _coinsRepo.getCoin(query.toUpperCase());
+    _analyticsBloc.logEvent(
+      SearchbarInputEventData(
+        queryLength: query.length,
+        assetSymbol: matchedCoin?.abbr,
+      ),
+    );
     add(CoinsManagerCoinsUpdate(state.action));
   }
 

--- a/lib/views/settings/widgets/general_settings/settings_theme_switcher.dart
+++ b/lib/views/settings/widgets/general_settings/settings_theme_switcher.dart
@@ -5,6 +5,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:web_dex/app_config/app_config.dart';
 import 'package:web_dex/bloc/settings/settings_bloc.dart';
 import 'package:web_dex/bloc/settings/settings_event.dart';
+import 'package:web_dex/bloc/analytics/analytics_bloc.dart';
+import 'package:web_dex/analytics/events/misc_events.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/views/settings/widgets/common/settings_section.dart';
 
@@ -55,8 +57,12 @@ class _SettingsModeSelector extends StatelessWidget {
         mode == context.select((SettingsBloc bloc) => bloc.state.themeMode);
     const double size = 16.0;
     return InkWell(
-      onTap: () =>
-          context.read<SettingsBloc>().add(ThemeModeChanged(mode: mode)),
+      onTap: () {
+        context.read<SettingsBloc>().add(ThemeModeChanged(mode: mode));
+        context.read<AnalyticsBloc>().logEvent(
+              ThemeSelectedEventData(themeName: _analyticsName),
+            );
+      },
       mouseCursor: SystemMouseCursors.click,
       child: Container(
         key: Key('theme-settings-switcher-$_themeName'),
@@ -123,6 +129,17 @@ class _SettingsModeSelector extends StatelessWidget {
         return LocaleKeys.light.tr();
       case ThemeMode.system:
         return LocaleKeys.defaultText.tr();
+    }
+  }
+
+  String get _analyticsName {
+    switch (mode) {
+      case ThemeMode.dark:
+        return 'dark';
+      case ThemeMode.light:
+        return 'light';
+      case ThemeMode.system:
+        return 'auto';
     }
   }
 


### PR DESCRIPTION
## Summary
- log `searchbar_input` analytics when search text changes
- log `theme_selected` analytics when selecting theme in settings

## Testing
- `dart format lib/bloc/coins_manager/coins_manager_bloc.dart lib/views/settings/widgets/general_settings/settings_theme_switcher.dart`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6888cbeefdec8326a81bd082c85ccbda