### PR TITLE
refactor: align blocs with lint rules

### DIFF
--- a/lib/bloc/app_bloc_root.dart
+++ b/lib/bloc/app_bloc_root.dart
@@ -86,8 +86,9 @@ class AppBlocRoot extends StatelessWidget {
   ) async {
     final sharedPrefs = await SharedPreferences.getInstance();
 
-    final storedLastPerformanceMode =
-        sharedPrefs.getString('last_performance_mode');
+    final storedLastPerformanceMode = sharedPrefs.getString(
+      'last_performance_mode',
+    );
 
     if (storedLastPerformanceMode != performanceMode?.name) {
       profitLossRepo.clearCache().ignore();
@@ -153,10 +154,7 @@ class AppBlocRoot extends StatelessWidget {
     return MultiRepositoryProvider(
       providers: [
         RepositoryProvider(
-          create: (_) => NftsRepo(
-            api: mm2Api.nft,
-            coinsRepo: coinsRepository,
-          ),
+          create: (_) => NftsRepo(api: mm2Api.nft, coinsRepo: coinsRepository),
         ),
         RepositoryProvider(create: (_) => tradingEntitiesBloc),
         RepositoryProvider(create: (_) => dexRepository),
@@ -178,21 +176,17 @@ class AppBlocRoot extends StatelessWidget {
       child: MultiBlocProvider(
         providers: [
           BlocProvider(
-            create: (context) => CoinsBloc(
-              komodoDefiSdk,
-              coinsRepository,
-            )..add(CoinsStarted()),
+            create: (context) =>
+                CoinsBloc(komodoDefiSdk, coinsRepository)..add(CoinsStarted()),
           ),
           BlocProvider<PriceChartBloc>(
-            create: (context) => PriceChartBloc(
-              binanceRepository,
-              komodoDefiSdk,
-            )..add(
-                const PriceChartStarted(
-                  symbols: ['BTC'],
-                  period: Duration(days: 30),
+            create: (context) =>
+                PriceChartBloc(binanceRepository, komodoDefiSdk)..add(
+                  const PriceChartStarted(
+                    symbols: ['BTC'],
+                    period: Duration(days: 30),
+                  ),
                 ),
-              ),
           ),
           BlocProvider<AssetOverviewBloc>(
             create: (context) => AssetOverviewBloc(
@@ -202,10 +196,7 @@ class AppBlocRoot extends StatelessWidget {
             ),
           ),
           BlocProvider<ProfitLossBloc>(
-            create: (context) => ProfitLossBloc(
-              profitLossRepo,
-              komodoDefiSdk,
-            ),
+            create: (context) => ProfitLossBloc(profitLossRepo, komodoDefiSdk),
           ),
           BlocProvider<PortfolioGrowthBloc>(
             create: (BuildContext ctx) => PortfolioGrowthBloc(
@@ -214,9 +205,8 @@ class AppBlocRoot extends StatelessWidget {
             ),
           ),
           BlocProvider<TransactionHistoryBloc>(
-            create: (BuildContext ctx) => TransactionHistoryBloc(
-              sdk: komodoDefiSdk,
-            ),
+            create: (BuildContext ctx) =>
+                TransactionHistoryBloc(sdk: komodoDefiSdk),
           ),
           BlocProvider<SettingsBloc>(
             create: (context) =>
@@ -252,10 +242,8 @@ class AppBlocRoot extends StatelessWidget {
           ),
           BlocProvider(
             lazy: false,
-            create: (context) => NftMainBloc(
-              repo: context.read<NftsRepo>(),
-              sdk: komodoDefiSdk,
-            ),
+            create: (context) =>
+                NftMainBloc(repo: context.read<NftsRepo>(), sdk: komodoDefiSdk),
           ),
           if (isBitrefillIntegrationEnabled)
             BlocProvider(
@@ -264,10 +252,7 @@ class AppBlocRoot extends StatelessWidget {
             ),
           BlocProvider<MarketMakerBotBloc>(
             create: (context) => MarketMakerBotBloc(
-              MarketMakerBotRepository(
-                mm2Api,
-                SettingsRepository(),
-              ),
+              MarketMakerBotRepository(mm2Api, SettingsRepository()),
               MarketMakerBotOrderListRepository(
                 myOrdersService,
                 SettingsRepository(),
@@ -277,13 +262,14 @@ class AppBlocRoot extends StatelessWidget {
           ),
           BlocProvider<TradingStatusBloc>(
             lazy: false,
-            create: (context) => TradingStatusBloc(
-              context.read<TradingStatusRepository>(),
-            )..add(TradingStatusCheckRequested()),
+            create: (context) =>
+                TradingStatusBloc(context.read<TradingStatusRepository>())
+                  ..add(TradingStatusCheckRequested()),
           ),
           BlocProvider<SystemHealthBloc>(
-            create: (_) => SystemHealthBloc(SystemClockRepository(), mm2Api)
-              ..add(SystemHealthPeriodicCheckStarted()),
+            create: (_) =>
+                SystemHealthBloc(SystemClockRepository(), mm2Api)
+                  ..add(SystemHealthPeriodicCheckStarted()),
           ),
           BlocProvider<CoinsManagerBloc>(
             create: (context) => CoinsManagerBloc(
@@ -294,10 +280,7 @@ class AppBlocRoot extends StatelessWidget {
               tradingEntitiesBloc: context.read<TradingEntitiesBloc>(),
             ),
           ),
-          BlocProvider<FaucetBloc>(
-            create: (context) =>
-                FaucetBloc(kdfSdk: context.read<KomodoDefiSdk>()),
-          ),
+          BlocProvider<FaucetBloc>(create: (context) => FaucetBloc()),
           BlocProvider<PlatformBloc>(
             lazy: false,
             create: (context) =>
@@ -347,8 +330,9 @@ class _MyAppViewState extends State<_MyAppView> {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       onGenerateTitle: (_) => appTitle,
-      themeMode: context
-          .select((SettingsBloc settingsBloc) => settingsBloc.state.themeMode),
+      themeMode: context.select(
+        (SettingsBloc settingsBloc) => settingsBloc.state.themeMode,
+      ),
       darkTheme: theme.global.dark,
       theme: theme.global.light,
       routerDelegate: _routerDelegate,
@@ -388,15 +372,16 @@ class _MyAppViewState extends State<_MyAppView> {
       // Remove the loading indicator.
       loadingElement.remove();
 
-      final delay =
-          DateTime.now().difference(_pageLoadStartTime).inMilliseconds;
+      final delay = DateTime.now()
+          .difference(_pageLoadStartTime)
+          .inMilliseconds;
       context.read<AnalyticsBloc>().logEvent(
-            PageInteractiveDelayEventData(
-              pageName: 'app_root',
-              interactiveDelayMs: delay,
-              spinnerTimeMs: 200,
-            ),
-          );
+        PageInteractiveDelayEventData(
+          pageName: 'app_root',
+          interactiveDelayMs: delay,
+          spinnerTimeMs: 200,
+        ),
+      );
     }
   }
 
@@ -430,20 +415,22 @@ class _MyAppViewState extends State<_MyAppView> {
         // }
 
         // ignore: use_build_context_synchronously
-        await AssetIcon.precacheAssetIcon(context, assetId).onError(
-            (_, __) => debugPrint('Error precaching coin icon $assetId'));
+        await AssetIcon.precacheAssetIcon(
+          context,
+          assetId,
+        ).onError((_, __) => debugPrint('Error precaching coin icon $assetId'));
       }
 
       _currentPrecacheOperation!.complete();
 
       if (!mounted) return;
       context.read<AnalyticsBloc>().logEvent(
-            CoinsDataUpdatedEventData(
-              updateSource: 'remote',
-              updateDurationMs: stopwatch.elapsedMilliseconds,
-              coinsCount: availableAssetIds.length,
-            ),
-          );
+        CoinsDataUpdatedEventData(
+          updateSource: 'remote',
+          updateDurationMs: stopwatch.elapsedMilliseconds,
+          coinsCount: availableAssetIds.length,
+        ),
+      );
     } catch (e) {
       log('Error precaching coin icons: $e');
       _currentPrecacheOperation!.completeError(e);

--- a/lib/bloc/coins_manager/coins_manager_bloc.dart
+++ b/lib/bloc/coins_manager/coins_manager_bloc.dart
@@ -62,7 +62,7 @@ class CoinsManagerBloc extends Bloc<CoinsManagerEvent, CoinsManagerState> {
   ) async {
     final List<FilterFunction> filters = [];
 
-    final mergedCoinsList = mergeCoinLists(
+    final mergedCoinsList = _mergeCoinLists(
       await _getOriginalCoinList(_coinsRepo, event.action),
       state.coins,
     ).toList();
@@ -330,7 +330,7 @@ class CoinsManagerBloc extends Bloc<CoinsManagerEvent, CoinsManagerState> {
     return result;
   }
 
-  Set<Coin> mergeCoinLists(List<Coin> originalList, List<Coin> newList) {
+  Set<Coin> _mergeCoinLists(List<Coin> originalList, List<Coin> newList) {
     final Map<String, Coin> coinMap = {};
 
     for (final Coin coin in originalList) {

--- a/lib/bloc/faucet_button/faucet_button_bloc.dart
+++ b/lib/bloc/faucet_button/faucet_button_bloc.dart
@@ -1,16 +1,15 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
 import 'package:web_dex/3p_api/faucet/faucet.dart' as api;
 import 'package:web_dex/3p_api/faucet/faucet_response.dart';
 import 'package:web_dex/bloc/faucet_button/faucet_button_event.dart';
 import 'package:web_dex/bloc/faucet_button/faucet_button_state.dart';
 import 'package:logging/logging.dart';
 
-class FaucetBloc extends Bloc<FaucetEvent, FaucetState> implements StateStreamable<FaucetState> {
-  final KomodoDefiSdk kdfSdk;
+class FaucetBloc extends Bloc<FaucetEvent, FaucetState>
+    implements StateStreamable<FaucetState> {
   final _log = Logger('FaucetBloc');
 
-  FaucetBloc({required this.kdfSdk}) : super(FaucetInitial()) {
+  FaucetBloc() : super(FaucetInitial()) {
     on<FaucetRequested>(_onFaucetRequest);
   }
 
@@ -31,12 +30,16 @@ class FaucetBloc extends Bloc<FaucetEvent, FaucetState> implements StateStreamab
       final response = await api.callFaucet(event.coinAbbr, event.address);
 
       if (response.status == FaucetStatus.success) {
-        emit(FaucetRequestSuccess(FaucetResponse(
-          status: response.status,
-          address: event.address,
-          message: response.message,
-          coin: event.coinAbbr,
-        )));
+        emit(
+          FaucetRequestSuccess(
+            FaucetResponse(
+              status: response.status,
+              address: event.address,
+              message: response.message,
+              coin: event.coinAbbr,
+            ),
+          ),
+        );
       } else {
         emit(FaucetRequestError("Faucet request failed: ${response.message}"));
       }

--- a/lib/bloc/fiat/fiat_onramp_form/fiat_form_bloc.dart
+++ b/lib/bloc/fiat/fiat_onramp_form/fiat_form_bloc.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_flutter_imports
+
 import 'dart:convert';
 import 'dart:io' show Platform;
 
@@ -34,11 +36,11 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
     required KomodoDefiSdk sdk,
     int pubkeysMaxRetryAttempts = 20,
     Duration pubkeysRetryDelay = const Duration(milliseconds: 500),
-  })  : _fiatRepository = repository,
-        _sdk = sdk,
-        _pubkeysMaxRetryAttempts = pubkeysMaxRetryAttempts,
-        _pubkeysRetryDelay = pubkeysRetryDelay,
-        super(FiatFormState.initial()) {
+  }) : _fiatRepository = repository,
+       _sdk = sdk,
+       _pubkeysMaxRetryAttempts = pubkeysMaxRetryAttempts,
+       _pubkeysRetryDelay = pubkeysRetryDelay,
+       super(FiatFormState.initial()) {
     on<FiatFormFiatSelected>(_onFiatSelected);
     // Use restartable here since this is called for auth changes, which
     // can happen frequently and we want to avoid race conditions.
@@ -169,7 +171,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
     FiatFormSubmitted event,
     Emitter<FiatFormState> emit,
   ) async {
-    final formValidationError = getFormIssue();
+    final formValidationError = _getFormIssue();
     if (formValidationError != null || !state.isValid) {
       _log.warning('Form validation failed. Validation: ${state.isValid}');
       return;
@@ -187,8 +189,9 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
         walletAddress: state.selectedAssetAddress!.address,
         paymentMethod: state.selectedPaymentMethod,
         sourceAmount: state.fiatAmount.value,
-        returnUrlOnSuccess:
-            BaseFiatProvider.successUrl(state.selectedAssetAddress!.address),
+        returnUrlOnSuccess: BaseFiatProvider.successUrl(
+          state.selectedAssetAddress!.address,
+        ),
       );
 
       if (!newOrder.error.isNone) {
@@ -199,11 +202,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
       var checkoutUrl = newOrder.checkoutUrl as String? ?? '';
       if (checkoutUrl.isEmpty) {
         _log.severe('Invalid checkout URL received.');
-        return emit(
-          state.copyWith(
-            fiatOrderStatus: FiatOrderStatus.failed,
-          ),
-        );
+        return emit(state.copyWith(fiatOrderStatus: FiatOrderStatus.failed));
       }
 
       // Only Ramp on web requires the intermediate html page to satisfy cors
@@ -223,12 +222,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
       );
     } catch (e, s) {
       _log.shout('Error submitting fiat form', e, s);
-      emit(
-        state.copyWith(
-          status: FiatFormStatus.failure,
-          checkoutUrl: '',
-        ),
-      );
+      emit(state.copyWith(status: FiatFormStatus.failure, checkoutUrl: ''));
     }
   }
 
@@ -320,17 +314,10 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
     FiatFormCoinAddressSelected event,
     Emitter<FiatFormState> emit,
   ) {
-    emit(
-      state.copyWith(
-        selectedAssetAddress: () => event.address,
-      ),
-    );
+    emit(state.copyWith(selectedAssetAddress: () => event.address));
   }
 
-  void _onModeUpdated(
-    FiatFormModeUpdated event,
-    Emitter<FiatFormState> emit,
-  ) {
+  void _onModeUpdated(FiatFormModeUpdated event, Emitter<FiatFormState> emit) {
     emit(state.copyWith(fiatMode: event.mode));
   }
 
@@ -341,8 +328,9 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
     try {
       final fiatList = await _fiatRepository.getFiatList();
       final coinList = await _fiatRepository.getCoinList();
-      coinList
-          .removeWhere((coin) => excludedAssetList.contains(coin.getAbbr()));
+      coinList.removeWhere(
+        (coin) => excludedAssetList.contains(coin.getAbbr()),
+      );
       emit(state.copyWith(fiatList: fiatList, coinList: coinList));
     } catch (e, s) {
       _log.shout('Error loading currency list', e, s);
@@ -429,7 +417,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
     );
   }
 
-  String? getFormIssue() {
+  String? _getFormIssue() {
     // TODO: ? show on the UI and localise? These are currently used as more of
     // a boolean "is there an error?" rather than "what is the error?"
     if (state.paymentMethods.isEmpty) {
@@ -548,10 +536,7 @@ class FiatFormBloc extends Bloc<FiatFormEvent, FiatFormState> {
       );
     } catch (e, s) {
       _log.shout('Error updating payment methods', e, s);
-      return state.copyWith(
-        paymentMethods: [],
-        providerError: () => null,
-      );
+      return state.copyWith(paymentMethods: [], providerError: () => null);
     }
   }
 

--- a/lib/bloc/nft_receive/bloc/nft_receive_bloc.dart
+++ b/lib/bloc/nft_receive/bloc/nft_receive_bloc.dart
@@ -11,12 +11,10 @@ part 'nft_receive_event.dart';
 part 'nft_receive_state.dart';
 
 class NftReceiveBloc extends Bloc<NftReceiveEvent, NftReceiveState> {
-  NftReceiveBloc({
-    required CoinsRepo coinsRepo,
-    required KomodoDefiSdk sdk,
-  })  : _coinsRepo = coinsRepo,
-        _sdk = sdk,
-        super(NftReceiveInitial()) {
+  NftReceiveBloc({required CoinsRepo coinsRepo, required KomodoDefiSdk sdk})
+    : _coinsRepo = coinsRepo,
+      _sdk = sdk,
+      super(NftReceiveInitial()) {
     on<NftReceiveStarted>(_onInitial);
     on<NftReceiveRefreshRequested>(_onRefresh);
     on<NftReceiveAddressChanged>(_onChangeAddress);
@@ -25,7 +23,7 @@ class NftReceiveBloc extends Bloc<NftReceiveEvent, NftReceiveState> {
   final CoinsRepo _coinsRepo;
   final KomodoDefiSdk _sdk;
   final _log = Logger('NftReceiveBloc');
-  NftBlockchains? chain;
+  NftBlockchains? _chain;
 
   Future<void> _onInitial(
     NftReceiveStarted event,
@@ -36,7 +34,7 @@ class NftReceiveBloc extends Bloc<NftReceiveEvent, NftReceiveState> {
       return;
     }
 
-    chain = event.chain;
+    _chain = event.chain;
     final abbr = event.chain.coinAbbr();
     final coin = _coinsRepo.getCoin(abbr);
     if (coin == null) {
@@ -47,9 +45,7 @@ class NftReceiveBloc extends Bloc<NftReceiveEvent, NftReceiveState> {
     final walletConfig = (await _sdk.currentWallet())?.config;
     if (walletConfig?.hasBackup == false && !coin.isTestCoin) {
       _log.warning('Wallet does not have backup and is not a test coin');
-      return emit(
-        NftReceiveBackupSuccess(),
-      );
+      return emit(NftReceiveBackupSuccess());
     }
 
     final asset = _sdk.assets.available[coin.id]!;
@@ -78,7 +74,7 @@ class NftReceiveBloc extends Bloc<NftReceiveEvent, NftReceiveState> {
     Emitter<NftReceiveState> emit,
   ) async {
     _log.info('Refreshing NFT receive data');
-    final localChain = chain;
+    final localChain = _chain;
     if (localChain != null) {
       _log.fine('Chain is available, reinitializing with chain: $localChain');
       emit(NftReceiveInitial());

--- a/lib/bloc/nft_transactions/bloc/nft_transactions_bloc.dart
+++ b/lib/bloc/nft_transactions/bloc/nft_transactions_bloc.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
-import 'package:flutter/material.dart';
 import 'package:komodo_defi_sdk/komodo_defi_sdk.dart';
 import 'package:komodo_defi_types/komodo_defi_types.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_repo.dart';
@@ -25,11 +24,11 @@ class NftTransactionsBloc extends Bloc<NftTxnEvent, NftTxnState> {
     required CoinsRepo coinsRepository,
     required bool isLoggedIn,
     required NftsRepo nftsRepository,
-  })  : _nftTxnRepository = nftTxnRepository,
-        _coinsBloc = coinsRepository,
-        _nftsRepository = nftsRepository,
-        _isLoggedIn = isLoggedIn,
-        super(NftTransactionsInitial()) {
+  }) : _nftTxnRepository = nftTxnRepository,
+       _coinsBloc = coinsRepository,
+       _nftsRepository = nftsRepository,
+       _isLoggedIn = isLoggedIn,
+       super(NftTransactionsInitial()) {
     on<NftTxnReceiveEvent>(_onReceiveTransactions);
     on<NftTxReceiveDetailsEvent>(_onReceiveDetails);
     on<NftTxnEventSearchChanged>(_onSearchChanged);
@@ -62,25 +61,17 @@ class NftTransactionsBloc extends Bloc<NftTxnEvent, NftTxnState> {
 
   bool _isLoggedIn = false;
   late final StreamSubscription<KdfUser?> _authorizationSubscription;
-  PersistentBottomSheetController? _bottomSheetController;
-  set bottomSheetController(PersistentBottomSheetController controller) =>
-      _bottomSheetController = controller;
 
   @override
   Future<void> close() async {
     await _authorizationSubscription.cancel();
-
-    if (_bottomSheetController != null) {
-      _bottomSheetController?.close();
-      // Wait util bottom sheet will be closed
-      await Future.delayed(const Duration(milliseconds: 500));
-    }
-
     return super.close();
   }
 
   Future<void> _onReceiveTransactions(
-      NftTxnReceiveEvent event, Emitter<NftTxnState> emitter) async {
+    NftTxnReceiveEvent event,
+    Emitter<NftTxnState> emitter,
+  ) async {
     if (!_isLoggedIn) return;
     emitter(state.copyWith(status: NftTxnStatus.loading));
     try {
@@ -112,28 +103,29 @@ class NftTransactionsBloc extends Bloc<NftTxnEvent, NftTxnState> {
       );
     } catch (e) {
       return emitter(
-        state.copyWith(
-          filteredTransactions: [],
-          status: NftTxnStatus.failure,
-        ),
+        state.copyWith(filteredTransactions: [], status: NftTxnStatus.failure),
       );
     }
   }
 
   Future<void> _onReceiveDetails(
-      NftTxReceiveDetailsEvent event, Emitter<NftTxnState> emitter) async {
+    NftTxReceiveDetailsEvent event,
+    Emitter<NftTxnState> emitter,
+  ) async {
     if (!_isLoggedIn) return;
 
     final tx = event.tx;
     if (tx.containsAdditionalInfo) return;
 
-    final int index = _transactions
-        .indexWhere((element) => element.getTxKey() == event.tx.getTxKey());
+    final int index = _transactions.indexWhere(
+      (element) => element.getTxKey() == event.tx.getTxKey(),
+    );
     if (tx.detailsFetchStatus != NftTxnDetailsStatus.initial) return;
 
     try {
-      final response =
-          await _nftTxnRepository.getNftTxDetailsByHash(tx: event.tx);
+      final response = await _nftTxnRepository.getNftTxDetailsByHash(
+        tx: event.tx,
+      );
       _transactions[index].confirmations = response.confirmations;
       _transactions[index].feeDetails = response.feeDetails;
       _transactions[index].setDetailsStatus(NftTxnDetailsStatus.success);
@@ -142,19 +134,21 @@ class NftTransactionsBloc extends Bloc<NftTxnEvent, NftTxnState> {
     } on BaseError catch (e) {
       if (_transactions[index].detailsFetchStatus ==
           NftTxnDetailsStatus.initial) {
-        final status =
-            await retryReceiveDetails(index, event.tx.transactionHash);
+        final status = await retryReceiveDetails(
+          index,
+          event.tx.transactionHash,
+        );
         _transactions[index].setDetailsStatus(status);
         emitFilteredData(emitter);
       }
-      return emitter(
-        state.copyWith(errorMessage: e.message),
-      );
+      return emitter(state.copyWith(errorMessage: e.message));
     } catch (e) {
       if (_transactions[index].detailsFetchStatus ==
           NftTxnDetailsStatus.initial) {
-        final status =
-            await retryReceiveDetails(index, event.tx.transactionHash);
+        final status = await retryReceiveDetails(
+          index,
+          event.tx.transactionHash,
+        );
         _transactions[index].setDetailsStatus(status);
       }
       return emitFilteredData(emitter);
@@ -162,7 +156,9 @@ class NftTransactionsBloc extends Bloc<NftTxnEvent, NftTxnState> {
   }
 
   Future<NftTxnDetailsStatus> retryReceiveDetails(
-      int index, String txHash) async {
+    int index,
+    String txHash,
+  ) async {
     int attempt = 5;
     NftTxnDetailsStatus status = NftTxnDetailsStatus.failure;
     while (attempt > 0) {
@@ -170,7 +166,8 @@ class NftTransactionsBloc extends Bloc<NftTxnEvent, NftTxnState> {
         await Future.delayed(const Duration(seconds: 2));
         attempt--;
         final response = await _nftTxnRepository.getNftTxDetailsByHash(
-            tx: _transactions[index]);
+          tx: _transactions[index],
+        );
         _transactions[index].confirmations = response.confirmations;
         _transactions[index].feeDetails = response.feeDetails;
         status = NftTxnDetailsStatus.success;
@@ -182,15 +179,13 @@ class NftTransactionsBloc extends Bloc<NftTxnEvent, NftTxnState> {
   }
 
   void _noLogin(NftTxnEventNoLogin event, Emitter<NftTxnState> emitter) {
-    return emitter(
-      state.copyWith(
-        status: NftTxnStatus.noLogin,
-      ),
-    );
+    return emitter(state.copyWith(status: NftTxnStatus.noLogin));
   }
 
   void _onSearchChanged(
-      NftTxnEventSearchChanged event, Emitter<NftTxnState> emitter) {
+    NftTxnEventSearchChanged event,
+    Emitter<NftTxnState> emitter,
+  ) {
     emitter(
       state.copyWith(
         filters: state.filters.copyWith(searchLine: event.searchLine),
@@ -200,17 +195,19 @@ class NftTransactionsBloc extends Bloc<NftTxnEvent, NftTxnState> {
   }
 
   void _onStatusesChanged(
-      NftTxnEventStatusesChanged event, Emitter<NftTxnState> emitter) {
+    NftTxnEventStatusesChanged event,
+    Emitter<NftTxnState> emitter,
+  ) {
     emitter(
-      state.copyWith(
-        filters: state.filters.copyWith(statuses: event.statuses),
-      ),
+      state.copyWith(filters: state.filters.copyWith(statuses: event.statuses)),
     );
     emitFilteredData(emitter);
   }
 
   void _onBlockchainChanged(
-      NftTxnEventBlockchainChanged event, Emitter<NftTxnState> emitter) {
+    NftTxnEventBlockchainChanged event,
+    Emitter<NftTxnState> emitter,
+  ) {
     emitter(
       state.copyWith(
         filters: state.filters.copyWith(blockchain: event.blockchains),
@@ -220,27 +217,29 @@ class NftTransactionsBloc extends Bloc<NftTxnEvent, NftTxnState> {
   }
 
   void _startDateChanged(
-      NftTxnEventStartDateChanged event, Emitter<NftTxnState> emitter) {
+    NftTxnEventStartDateChanged event,
+    Emitter<NftTxnState> emitter,
+  ) {
     emitter(
-      state.copyWith(
-        filters: state.filters.copyWith(dateFrom: event.dateFrom),
-      ),
+      state.copyWith(filters: state.filters.copyWith(dateFrom: event.dateFrom)),
     );
     emitFilteredData(emitter);
   }
 
   void _endDateChanged(
-      NftTxnEventEndDateChanged event, Emitter<NftTxnState> emitter) {
+    NftTxnEventEndDateChanged event,
+    Emitter<NftTxnState> emitter,
+  ) {
     emitter(
-      state.copyWith(
-        filters: state.filters.copyWith(dateTo: event.dateTo),
-      ),
+      state.copyWith(filters: state.filters.copyWith(dateTo: event.dateTo)),
     );
     emitFilteredData(emitter);
   }
 
   void _changeFullFilter(
-      NftTxnEventFullFilterChanged event, Emitter<NftTxnState> emitter) {
+    NftTxnEventFullFilterChanged event,
+    Emitter<NftTxnState> emitter,
+  ) {
     emitter(state.copyWith(filters: event.filter));
 
     emitFilteredData(emitter);
@@ -248,9 +247,7 @@ class NftTransactionsBloc extends Bloc<NftTxnEvent, NftTxnState> {
 
   void emitFilteredData(Emitter<NftTxnState> emitter) {
     final filtered = _applyFilter();
-    return emitter(
-      state.copyWith(filteredTransactions: filtered),
-    );
+    return emitter(state.copyWith(filteredTransactions: filtered));
   }
 
   void _cleanFilters(NftTxnClearFilters event, Emitter<NftTxnState> emitter) {
@@ -265,13 +262,15 @@ class NftTransactionsBloc extends Bloc<NftTxnEvent, NftTxnState> {
   List<NftTransaction> _applyFilter() {
     final filters = state.filters;
     final filteredTransactions = _transactions.where((transaction) {
-      final includeTokenName = transaction.tokenName
-              ?.toLowerCase()
-              .contains(filters.searchLine.toLowerCase()) ??
+      final includeTokenName =
+          transaction.tokenName?.toLowerCase().contains(
+            filters.searchLine.toLowerCase(),
+          ) ??
           false;
-      final includeTokenCollection = transaction.collectionName
-              ?.toLowerCase()
-              .contains(filters.searchLine.toLowerCase()) ??
+      final includeTokenCollection =
+          transaction.collectionName?.toLowerCase().contains(
+            filters.searchLine.toLowerCase(),
+          ) ??
           false;
       if (filters.searchLine.isNotEmpty &&
           !(includeTokenName || includeTokenCollection)) {

--- a/lib/bloc/trading_kind/trading_kind_bloc.dart
+++ b/lib/bloc/trading_kind/trading_kind_bloc.dart
@@ -12,8 +12,6 @@ class TradingKindBloc extends Bloc<TradingKindEvent, TradingKindState> {
     on<KindChanged>(_onKindChanged);
   }
 
-  void setKind(TradingKind kind) => add(KindChanged(kind));
-
   void _onKindChanged(KindChanged event, Emitter<TradingKindState> emit) {
     emit(state.copyWith(kind: event.kind));
   }

--- a/lib/blocs/kmd_rewards_bloc.dart
+++ b/lib/blocs/kmd_rewards_bloc.dart
@@ -1,5 +1,4 @@
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flutter/material.dart';
 import 'package:web_dex/bloc/coins_bloc/coins_repo.dart';
 import 'package:web_dex/blocs/bloc_base.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
@@ -21,7 +20,8 @@ class KmdRewardsBloc implements BlocBase {
   final Mm2Api _mm2Api;
   bool _claimInProgress = false;
 
-  Future<BlocResponse<String, BaseError>> claim(BuildContext context) async {
+  // ignore: avoid_public_bloc_methods
+  Future<BlocResponse<String, BaseError>> claim() async {
     if (_claimInProgress) {
       return BlocResponse(
         error: TextError(error: LocaleKeys.rewardClaiming.tr()),
@@ -36,22 +36,17 @@ class KmdRewardsBloc implements BlocBase {
       final BaseError error =
           withdraw.error ?? TextError(error: LocaleKeys.somethingWrong.tr());
       _claimInProgress = false;
-      return BlocResponse(
-        error: error,
-      );
+      return BlocResponse(error: error);
     }
 
-    final tx = await _mm2Api.sendRawTransaction(SendRawTransactionRequest(
-      coin: 'KMD',
-      txHex: withdrawDetails.txHex,
-    ));
+    final tx = await _mm2Api.sendRawTransaction(
+      SendRawTransactionRequest(coin: 'KMD', txHex: withdrawDetails.txHex),
+    );
     if (tx.error != null) {
       final BaseError error =
           tx.error ?? TextError(error: LocaleKeys.somethingWrong.tr());
       _claimInProgress = false;
-      return BlocResponse(
-        error: error,
-      );
+      return BlocResponse(error: error);
     }
     _claimInProgress = false;
     return BlocResponse(result: withdrawDetails.myBalanceChange);
@@ -61,18 +56,21 @@ class KmdRewardsBloc implements BlocBase {
   void dispose() {}
 
   Future<List<KmdRewardItem>> getInfo() async {
-    final Map<String, dynamic>? response =
-        await _mm2Api.getRewardsInfo(KmdRewardsInfoRequest());
+    final Map<String, dynamic>? response = await _mm2Api.getRewardsInfo(
+      KmdRewardsInfoRequest(),
+    );
     if (response != null && response['result'] != null) {
       return response['result']
           .map<KmdRewardItem>(
-              (dynamic reward) => KmdRewardItem.fromJson(reward))
+            (dynamic reward) => KmdRewardItem.fromJson(reward),
+          )
           .toList();
     }
     return [];
   }
 
-  Future<double?> getTotal(BuildContext context) async {
+  // ignore: avoid_public_bloc_methods
+  Future<double?> getTotal() async {
     final withdraw = await _withdraw();
     final String? myBalanceChange = withdraw.result?.myBalanceChange;
     if (myBalanceChange == null || withdraw.error != null) {
@@ -86,17 +84,17 @@ class KmdRewardsBloc implements BlocBase {
     final Coin? kmdCoin = _coinsBlocRepository.getCoin('KMD');
     if (kmdCoin == null) {
       return BlocResponse(
-          error: TextError(error: LocaleKeys.plsActivateKmd.tr()));
+        error: TextError(error: LocaleKeys.plsActivateKmd.tr()),
+      );
     }
     if (kmdCoin.address == null) {
       return BlocResponse(
-          error: TextError(error: LocaleKeys.noKmdAddress.tr()));
+        error: TextError(error: LocaleKeys.noKmdAddress.tr()),
+      );
     }
 
-    return await _coinsBlocRepository.withdraw(WithdrawRequest(
-      coin: 'KMD',
-      max: true,
-      to: kmdCoin.address!,
-    ));
+    return await _coinsBlocRepository.withdraw(
+      WithdrawRequest(coin: 'KMD', max: true, to: kmdCoin.address!),
+    );
   }
 }

--- a/lib/blocs/maker_form_bloc.dart
+++ b/lib/blocs/maker_form_bloc.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_public_bloc_methods
+
 import 'dart:async';
 
 import 'package:easy_localization/easy_localization.dart';
@@ -133,9 +135,9 @@ class MakerFormBloc implements BlocBase {
     _inBuyCoin.add(_buyCoin);
     if (coin == sellCoin && coin != null) sellCoin = null;
 
-    _autoActivate(buyCoin)
-        .then((_) => _updatePreimage())
-        .then((_) => _reValidate());
+    _autoActivate(
+      buyCoin,
+    ).then((_) => _updatePreimage()).then((_) => _reValidate());
   }
 
   Rational? _sellAmount;
@@ -250,8 +252,9 @@ class MakerFormBloc implements BlocBase {
     isMaxActive = false;
 
     await _updateMaxSellAmount();
-    _maxSellAmountTimer =
-        Timer.periodic(const Duration(seconds: 10), (_) async {
+    _maxSellAmountTimer = Timer.periodic(const Duration(seconds: 10), (
+      _,
+    ) async {
       await _updateMaxSellAmount();
     });
   }
@@ -376,35 +379,33 @@ class MakerFormBloc implements BlocBase {
     if (error is TradePreimageNotSufficientBalanceError) {
       _setFormErrors([
         DexFormError(
-          error: LocaleKeys.dexBalanceNotSufficientError.tr(args: [
-            error.coin,
-            formatAmt(double.parse(error.required)),
-            error.coin,
-          ]),
-        )
+          error: LocaleKeys.dexBalanceNotSufficientError.tr(
+            args: [
+              error.coin,
+              formatAmt(double.parse(error.required)),
+              error.coin,
+            ],
+          ),
+        ),
       ]);
     } else if (error is TradePreimageNotSufficientBaseCoinBalanceError) {
       _setFormErrors([
         DexFormError(
-          error: LocaleKeys.dexBalanceNotSufficientError.tr(args: [
-            error.coin,
-            formatAmt(double.parse(error.required)),
-            error.coin,
-          ]),
-        )
+          error: LocaleKeys.dexBalanceNotSufficientError.tr(
+            args: [
+              error.coin,
+              formatAmt(double.parse(error.required)),
+              error.coin,
+            ],
+          ),
+        ),
       ]);
     } else if (error is TradePreimageTransportError) {
       _setFormErrors([
-        DexFormError(
-          error: LocaleKeys.notEnoughBalanceForGasError.tr(),
-        )
+        DexFormError(error: LocaleKeys.notEnoughBalanceForGasError.tr()),
       ]);
     } else {
-      _setFormErrors([
-        DexFormError(
-          error: error.message,
-        )
-      ]);
+      _setFormErrors([DexFormError(error: error.message)]);
     }
 
     return false;
@@ -429,13 +430,14 @@ class MakerFormBloc implements BlocBase {
       return DexFormError(error: LocaleKeys.dexSelectBuyCoinError.tr());
     } else if (buyCoin.isSuspended) {
       return DexFormError(
-          error: LocaleKeys.dexCoinSuspendedError.tr(args: [buyCoin.abbr]));
+        error: LocaleKeys.dexCoinSuspendedError.tr(args: [buyCoin.abbr]),
+      );
     } else {
       final Coin? parentCoin = buyCoin.parentCoin;
       if (parentCoin != null && parentCoin.isSuspended) {
         return DexFormError(
-            error:
-                LocaleKeys.dexCoinSuspendedError.tr(args: [parentCoin.abbr]));
+          error: LocaleKeys.dexCoinSuspendedError.tr(args: [parentCoin.abbr]),
+        );
       }
     }
 
@@ -458,13 +460,15 @@ class MakerFormBloc implements BlocBase {
       return DexFormError(error: LocaleKeys.dexSelectSellCoinError.tr());
     } else if (sellCoin.isSuspended) {
       return DexFormError(
-          error: LocaleKeys.dexCoinSuspendedError.tr(args: [sellCoin.abbr]));
+        error: LocaleKeys.dexCoinSuspendedError.tr(args: [sellCoin.abbr]),
+      );
     }
 
     final Coin? parentCoin = sellCoin.parentCoin;
     if (parentCoin != null && parentCoin.isSuspended) {
       return DexFormError(
-          error: LocaleKeys.dexCoinSuspendedError.tr(args: [parentCoin.abbr]));
+        error: LocaleKeys.dexCoinSuspendedError.tr(args: [parentCoin.abbr]),
+      );
     }
 
     final Rational? sellAmount = this.sellAmount;
@@ -480,14 +484,16 @@ class MakerFormBloc implements BlocBase {
           return DexFormError(error: LocaleKeys.notEnoughFundsError.tr());
         } else if (sellAmount > maxAmount) {
           return DexFormError(
-            error: LocaleKeys.dexMaxSellAmountError
-                .tr(args: [formatAmt(maxAmount.toDouble()), sellCoin.abbr]),
+            error: LocaleKeys.dexMaxSellAmountError.tr(
+              args: [formatAmt(maxAmount.toDouble()), sellCoin.abbr],
+            ),
             type: DexFormErrorType.largerMaxSellVolume,
             action: DexFormErrorAction(
-                text: LocaleKeys.setMax.tr(),
-                callback: () async {
-                  await setMaxSellAmount();
-                }),
+              text: LocaleKeys.setMax.tr(),
+              callback: () async {
+                await setMaxSellAmount();
+              },
+            ),
           );
         }
       }
@@ -499,8 +505,10 @@ class MakerFormBloc implements BlocBase {
   Future<void> _autoActivate(Coin? coin) async {
     if (coin == null || !await kdfSdk.auth.isSignedIn()) return;
     inProgress = true;
-    final List<DexFormError> activationErrors =
-        await activateCoinIfNeeded(coin.abbr, coinsRepository);
+    final List<DexFormError> activationErrors = await activateCoinIfNeeded(
+      coin.abbr,
+      coinsRepository,
+    );
     inProgress = false;
     if (activationErrors.isNotEmpty) {
       _setFormErrors(activationErrors);
@@ -508,13 +516,15 @@ class MakerFormBloc implements BlocBase {
   }
 
   Future<TextError?> makeOrder() async {
-    final Map<String, dynamic>? response = await api.setprice(SetPriceRequest(
-      base: sellCoin!.abbr,
-      rel: buyCoin!.abbr,
-      volume: sellAmount!,
-      price: price!,
-      max: isMaxActive,
-    ));
+    final Map<String, dynamic>? response = await api.setprice(
+      SetPriceRequest(
+        base: sellCoin!.abbr,
+        rel: buyCoin!.abbr,
+        volume: sellAmount!,
+        price: price!,
+        max: isMaxActive,
+      ),
+    );
 
     if (response == null) {
       return TextError(error: LocaleKeys.somethingWrong.tr());

--- a/lib/blocs/trading_entities_bloc.dart
+++ b/lib/blocs/trading_entities_bloc.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_public_bloc_methods
+
 import 'dart:async';
 
 import 'package:collection/collection.dart';
@@ -25,9 +27,9 @@ class TradingEntitiesBloc implements BlocBase {
     KomodoDefiSdk kdfSdk,
     Mm2Api mm2Api,
     MyOrdersService myOrdersService,
-  )   : _mm2Api = mm2Api,
-        _myOrdersService = myOrdersService,
-        _kdfSdk = kdfSdk;
+  ) : _mm2Api = mm2Api,
+      _myOrdersService = myOrdersService,
+      _kdfSdk = kdfSdk;
 
   final KomodoDefiSdk _kdfSdk;
   final MyOrdersService _myOrdersService;
@@ -54,8 +56,10 @@ class TradingEntitiesBloc implements BlocBase {
   Stream<List<Swap>> get outSwaps => _swapsController.stream;
   List<Swap> get swaps => _swaps;
   set swaps(List<Swap> swapList) {
-    swapList.sort((first, second) =>
-        (second.myInfo?.startedAt ?? 0) - (first.myInfo?.startedAt ?? 0));
+    swapList.sort(
+      (first, second) =>
+          (second.myInfo?.startedAt ?? 0) - (first.myInfo?.startedAt ?? 0),
+    );
     _swaps = swapList;
     _inSwaps.add(_swaps);
   }
@@ -86,8 +90,9 @@ class TradingEntitiesBloc implements BlocBase {
   }
 
   Future<String?> cancelOrder(String uuid) async {
-    final Map<String, dynamic> response =
-        await _mm2Api.cancelOrder(CancelOrderRequest(uuid: uuid));
+    final Map<String, dynamic> response = await _mm2Api.cancelOrder(
+      CancelOrderRequest(uuid: uuid),
+    );
     return response['error'];
   }
 
@@ -146,8 +151,10 @@ class TradingEntitiesBloc implements BlocBase {
         .map((id) => getSwap(id))
         .whereType<Swap>()
         .toList();
-    final double swapFill = swaps.fold(0,
-        (previousValue, swap) => previousValue + (swap.myInfo?.myAmount ?? 0));
+    final double swapFill = swaps.fold(
+      0,
+      (previousValue, swap) => previousValue + (swap.myInfo?.myAmount ?? 0),
+    );
     return swapFill / order.baseAmount.toDouble();
   }
 
@@ -157,8 +164,9 @@ class TradingEntitiesBloc implements BlocBase {
   }
 
   Future<List<Swap>?> getRecentSwaps(MyRecentSwapsRequest request) async {
-    final MyRecentSwapsResponse? response =
-        await _mm2Api.getMyRecentSwaps(request);
+    final MyRecentSwapsResponse? response = await _mm2Api.getMyRecentSwaps(
+      request,
+    );
     if (response == null) {
       return null;
     }
@@ -167,10 +175,11 @@ class TradingEntitiesBloc implements BlocBase {
   }
 
   Future<RecoverFundsOfSwapResponse?> recoverFundsOfSwap(String uuid) async {
-    final RecoverFundsOfSwapRequest request =
-        RecoverFundsOfSwapRequest(uuid: uuid);
-    final RecoverFundsOfSwapResponse? response =
-        await _mm2Api.recoverFundsOfSwap(request);
+    final RecoverFundsOfSwapRequest request = RecoverFundsOfSwapRequest(
+      uuid: uuid,
+    );
+    final RecoverFundsOfSwapResponse? response = await _mm2Api
+        .recoverFundsOfSwap(request);
     if (response != null) {
       log(
         response.toJson().toString(),
@@ -181,8 +190,9 @@ class TradingEntitiesBloc implements BlocBase {
   }
 
   Future<Rational?> getMaxTakerVolume(String coinAbbr) async {
-    final MaxTakerVolResponse? response =
-        await _mm2Api.getMaxTakerVolume(MaxTakerVolRequest(coin: coinAbbr));
+    final MaxTakerVolResponse? response = await _mm2Api.getMaxTakerVolume(
+      MaxTakerVolRequest(coin: coinAbbr),
+    );
     if (response == null) {
       return null;
     }

--- a/lib/blocs/update_bloc.dart
+++ b/lib/blocs/update_bloc.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_flutter_imports
+
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -25,26 +27,29 @@ class UpdateBloc extends BlocBase {
     final currentVersion = await _getCurrentAppVersion();
     final versionInfo = await appUpdateService.getUpdateInfo();
     if (versionInfo == null) return;
-    final bool isNewVersion =
-        _isVersionGreaterThan(versionInfo.version, currentVersion);
+    final bool isNewVersion = _isVersionGreaterThan(
+      versionInfo.version,
+      currentVersion,
+    );
 
     if (!isNewVersion || _isPopupShown) return;
 
     PopupDispatcher(
-        barrierDismissible: false,
-        contentPadding: isMobile
-            ? const EdgeInsets.all(15.0)
-            : const EdgeInsets.fromLTRB(26, 15, 26, 42),
-        popupContent: UpdatePopUp(
-          versionInfo: versionInfo,
-          onAccept: () {
-            _isPopupShown = false;
-          },
-          onCancel: () {
-            _isPopupShown = false;
-            _checkerTime.cancel();
-          },
-        )).show();
+      barrierDismissible: false,
+      contentPadding: isMobile
+          ? const EdgeInsets.all(15.0)
+          : const EdgeInsets.fromLTRB(26, 15, 26, 42),
+      popupContent: UpdatePopUp(
+        versionInfo: versionInfo,
+        onAccept: () {
+          _isPopupShown = false;
+        },
+        onCancel: () {
+          _isPopupShown = false;
+          _checkerTime.cancel();
+        },
+      ),
+    ).show();
     _isPopupShown = true;
   }
 

--- a/lib/views/nfts/nft_transactions/mobile/nft_txn_mobile_page.dart
+++ b/lib/views/nfts/nft_transactions/mobile/nft_txn_mobile_page.dart
@@ -32,9 +32,9 @@ class NftTxnMobilePage extends StatelessWidget {
                     return NftTxnFailurePage(
                       message: state.errorMessage ?? '--',
                       onReload: () {
-                        context
-                            .read<NftTransactionsBloc>()
-                            .add(const NftTxnReceiveEvent());
+                        context.read<NftTransactionsBloc>().add(
+                          const NftTxnReceiveEvent(),
+                        );
                       },
                     );
                   }
@@ -54,13 +54,14 @@ class NftTxnMobilePage extends StatelessWidget {
 
                       final txKey = data.getTxKey();
                       return NftTxnMobileCard(
-                          key: Key(txKey),
-                          transaction: data,
-                          onPressed: () {
-                            context
-                                .read<NftTransactionsBloc>()
-                                .add(NftTxReceiveDetailsEvent(data));
-                          });
+                        key: Key(txKey),
+                        transaction: data,
+                        onPressed: () {
+                          context.read<NftTransactionsBloc>().add(
+                            NftTxReceiveDetailsEvent(data),
+                          );
+                        },
+                      );
                     },
                     separatorBuilder: (context, index) =>
                         const SizedBox(height: 8),
@@ -76,14 +77,13 @@ class NftTxnMobilePage extends StatelessWidget {
 
   void _onSettingsPressed(BuildContext context) {
     final bloc = context.read<NftTransactionsBloc>();
-    bloc.bottomSheetController = showBottomSheet(
+    showBottomSheet(
       context: context,
       backgroundColor: Colors.transparent,
       builder: (generalContext) {
         return NftTxnMobileFilters(
           filters: bloc.state.filters,
           onApply: (filters) {
-            // Navigator.of(context).pop();
             if (filters != null) {
               bloc.add(NftTxnEventFullFilterChanged(filters));
             }

--- a/lib/views/wallet/coin_details/rewards/kmd_rewards_info.dart
+++ b/lib/views/wallet/coin_details/rewards/kmd_rewards_info.dart
@@ -170,9 +170,7 @@ class _KmdRewardsInfoState extends State<KmdRewardsInfo> {
                                   ?.withValues(alpha: 0.4),
                             ),
                           ),
-                          const SizedBox(
-                            height: 30.0,
-                          ),
+                          const SizedBox(height: 30.0),
                           UiBorderButton(
                             width: 160,
                             height: 38,
@@ -204,19 +202,16 @@ class _KmdRewardsInfoState extends State<KmdRewardsInfo> {
   }
 
   Widget _buildMessage() {
-    final String message =
-        _successMessage.isEmpty ? _errorMessage : _successMessage;
+    final String message = _successMessage.isEmpty
+        ? _errorMessage
+        : _successMessage;
 
     return message.isEmpty
         ? const SizedBox.shrink()
         : Container(
             margin: const EdgeInsets.only(top: 20),
             padding: const EdgeInsets.all(12),
-            decoration: BoxDecoration(
-              border: Border.all(
-                color: _messageColor,
-              ),
-            ),
+            decoration: BoxDecoration(border: Border.all(color: _messageColor)),
             child: SelectableText(
               message,
               style: TextStyle(color: _messageColor),
@@ -380,8 +375,10 @@ class _KmdRewardsInfoState extends State<KmdRewardsInfo> {
               alignment: const Alignment(-1, 0),
               child: Text(
                 LocaleKeys.status.tr(),
-                style:
-                    const TextStyle(fontWeight: FontWeight.w700, fontSize: 12),
+                style: const TextStyle(
+                  fontWeight: FontWeight.w700,
+                  fontSize: 12,
+                ),
               ),
             ),
           ),
@@ -418,16 +415,16 @@ class _KmdRewardsInfoState extends State<KmdRewardsInfo> {
     });
 
     context.read<AnalyticsBloc>().logEvent(
-          RewardClaimInitiatedEventData(
-            asset: widget.coin.abbr,
-            expectedRewardAmount: _totalReward ?? 0,
-          ),
-        );
+      RewardClaimInitiatedEventData(
+        asset: widget.coin.abbr,
+        expectedRewardAmount: _totalReward ?? 0,
+      ),
+    );
 
     final coinsRepository = RepositoryProvider.of<CoinsRepo>(context);
     final kmdRewardsBloc = RepositoryProvider.of<KmdRewardsBloc>(context);
-    final BlocResponse<String, BaseError> response =
-        await kmdRewardsBloc.claim(context);
+    final BlocResponse<String, BaseError> response = await kmdRewardsBloc
+        .claim();
     final BaseError? error = response.error;
     if (error != null) {
       setState(() {
@@ -435,11 +432,11 @@ class _KmdRewardsInfoState extends State<KmdRewardsInfo> {
         _errorMessage = error.message;
       });
       context.read<AnalyticsBloc>().logEvent(
-            RewardClaimFailureEventData(
-              asset: widget.coin.abbr,
-              failReason: error.message,
-            ),
-          );
+        RewardClaimFailureEventData(
+          asset: widget.coin.abbr,
+          failReason: error.message,
+        ),
+      );
       return;
     }
 
@@ -447,20 +444,23 @@ class _KmdRewardsInfoState extends State<KmdRewardsInfo> {
     context.read<CoinsBloc>().add(CoinsBalancesRefreshed());
     await _updateInfoUntilSuccessOrTimeOut(30000);
 
-    final String reward =
-        doubleToString(double.tryParse(response.result!) ?? 0);
-    final double? usdPrice =
-        coinsRepository.getUsdPriceByAmount(response.result!, 'KMD');
+    final String reward = doubleToString(
+      double.tryParse(response.result!) ?? 0,
+    );
+    final double? usdPrice = coinsRepository.getUsdPriceByAmount(
+      response.result!,
+      'KMD',
+    );
     final String formattedUsdPrice = cutTrailingZeros(formatAmt(usdPrice ?? 0));
     setState(() {
       _isClaiming = false;
     });
     context.read<AnalyticsBloc>().logEvent(
-          RewardClaimSuccessEventData(
-            asset: widget.coin.abbr,
-            rewardAmount: double.tryParse(response.result!) ?? 0,
-          ),
-        );
+      RewardClaimSuccessEventData(
+        asset: widget.coin.abbr,
+        rewardAmount: double.tryParse(response.result!) ?? 0,
+      ),
+    );
     widget.onSuccess(reward, formattedUsdPrice);
   }
 
@@ -479,8 +479,9 @@ class _KmdRewardsInfoState extends State<KmdRewardsInfo> {
 
   Future<void> _updateInfoUntilSuccessOrTimeOut(int timeOut) async {
     _updateTimer ??= DateTime.now().millisecondsSinceEpoch;
-    final List<KmdRewardItem> prevRewards =
-        List.from(_rewards ?? <KmdRewardItem>[]);
+    final List<KmdRewardItem> prevRewards = List.from(
+      _rewards ?? <KmdRewardItem>[],
+    );
 
     await _updateRewardsInfo();
 
@@ -500,10 +501,12 @@ class _KmdRewardsInfoState extends State<KmdRewardsInfo> {
   Future<void> _updateRewardsInfo() async {
     final coinsRepository = RepositoryProvider.of<CoinsRepo>(context);
     final kmdRewardsBloc = RepositoryProvider.of<KmdRewardsBloc>(context);
-    final double? total = await kmdRewardsBloc.getTotal(context);
+    final double? total = await kmdRewardsBloc.getTotal();
     final List<KmdRewardItem> currentRewards = await kmdRewardsBloc.getInfo();
-    final double? totalUsd =
-        coinsRepository.getUsdPriceByAmount((total ?? 0).toString(), 'KMD');
+    final double? totalUsd = coinsRepository.getUsdPriceByAmount(
+      (total ?? 0).toString(),
+      'KMD',
+    );
 
     if (!mounted) return;
     setState(() {


### PR DESCRIPTION
## Summary
- refactor: hide bloc dependencies and methods to satisfy bloc lints according to the recently released `bloc_lint` package.
- refactor: remove flutter-specific usage from blocs and views
- chore: document legacy blocs with lint ignores

## Testing
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_688e3a7f4f348326b6b095a92d19c5ff