### PR TITLE
fix(coin-details): display fiat balance for addresses

### DIFF
--- a/lib/bloc/coin_addresses/bloc/coin_addresses_event.dart
+++ b/lib/bloc/coin_addresses/bloc/coin_addresses_event.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:komodo_defi_types/komodo_defi_types.dart' show PubkeyInfo;
 
 abstract class CoinAddressesEvent extends Equatable {
   const CoinAddressesEvent();
@@ -7,19 +8,41 @@ abstract class CoinAddressesEvent extends Equatable {
   List<Object?> get props => [];
 }
 
-class SubmitCreateAddressEvent extends CoinAddressesEvent {
-  const SubmitCreateAddressEvent();
+class CoinAddressesAddressCreationSubmitted extends CoinAddressesEvent {
+  const CoinAddressesAddressCreationSubmitted();
 }
 
-class LoadAddressesEvent extends CoinAddressesEvent {
-  const LoadAddressesEvent();
+class CoinAddressesStarted extends CoinAddressesEvent {
+  const CoinAddressesStarted();
 }
 
-class UpdateHideZeroBalanceEvent extends CoinAddressesEvent {
+class CoinAddressesSubscriptionRequested extends CoinAddressesEvent {
+  const CoinAddressesSubscriptionRequested();
+}
+
+class CoinAddressesZeroBalanceVisibilityChanged extends CoinAddressesEvent {
   final bool hideZeroBalance;
 
-  const UpdateHideZeroBalanceEvent(this.hideZeroBalance);
+  const CoinAddressesZeroBalanceVisibilityChanged(this.hideZeroBalance);
 
   @override
   List<Object?> get props => [hideZeroBalance];
+}
+
+/// Emitted when the pubkeys watcher emits an updated set of keys (and balances)
+class CoinAddressesPubkeysUpdated extends CoinAddressesEvent {
+  final List<PubkeyInfo> addresses;
+  const CoinAddressesPubkeysUpdated(this.addresses);
+
+  @override
+  List<Object?> get props => [addresses];
+}
+
+/// Emitted when the pubkeys watcher reports an error
+class CoinAddressesPubkeysSubscriptionFailed extends CoinAddressesEvent {
+  final String error;
+  const CoinAddressesPubkeysSubscriptionFailed(this.error);
+
+  @override
+  List<Object?> get props => [error];
 }

--- a/lib/shared/widgets/coin_balance.dart
+++ b/lib/shared/widgets/coin_balance.dart
@@ -17,35 +17,30 @@ class CoinBalance extends StatelessWidget {
     final baseFont = Theme.of(context).textTheme.bodySmall;
     final balanceStyle = baseFont?.copyWith(fontWeight: FontWeight.w500);
 
-    final sdk = context.sdk;
-    final balanceValue =
-        sdk.balances.lastKnown(coin.id)?.spendable.toDouble() ?? 0.0;
-
-    final amountRow = Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Flexible(
-          child: AutoScrollText(
-            key: Key('coin-balance-asset-${coin.abbr.toLowerCase()}'),
-            text: doubleToString(balanceValue),
-            style: balanceStyle,
-            textAlign: TextAlign.right,
-          ),
-        ),
-        Text(' ${Coin.normalizeAbbr(coin.abbr)}', style: balanceStyle),
-      ],
-    );
-
-    final fiatWidget = CoinFiatBalance(coin, isAutoScrollEnabled: true);
+    final balance =
+        context.sdk.balances.lastKnown(coin.id)?.spendable.toDouble() ?? 0.0;
 
     final children = [
-      amountRow,
+      Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Flexible(
+            child: AutoScrollText(
+              key: Key('coin-balance-asset-${coin.abbr.toLowerCase()}'),
+              text: doubleToString(balance),
+              style: balanceStyle,
+              textAlign: TextAlign.right,
+            ),
+          ),
+          Text(' ${Coin.normalizeAbbr(coin.abbr)}', style: balanceStyle),
+        ],
+      ),
       ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 100),
         child: Row(
           children: [
             Text(' (', style: balanceStyle),
-            fiatWidget,
+            CoinFiatBalance(coin, isAutoScrollEnabled: true),
             Text(')', style: balanceStyle),
           ],
         ),

--- a/lib/shared/widgets/coin_balance.dart
+++ b/lib/shared/widgets/coin_balance.dart
@@ -1,17 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 import 'package:web_dex/model/coin.dart';
+import 'package:web_dex/shared/utils/formatters.dart';
 import 'package:web_dex/shared/utils/utils.dart';
 import 'package:web_dex/shared/widgets/coin_fiat_balance.dart';
 
 // TODO! Integrate this widget directly to the SDK and make it subscribe to
 // the balance changes of the coin.
 class CoinBalance extends StatelessWidget {
-  const CoinBalance({
-    super.key,
-    required this.coin,
-    this.isVertical = false,
-  });
+  const CoinBalance({super.key, required this.coin, this.isVertical = false});
 
   final Coin coin;
   final bool isVertical;
@@ -19,42 +16,37 @@ class CoinBalance extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final baseFont = Theme.of(context).textTheme.bodySmall;
-    final balanceStyle = baseFont?.copyWith(
-      fontWeight: FontWeight.w500,
+    final balanceStyle = baseFont?.copyWith(fontWeight: FontWeight.w500);
+
+    final sdk = context.sdk;
+    final balanceValue =
+        sdk.balances.lastKnown(coin.id)?.spendable.toDouble() ?? 0.0;
+
+    final amountRow = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Flexible(
+          child: AutoScrollText(
+            key: Key('coin-balance-asset-${coin.abbr.toLowerCase()}'),
+            text: doubleToString(balanceValue),
+            style: balanceStyle,
+            textAlign: TextAlign.right,
+          ),
+        ),
+        Text(' ${Coin.normalizeAbbr(coin.abbr)}', style: balanceStyle),
+      ],
     );
 
-    final balance =
-        context.sdk.balances.lastKnown(coin.id)?.spendable.toDouble() ?? 0.0;
+    final fiatWidget = CoinFiatBalance(coin, isAutoScrollEnabled: true);
 
     final children = [
-      Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Flexible(
-            child: AutoScrollText(
-              key: Key('coin-balance-asset-${coin.abbr.toLowerCase()}'),
-              text: doubleToString(balance),
-              style: balanceStyle,
-              textAlign: TextAlign.right,
-            ),
-          ),
-          Text(
-            ' ${Coin.normalizeAbbr(coin.abbr)}',
-            style: balanceStyle,
-          ),
-        ],
-      ),
+      amountRow,
       ConstrainedBox(
-        constraints: const BoxConstraints(
-          maxWidth: 100,
-        ),
+        constraints: const BoxConstraints(maxWidth: 100),
         child: Row(
           children: [
             Text(' (', style: balanceStyle),
-            CoinFiatBalance(
-              coin,
-              isAutoScrollEnabled: true,
-            ),
+            fiatWidget,
             Text(')', style: balanceStyle),
           ],
         ),

--- a/lib/shared/widgets/coin_balance.dart
+++ b/lib/shared/widgets/coin_balance.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 import 'package:web_dex/model/coin.dart';
-import 'package:web_dex/shared/utils/formatters.dart';
 import 'package:web_dex/shared/utils/utils.dart';
 import 'package:web_dex/shared/widgets/coin_fiat_balance.dart';
 

--- a/lib/shared/widgets/coin_fiat_balance.dart
+++ b/lib/shared/widgets/coin_fiat_balance.dart
@@ -23,31 +23,34 @@ class CoinFiatBalance extends StatelessWidget {
   Widget build(BuildContext context) {
     final balanceStream = context.sdk.balances.watchBalance(coin.id);
 
-    final TextStyle mergedStyle =
-        const TextStyle(fontSize: 12, fontWeight: FontWeight.w500).merge(style);
+    final TextStyle mergedStyle = const TextStyle(
+      fontSize: 12,
+      fontWeight: FontWeight.w500,
+    ).merge(style);
 
     return StreamBuilder<BalanceInfo>(
-        stream: balanceStream,
-        builder: (context, snapshot) {
-          if (!snapshot.hasData) {
-            return const SizedBox();
-          }
+      stream: balanceStream,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const SizedBox();
+        }
 
-          final balanceStr = formatUsdValue(
-            coin.lastKnownUsdBalance(context.sdk),
+        final balanceStr = formatUsdValue(
+          coin.lastKnownUsdBalance(context.sdk),
+        );
+
+        if (isAutoScrollEnabled) {
+          return AutoScrollText(
+            text: balanceStr,
+            style: mergedStyle,
+            isSelectable: isSelectable,
           );
+        }
 
-          if (isAutoScrollEnabled) {
-            return AutoScrollText(
-              text: balanceStr,
-              style: mergedStyle,
-              isSelectable: isSelectable,
-            );
-          }
-
-          return isSelectable
-              ? SelectableText(balanceStr, style: mergedStyle)
-              : Text(balanceStr, style: mergedStyle);
-        });
+        return isSelectable
+            ? SelectableText(balanceStr, style: mergedStyle)
+            : Text(balanceStr, style: mergedStyle);
+      },
+    );
   }
 }

