### PR TITLE
fix: prevent blank screen after login

### DIFF
--- a/lib/shared/widgets/app_dialog.dart
+++ b/lib/shared/widgets/app_dialog.dart
@@ -153,7 +153,10 @@ class AppDialog {
       contentPadding: contentPadding,
       onDismiss: onDismiss,
       child: childBuilder(() {
-        Navigator.of(context).pop();
+        // Ensure we pop the dialog from the root navigator. Using the root
+        // navigator prevents accidentally popping routes from nested
+        // navigators which can lead to a blank screen after login.
+        Navigator.of(context, rootNavigator: true).pop();
         if (onSuccess != null) {
           onSuccess(null); // Pass null since we don't have a specific result
         }


### PR DESCRIPTION
## Summary
- fix AppDialog to pop root navigator and avoid blank screen after sign in

## Testing
- `flutter pub get --enforce-lockfile`
- `flutter analyze lib/shared/widgets/app_dialog.dart`


------
https://chatgpt.com/codex/tasks/task_e_688e7fb6da788326a76a03cd47502ad5