### PR TITLE
chore(deps): bump SDK to c3780d to add fallback usd price provider

### DIFF
--- a/packages/komodo_ui_kit/pubspec.lock
+++ b/packages/komodo_ui_kit/pubspec.lock
@@ -32,6 +32,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
   decimal:
     dependency: transitive
     description:
@@ -95,7 +103,7 @@ packages:
     description:
       path: "packages/komodo_defi_rpc_methods"
       ref: dev
-      resolved-ref: "60e5f2e770b2a2908887a1848f7c6013dc81648f"
+      resolved-ref: c3780d8948bdfe942813b5001a9e3ac7ed9fddea
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.3.0+0"
@@ -104,7 +112,7 @@ packages:
     description:
       path: "packages/komodo_defi_types"
       ref: dev
-      resolved-ref: "60e5f2e770b2a2908887a1848f7c6013dc81648f"
+      resolved-ref: c3780d8948bdfe942813b5001a9e3ac7ed9fddea
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.3.0+0"
@@ -113,7 +121,7 @@ packages:
     description:
       path: "packages/komodo_ui"
       ref: dev
-      resolved-ref: "60e5f2e770b2a2908887a1848f7c6013dc81648f"
+      resolved-ref: c3780d8948bdfe942813b5001a9e3ac7ed9fddea
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.3.0+0"
@@ -178,6 +186,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -656,7 +656,7 @@ packages:
     description:
       path: "packages/komodo_cex_market_data"
       ref: dev
-      resolved-ref: "60e5f2e770b2a2908887a1848f7c6013dc81648f"
+      resolved-ref: c3780d8948bdfe942813b5001a9e3ac7ed9fddea
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.0.1"
@@ -665,7 +665,7 @@ packages:
     description:
       path: "packages/komodo_coin_updates"
       ref: dev
-      resolved-ref: "60e5f2e770b2a2908887a1848f7c6013dc81648f"
+      resolved-ref: c3780d8948bdfe942813b5001a9e3ac7ed9fddea
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "1.0.0"
@@ -674,7 +674,7 @@ packages:
     description:
       path: "packages/komodo_coins"
       ref: dev
-      resolved-ref: "60e5f2e770b2a2908887a1848f7c6013dc81648f"
+      resolved-ref: c3780d8948bdfe942813b5001a9e3ac7ed9fddea
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.3.0+0"
@@ -683,7 +683,7 @@ packages:
     description:
       path: "packages/komodo_defi_framework"
       ref: dev
-      resolved-ref: "60e5f2e770b2a2908887a1848f7c6013dc81648f"
+      resolved-ref: c3780d8948bdfe942813b5001a9e3ac7ed9fddea
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.3.0+0"
@@ -692,7 +692,7 @@ packages:
     description:
       path: "packages/komodo_defi_local_auth"
       ref: dev
-      resolved-ref: "60e5f2e770b2a2908887a1848f7c6013dc81648f"
+      resolved-ref: c3780d8948bdfe942813b5001a9e3ac7ed9fddea
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.3.0+0"
@@ -701,7 +701,7 @@ packages:
     description:
       path: "packages/komodo_defi_rpc_methods"
       ref: dev
-      resolved-ref: "60e5f2e770b2a2908887a1848f7c6013dc81648f"
+      resolved-ref: c3780d8948bdfe942813b5001a9e3ac7ed9fddea
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.3.0+0"
@@ -710,7 +710,7 @@ packages:
     description:
       path: "packages/komodo_defi_sdk"
       ref: dev
-      resolved-ref: "60e5f2e770b2a2908887a1848f7c6013dc81648f"
+      resolved-ref: c3780d8948bdfe942813b5001a9e3ac7ed9fddea
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.3.0+0"
@@ -719,7 +719,7 @@ packages:
     description:
       path: "packages/komodo_defi_types"
       ref: dev
-      resolved-ref: "60e5f2e770b2a2908887a1848f7c6013dc81648f"
+      resolved-ref: c3780d8948bdfe942813b5001a9e3ac7ed9fddea
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.3.0+0"
@@ -735,7 +735,7 @@ packages:
     description:
       path: "packages/komodo_ui"
       ref: dev
-      resolved-ref: "60e5f2e770b2a2908887a1848f7c6013dc81648f"
+      resolved-ref: c3780d8948bdfe942813b5001a9e3ac7ed9fddea
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.3.0+0"
@@ -751,7 +751,7 @@ packages:
     description:
       path: "packages/komodo_wallet_build_transformer"
       ref: dev
-      resolved-ref: "60e5f2e770b2a2908887a1848f7c6013dc81648f"
+      resolved-ref: c3780d8948bdfe942813b5001a9e3ac7ed9fddea
       url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
     source: git
     version: "0.3.0+0"


### PR DESCRIPTION
Adds support for coins unsupported by Binance by defaulting to the [komodo.earth](https://defi-stats.komodo.earth/api/v3/prices/tickers_v2?expire_at=600) tickers endpoint with wider coin coverage