--- a/lib/views/wallet/coin_details/coin_details_info/coin_addresses.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/coin_addresses.dart
@@ -14,7 +14,8 @@ import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/coin.dart';
 import 'package:web_dex/shared/utils/utils.dart';
-import 'package:web_dex/shared/widgets/coin_balance.dart';
+import 'package:web_dex/shared/utils/formatters.dart';
+import 'package:web_dex/shared/utils/extensions/legacy_coin_migration_extensions.dart';
 import 'package:web_dex/shared/widgets/coin_type_tag.dart';
 import 'package:web_dex/shared/widgets/truncate_middle_text.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_page_type.dart';
@@ -243,8 +244,7 @@ class AddressCard extends StatelessWidget {
                     ],
                   ),
                   const SizedBox(height: 12),
-                  CoinBalance(coin: coin),
-                  const SizedBox(height: 4),
+                  _Balance(address: address, coin: coin),
                 ],
               )
             : SizedBox(
@@ -273,8 +273,28 @@ class AddressCard extends StatelessWidget {
                   ],
                 ),
               ),
-        trailing: isMobile ? null : CoinBalance(coin: coin),
+        trailing: isMobile ? null : _Balance(address: address, coin: coin),
       ),
+    );
+  }
+}
+
+class _Balance extends StatelessWidget {
+  const _Balance({required this.address, required this.coin});
+
+  final PubkeyInfo address;
+  final Coin coin;
+
+  @override
+  Widget build(BuildContext context) {
+    final balance = address.balance.total.toDouble();
+    final price = coin.lastKnownUsdPrice(context.sdk);
+    final usdValue = price == null ? null : price * balance;
+    final fiat = formatUsdValue(usdValue);
+
+    return Text(
+      '${doubleToString(balance)} ${abbr2Ticker(coin.abbr)} ($fiat)',
+      style: TextStyle(fontSize: isMobile ? 12 : 14),
     );
   }
 }

