### PR TITLE
fix: persist quick login dialog state across page changes

### DIFF
--- a/lib/router/navigators/app_router_delegate.dart
+++ b/lib/router/navigators/app_router_delegate.dart
@@ -37,9 +37,7 @@ class AppRouterDelegate extends RouterDelegate<AppRoutePath>
           materialPageContext = context;
           return GestureDetector(
             onTap: () => runDropdownDismiss(context),
-            child: MainLayout(
-              key: ValueKey('${routingState.selectedMenu}'),
-            ),
+            child: const MainLayout(),
           );
         },
       ),

--- a/lib/views/main_layout/main_layout.dart
+++ b/lib/views/main_layout/main_layout.dart
@@ -90,7 +90,11 @@ class _MainLayoutState extends State<MainLayout> {
               floatingActionButtonLocation:
                   FloatingActionButtonLocation.endFloat,
               appBar: null,
-              body: SafeArea(child: MainLayoutRouter()),
+              body: SafeArea(
+                child: MainLayoutRouter(
+                  key: ValueKey('${routingState.selectedMenu}'),
+                ),
+              ),
               bottomNavigationBar: (isMobile || isTablet)
                   ? MainMenuBarMobile()
                   : null,
@@ -145,7 +149,9 @@ class _MainLayoutState extends State<MainLayout> {
         // If we have a pubkey hash in the stored WalletId, ensure it matches
         if (walletId.hasFullIdentity && w.config.pubKey != null) {
           // Verify if wallet.config.pubKey corresponds to walletId.pubkeyHash
-          final pubKeyHash = md5.convert(utf8.encode(w.config.pubKey!)).toString();
+          final pubKeyHash = md5
+              .convert(utf8.encode(w.config.pubKey!))
+              .toString();
           if (pubKeyHash != walletId.pubkeyHash) return false;
         }
         return true;


### PR DESCRIPTION
## Summary
- prevent `MainLayout` from reinitializing on menu changes
- reset internal router instead to avoid repeated quick login prompts

## Testing
- `flutter pub get --enforce-lockfile`
- `dart format lib/router/navigators/app_router_delegate.dart lib/views/main_layout/main_layout.dart`
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_688e9bfe3ff4832693c9deebc72d1e20