### PR TITLE
fix(trezor): pin input not visible in light mode

### DIFF
--- a/app_theme/lib/src/light/theme_custom_light.dart
+++ b/app_theme/lib/src/light/theme_custom_light.dart
@@ -7,12 +7,9 @@ class ThemeCustomLight extends ThemeExtension<ThemeCustomLight>
 
   @override
   late final Color suspendedBannerBackgroundColor;
-  @override
-  late final Color keyPadColor;
 
   void initializeThemeDependentColors(ThemeData theme) {
     suspendedBannerBackgroundColor = theme.colorScheme.onSurface;
-    keyPadColor = theme.colorScheme.onSurface;
   }
 
   @override
@@ -212,6 +209,8 @@ class ThemeCustomLight extends ThemeExtension<ThemeCustomLight>
   @override
   final bridgeFormHeader = const TextStyle(
       fontSize: 11, fontWeight: FontWeight.w500, letterSpacing: 3.5);
+  @override
+  final Color keyPadColor = const Color.fromRGBO(251, 251, 251, 1);
   @override
   final Color keyPadTextColor = const Color.fromRGBO(129, 151, 182, 1);
   @override

--- a/lib/bloc/auth_bloc/trezor_auth_mixin.dart
+++ b/lib/bloc/auth_bloc/trezor_auth_mixin.dart
@@ -49,10 +49,7 @@ mixin TrezorAuthMixin on Bloc<AuthBlocEvent, AuthBlocState> {
       _log.shout('Trezor authentication failed', e);
       emit(
         AuthBlocState.error(
-          AuthException(
-            e.toString(),
-            type: AuthExceptionType.generalAuthError,
-          ),
+          AuthException(e.toString(), type: AuthExceptionType.generalAuthError),
         ),
       );
     }
@@ -75,7 +72,8 @@ mixin TrezorAuthMixin on Bloc<AuthBlocEvent, AuthBlocState> {
         );
       case AuthenticationStatus.waitingForDeviceConfirmation:
         return AuthBlocState.trezorAwaitingConfirmation(
-          message: authState.message ??
+          message:
+              authState.message ??
               'Please follow instructions on your Trezor device',
           taskId: authState.taskId,
         );
@@ -191,10 +189,7 @@ mixin TrezorAuthMixin on Bloc<AuthBlocEvent, AuthBlocState> {
         return;
       }
 
-      await _sdk.auth.setHardwareDevicePassphrase(
-        taskId,
-        event.passphrase,
-      );
+      await _sdk.auth.setHardwareDevicePassphrase(taskId, event.passphrase);
     } catch (e) {
       _log.shout('Failed to provide passphrase', e);
       emit(
@@ -212,6 +207,14 @@ mixin TrezorAuthMixin on Bloc<AuthBlocEvent, AuthBlocState> {
     AuthTrezorCancelled event,
     Emitter<AuthBlocState> emit,
   ) async {
+    final taskId = state.authenticationState?.taskId;
+    if (taskId != null) {
+      try {
+        await _sdk.auth.cancelHardwareDeviceInitialization(taskId);
+      } catch (e) {
+        _log.shout('Failed to cancel Trezor initialization', e);
+      }
+    }
     emit(AuthBlocState.initial());
   }
 }

--- a/lib/views/common/hw_wallet_dialog/show_trezor_pin_dialog.dart
+++ b/lib/views/common/hw_wallet_dialog/show_trezor_pin_dialog.dart
@@ -28,7 +28,10 @@ Future<void> showTrezorPinDialog(TrezorTask task) async {
         authBloc.add(AuthTrezorPinProvided(pin));
         close();
       },
-      onClose: close,
+      onClose: () {
+        context.read<AuthBloc>().add(AuthTrezorCancelled());
+        close();
+      },
     ),
   );
 


### PR DESCRIPTION
Aligns the light-mode `keyPadColor` initialisation with the dark theme approach.

## Before

<img width="437" height="302" alt="image" src="https://github.com/user-attachments/assets/e3f7d13f-8556-4c73-9be0-351f2e0445b4" />


## After

<img width="400" height="520" alt="image" src="https://github.com/user-attachments/assets/ad43af1a-a880-4f5d-9a2b-445799a793b2" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of Trezor authentication cancellation by explicitly dispatching a cancellation event when the PIN dialog is closed.

* **Style**
  * Minor formatting adjustments for improved code readability.

* **Refactor**
  * Updated theme color assignment to use a fixed color value for the keypad background, ensuring consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->