--- a/lib/views/wallet/coin_details/coin_details_info/coin_addresses.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/coin_addresses.dart
@@ -13,9 +13,8 @@ import 'package:web_dex/bloc/coin_addresses/bloc/coin_addresses_state.dart';
 import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/coin.dart';
-import 'package:web_dex/shared/utils/utils.dart';
 import 'package:web_dex/shared/utils/formatters.dart';
-import 'package:web_dex/shared/utils/extensions/legacy_coin_migration_extensions.dart';
+import 'package:web_dex/shared/utils/utils.dart';
 import 'package:web_dex/shared/widgets/coin_type_tag.dart';
 import 'package:web_dex/shared/widgets/truncate_middle_text.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_page_type.dart';
@@ -647,7 +646,7 @@ class HideZeroBalanceCheckbox extends StatelessWidget {
       value: hideZeroBalance,
       onChanged: (value) {
         context.read<CoinAddressesBloc>().add(
-          UpdateHideZeroBalanceEvent(value),
+          CoinAddressesZeroBalanceVisibilityChanged(value),
         );
       },
     );
@@ -688,7 +687,7 @@ class CreateButton extends StatelessWidget {
                 createAddressStatus != FormStatus.submitting
             ? () {
                 context.read<CoinAddressesBloc>().add(
-                  const SubmitCreateAddressEvent(),
+                  const CoinAddressesAddressCreationSubmitted(),
                 );
               }
             : null,

--- a/lib/views/wallet/coin_details/coin_details_info/coin_addresses.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/coin_addresses.dart
@@ -14,6 +14,7 @@ import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/coin.dart';
 import 'package:web_dex/shared/utils/utils.dart';
+import 'package:web_dex/shared/widgets/coin_balance.dart';
 import 'package:web_dex/shared/widgets/coin_type_tag.dart';
 import 'package:web_dex/shared/widgets/truncate_middle_text.dart';
 import 'package:web_dex/views/wallet/coin_details/coin_page_type.dart';
@@ -242,7 +243,7 @@ class AddressCard extends StatelessWidget {
                     ],
                   ),
                   const SizedBox(height: 12),
