### PR TITLE
feat(ui): add tooltip to price history sparkline

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -675,5 +675,6 @@
     "searchAddresses": "Search addresses",
     "chart": "Chart",
     "tradingDisabledTooltip": "Trading features are currently disabled",
-    "tradingDisabled": "Trading is currently unavailable"
+    "tradingDisabled": "Trading is currently unavailable",
+    "priceHistorySparklineTooltip": "Price history for the last 7 days"
 }

--- a/lib/generated/codegen_loader.g.dart
+++ b/lib/generated/codegen_loader.g.dart
@@ -673,5 +673,6 @@ abstract class  LocaleKeys {
   static const chart = 'chart';
   static const tradingDisabledTooltip = 'tradingDisabledTooltip';
   static const tradingDisabled = 'tradingDisabled';
+  static const priceHistorySparklineTooltip = 'priceHistorySparklineTooltip';
 
 }

--- a/lib/views/wallet/coin_details/coin_details_info/charts/coin_sparkline.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/charts/coin_sparkline.dart
@@ -28,7 +28,7 @@ class CoinSparkline extends StatelessWidget {
           return UiTooltip(
             message: LocaleKeys.priceHistorySparklineTooltip.tr(),
             child: LimitedBox(
-              maxWidth: 130,
+              maxWidth: 90,
               child: SizedBox(
                 height: 35,
                 child: SparklineChart(

--- a/lib/views/wallet/coin_details/coin_details_info/charts/coin_sparkline.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/charts/coin_sparkline.dart
@@ -1,6 +1,9 @@
 import 'package:dragon_charts_flutter/dragon_charts_flutter.dart';
 import 'package:flutter/material.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:komodo_cex_market_data/komodo_cex_market_data.dart';
+import 'package:komodo_ui_kit/komodo_ui_kit.dart';
+import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/shared/utils/utils.dart';
 
 class CoinSparkline extends StatelessWidget {
@@ -22,16 +25,19 @@ class CoinSparkline extends StatelessWidget {
         } else if (!snapshot.hasData || (snapshot.data?.isEmpty ?? true)) {
           return const SizedBox.shrink();
         } else {
-          return LimitedBox(
-            maxWidth: 130,
-            child: SizedBox(
-              height: 35,
-              child: SparklineChart(
-                data: snapshot.data!,
-                positiveLineColor: Colors.green,
-                negativeLineColor: Colors.red,
-                lineThickness: 1.0,
-                isCurved: true,
+          return UiTooltip(
+            message: LocaleKeys.priceHistorySparklineTooltip.tr(),
+            child: LimitedBox(
+              maxWidth: 130,
+              child: SizedBox(
+                height: 35,
+                child: SparklineChart(
+                  data: snapshot.data!,
+                  positiveLineColor: Colors.green,
+                  negativeLineColor: Colors.red,
+                  lineThickness: 1.0,
+                  isCurved: true,
+                ),
               ),
             ),
           );


### PR DESCRIPTION
## Summary
- add tooltip message for sparkline chart in translations
- expose new `priceHistorySparklineTooltip` key in locale loader
- wrap the sparkline chart with `UiTooltip` widget

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6888dc4cf3a48326bdd9c2741e0374dc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tooltip to the sparkline chart in coin details, showing localized information about the price history for the last 7 days.

* **Chores**
  * Updated translations with a new entry for the price history sparkline tooltip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->