### PR TITLE
fix: reset NFT image on url change

### DIFF
--- a/lib/views/nfts/common/widgets/nft_image.dart
+++ b/lib/views/nfts/common/widgets/nft_image.dart
@@ -37,7 +37,7 @@ class NftImage extends StatelessWidget {
               return PlatformTuner.isNativeDesktop
                   ? const _NftPlaceholder()
                   : _NftVideoWithFallback(
-                      key: Key(imageUrl!),
+                      key: ValueKey(imageUrl!),
                       videoUrl: imageUrl!,
                     );
             case NftImageType.placeholder:

--- a/lib/views/nfts/common/widgets/nft_image.dart
+++ b/lib/views/nfts/common/widgets/nft_image.dart
@@ -27,6 +27,7 @@ class NftImage extends StatelessWidget {
           switch (type) {
             case NftImageType.image:
               return _NftImageWithFallback(
+                key: Key(imageUrl!),
                 imageUrl: imageUrl!,
               );
             case NftImageType.video:
@@ -36,6 +37,7 @@ class NftImage extends StatelessWidget {
               return PlatformTuner.isNativeDesktop
                   ? const _NftPlaceholder()
                   : _NftVideoWithFallback(
+                      key: Key(imageUrl!),
                       videoUrl: imageUrl!,
                     );
             case NftImageType.placeholder:
@@ -82,6 +84,16 @@ class _NftImageWithFallbackState extends State<_NftImageWithFallback> {
             imageUrl: widget.imageUrl,
           ));
     });
+  }
+
+  @override
+  void didUpdateWidget(covariant _NftImageWithFallback oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.imageUrl != widget.imageUrl) {
+      final bloc = context.read<NftImageBloc>();
+      bloc.add(const NftImageResetRequested());
+      bloc.add(NftImageLoadRequested(imageUrl: widget.imageUrl));
+    }
   }
 
   @override
@@ -199,6 +211,19 @@ class _NftVideoWithFallbackState extends State<_NftVideoWithFallback> {
             imageUrl: widget.videoUrl,
           ));
     });
+  }
+
+  @override
+  void didUpdateWidget(covariant _NftVideoWithFallback oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.videoUrl != widget.videoUrl) {
+      _controller?.dispose();
+      _controller = null;
+      currentVideoUrl = null;
+      final bloc = context.read<NftImageBloc>();
+      bloc.add(const NftImageResetRequested());
+      bloc.add(NftImageLoadRequested(imageUrl: widget.videoUrl));
+    }
   }
 
   @override

--- a/lib/views/nfts/common/widgets/nft_image.dart
+++ b/lib/views/nfts/common/widgets/nft_image.dart
@@ -27,7 +27,7 @@ class NftImage extends StatelessWidget {
           switch (type) {
             case NftImageType.image:
               return _NftImageWithFallback(
-                key: Key(imageUrl!),
+                key: ValueKey(imageUrl!),
                 imageUrl: imageUrl!,
               );
             case NftImageType.video:


### PR DESCRIPTION
## Summary
- reset NFT image bloc when media URL changes
- reload videos on URL updates

## Testing
- `dart format lib/views/nfts/common/widgets/nft_image.dart`
- `flutter pub get --enforce-lockfile --offline`
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_689083341eb4833195b2eb0763e772a6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updating NFT images and videos, ensuring that media reloads correctly if the URL changes. This enhances consistency and prevents display issues when content is updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->