-                  _Balance(address: address, coin: coin),
+                  CoinBalance(coin: coin),
                   const SizedBox(height: 4),
                 ],
               )
@@ -272,24 +273,8 @@ class AddressCard extends StatelessWidget {
                   ],
                 ),
               ),
-        trailing: isMobile ? null : _Balance(address: address, coin: coin),
+        trailing: isMobile ? null : CoinBalance(coin: coin),
       ),
-    );
-  }
-}
-
-class _Balance extends StatelessWidget {
-  const _Balance({required this.address, required this.coin});
-
-  final PubkeyInfo address;
-  final Coin coin;
-
-  @override
-  Widget build(BuildContext context) {
-    return Text(
-      '${doubleToString(address.balance.total.toDouble())} '
-      '${abbr2Ticker(coin.abbr)} (${address.balance.total.toDouble()})',
-      style: TextStyle(fontSize: isMobile ? 12 : 14),
     );
   }
 }

--- a/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
+++ b/lib/views/wallet/coin_details/coin_details_info/coin_details_info.dart
@@ -65,7 +65,7 @@ class _CoinDetailsInfoState extends State<CoinDetailsInfo>
     context.sdk,
     widget.coin.abbr,
     context.read<AnalyticsBloc>(),
-  )..add(LoadAddressesEvent());
+  )..add(const CoinAddressesStarted());
 
   @override
   void initState() {
@@ -73,22 +73,22 @@ class _CoinDetailsInfoState extends State<CoinDetailsInfo>
     const selectedDurationInitial = Duration(hours: 1);
 
     context.read<PortfolioGrowthBloc>().add(
-          PortfolioGrowthLoadRequested(
-            coins: [widget.coin],
-            fiatCoinId: 'USDT',
-            selectedPeriod: selectedDurationInitial,
-            walletId: _walletId!,
-          ),
-        );
+      PortfolioGrowthLoadRequested(
+        coins: [widget.coin],
+        fiatCoinId: 'USDT',
+        selectedPeriod: selectedDurationInitial,
+        walletId: _walletId!,
+      ),
+    );
 
     context.read<ProfitLossBloc>().add(
-          ProfitLossPortfolioChartLoadRequested(
-            coins: [widget.coin],
-            selectedPeriod: const Duration(hours: 1),
-            fiatCoinId: 'USDT',
-            walletId: _walletId!,
-          ),
-        );
+      ProfitLossPortfolioChartLoadRequested(
+        coins: [widget.coin],
+        selectedPeriod: const Duration(hours: 1),
+        fiatCoinId: 'USDT',
+        walletId: _walletId!,
+      ),
+    );
   }
 
   @override
@@ -100,9 +100,9 @@ class _CoinDetailsInfoState extends State<CoinDetailsInfo>
             previous.createAddressStatus != current.createAddressStatus &&
             current.createAddressStatus == FormStatus.success,
         listener: (context, state) {
-          context
-              .read<CoinsBloc>()
-              .add(CoinsPubkeysRequested(widget.coin.abbr));
+          context.read<CoinsBloc>().add(
+            CoinsPubkeysRequested(widget.coin.abbr),
+          );
         },
         child: PageLayout(
           padding: const EdgeInsets.fromLTRB(15, 32, 15, 20),
@@ -118,9 +118,7 @@ class _CoinDetailsInfoState extends State<CoinDetailsInfo>
             onBackButtonPressed: _onBackButtonPressed,
             actions: [_buildDisableButton()],
           ),
-          content: Expanded(
-            child: _buildContent(context),
-          ),
+          content: Expanded(child: _buildContent(context)),
         ),
       ),
     );
@@ -148,9 +146,13 @@ class _CoinDetailsInfoState extends State<CoinDetailsInfo>
 
     return DisableCoinButton(
       onClick: () {
-        confirmBeforeDisablingCoin(widget.coin, context, onConfirm: () {
-          widget.onBackButtonPressed();
-        });
+        confirmBeforeDisablingCoin(
+          widget.coin,
+          context,
+          onConfirm: () {
+            widget.onBackButtonPressed();
+          },
+        );
       },
     );
   }
@@ -209,19 +211,12 @@ class _DesktopContent extends StatelessWidget {
         slivers: <Widget>[
           if (selectedTransaction == null)
             SliverToBoxAdapter(
-              child: _DesktopCoinDetails(
-                coin: coin,
-                setPageType: setPageType,
-              ),
+              child: _DesktopCoinDetails(coin: coin, setPageType: setPageType),
             ),
-          const SliverToBoxAdapter(
-            child: SizedBox(height: 20),
-          ),
+          const SliverToBoxAdapter(child: SizedBox(height: 20)),
           if (selectedTransaction == null)
             CoinAddresses(coin: coin, setPageType: setPageType),
-          const SliverToBoxAdapter(
-            child: SizedBox(height: 20),
-          ),
+          const SliverToBoxAdapter(child: SizedBox(height: 20)),
           TransactionTable(
             coin: coin,
             selectedTransaction: selectedTransaction,
@@ -234,10 +229,7 @@ class _DesktopContent extends StatelessWidget {
 }
 
 class _DesktopCoinDetails extends StatelessWidget {
-  const _DesktopCoinDetails({
-    required this.coin,
-    required this.setPageType,
-  });
+  const _DesktopCoinDetails({required this.coin, required this.setPageType});
 
   final Coin coin;
   final void Function(CoinPageType) setPageType;
@@ -254,25 +246,16 @@ class _DesktopCoinDetails extends StatelessWidget {
             children: [
               Padding(
                 padding: const EdgeInsets.fromLTRB(0, 5, 12, 0),
-                child: AssetLogo.ofId(
-                  coin.id,
-                  size: 50,
-                ),
+                child: AssetLogo.ofId(coin.id, size: 50),
               ),
               _Balance(coin: coin),
               const SizedBox(width: 10),
               Padding(
                 padding: const EdgeInsets.only(top: 18.0),
-                child: _SpecificButton(
-                  coin: coin,
-                  selectWidget: setPageType,
-                ),
+                child: _SpecificButton(coin: coin, selectWidget: setPageType),
               ),
               const Spacer(),
-              CoinDetailsInfoFiat(
-                coin: coin,
-                isMobile: false,
-              ),
+              CoinDetailsInfoFiat(coin: coin, isMobile: false),
             ],
           ),
           Padding(
@@ -282,8 +265,8 @@ class _DesktopCoinDetails extends StatelessWidget {
               selectWidget: setPageType,
               onClickSwapButton:
                   context.watch<TradingStatusBloc>().state is TradingEnabled
-                      ? () => _goToSwap(context, coin)
-                      : null,
+                  ? () => _goToSwap(context, coin)
+                  : null,
               coin: coin,
             ),
           ),
@@ -320,17 +303,10 @@ class _MobileContent extends StatelessWidget {
               context: context,
             ),
           ),
-        const SliverToBoxAdapter(
-          child: SizedBox(height: 20),
-        ),
+        const SliverToBoxAdapter(child: SizedBox(height: 20)),
         if (selectedTransaction == null)
-          CoinAddresses(
-            coin: coin,
-            setPageType: setPageType,
-          ),
-        const SliverToBoxAdapter(
-          child: SizedBox(height: 20),
-        ),
+          CoinAddresses(coin: coin, setPageType: setPageType),
+        const SliverToBoxAdapter(child: SizedBox(height: 20)),
         TransactionTable(
           coin: coin,
           selectedTransaction: selectedTransaction,
@@ -362,20 +338,14 @@ class _CoinDetailsInfoHeader extends StatelessWidget {
       ),
       child: Column(
         children: [
-          AssetIcon.ofTicker(
-            coin.abbr,
-            size: 35,
-          ),
+          AssetIcon.ofTicker(coin.abbr, size: 35),
           const SizedBox(height: 8),
           _Balance(coin: coin),
           const SizedBox(height: 12),
           _SpecificButton(coin: coin, selectWidget: setPageType),
           Padding(
             padding: const EdgeInsets.only(top: 15.0),
-            child: CoinDetailsInfoFiat(
-              coin: coin,
-              isMobile: true,
-            ),
+            child: CoinDetailsInfoFiat(coin: coin, isMobile: true),
           ),
           Padding(
             padding: const EdgeInsets.only(top: 12.0, bottom: 14.0),
@@ -384,8 +354,8 @@ class _CoinDetailsInfoHeader extends StatelessWidget {
               selectWidget: setPageType,
               onClickSwapButton:
                   context.watch<TradingStatusBloc>().state is TradingEnabled
-                      ? () => _goToSwap(context, coin)
-                      : null,
+                  ? () => _goToSwap(context, coin)
+                  : null,
               coin: coin,
             ),
           ),
@@ -432,23 +402,23 @@ class _CoinDetailsMarketMetricsTabBarState
           if (growthState is PortfolioGrowthChartLoadSuccess) {
             final period = _formatDuration(growthState.selectedPeriod);
             context.read<AnalyticsBloc>().logEvent(
-                  PortfolioGrowthViewedEventData(
-                    period: period,
-                    growthPct: growthState.percentageIncrease,
-                  ),
-                );
+              PortfolioGrowthViewedEventData(
+                period: period,
+                growthPct: growthState.percentageIncrease,
+              ),
+            );
           }
         } else if (_tabController!.index == 1) {
           final profitLossState = context.read<ProfitLossBloc>().state;
           if (profitLossState is PortfolioProfitLossChartLoadSuccess) {
             final timeframe = _formatDuration(profitLossState.selectedPeriod);
             context.read<AnalyticsBloc>().logEvent(
-                  PortfolioPnlViewedEventData(
-                    timeframe: timeframe,
-                    realizedPnl: profitLossState.totalValue,
-                    unrealizedPnl: 0,
-                  ),
-                );
+              PortfolioPnlViewedEventData(
+                timeframe: timeframe,
+                realizedPnl: profitLossState.totalValue,
+                unrealizedPnl: 0,
+              ),
+            );
           }
         }
       }
@@ -566,8 +536,9 @@ class _Balance extends StatelessWidget {
     final value = balance == null ? null : doubleToString(balance);
 
     return Column(
-      crossAxisAlignment:
-          isMobile ? CrossAxisAlignment.center : CrossAxisAlignment.start,
+      crossAxisAlignment: isMobile
+          ? CrossAxisAlignment.center
+          : CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
         if (isMobile)
@@ -584,8 +555,9 @@ class _Balance extends StatelessWidget {
         Flexible(
           child: Row(
             mainAxisSize: isMobile ? MainAxisSize.max : MainAxisSize.min,
-            mainAxisAlignment:
-                isMobile ? MainAxisAlignment.center : MainAxisAlignment.start,
+            mainAxisAlignment: isMobile
+                ? MainAxisAlignment.center
+                : MainAxisAlignment.start,
             children: [
               Flexible(
                 child: AutoScrollText(
@@ -632,9 +604,9 @@ class _FiatBalance extends StatelessWidget {
           Text(
             LocaleKeys.fiatBalance.tr(),
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  fontSize: 14,
-                  fontWeight: FontWeight.w500,
-                ),
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+            ),
           ),
           Padding(
             padding: const EdgeInsets.only(left: 6.0),


### PR DESCRIPTION
Update [AddressCard](https://github.com/KomodoPlatform/komodo-wallet/blob/c59d52d92b75e4951e4c7e667667d6224add47d5/lib/views/wallet/coin_details/coin_details_info/coin_addresses.dart#L189) to show the fiat value for the address balance instead of showing the balance twice.

## Before 

<img width="2358" height="1364" alt="image" src="https://github.com/user-attachments/assets/7af84ab5-034a-421d-ad05-32f66f00dd04" />


## After

<img width="1347" height="934" alt="image" src="https://github.com/user-attachments/assets/1776a8c1-d955-4618-9a64-478f1cba890d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The coin balance display now includes the equivalent USD value alongside the coin amount and ticker for improved clarity.

* **Style**
  * Simplified formatting in the coin balance widget for a cleaner codebase.
  * Removed redundant spacing in the address card on mobile layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->