### PR TITLE
Fix wallet HD mode persistence and migration bugs

### DIFF
--- a/lib/bloc/auth_bloc/auth_bloc.dart
+++ b/lib/bloc/auth_bloc/auth_bloc.dart
@@ -105,6 +105,7 @@ class AuthBloc extends Bloc<AuthBlocEvent, AuthBlocState> with TrezorAuthMixin {
       }
 
       _log.info('logged in from a wallet');
+      await _kdfSdk.setWalletType(event.wallet.config.type);
       emit(AuthBlocState.loggedIn(currentUser));
       _listenToAuthStateChanges();
     } catch (e, s) {

--- a/lib/views/wallets_manager/widgets/wallet_login.dart
+++ b/lib/views/wallets_manager/widgets/wallet_login.dart
@@ -74,9 +74,7 @@ class _WalletLogInState extends State<WalletLogIn> {
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       widget.wallet.config.type =
-          _isHdMode && _user != null && _user!.isBip39Seed == true
-              ? WalletType.hdwallet
-              : WalletType.iguana;
+          _isHdMode ? WalletType.hdwallet : WalletType.iguana;
 
       widget.onLogin(
         _passwordController.text,


### PR DESCRIPTION
Persist wallet HD mode after sign-in and fix incorrect mode application during legacy wallet migration.

Previously, the login flow would incorrectly force `iguana` mode during legacy wallet migration if the user was not yet loaded from the SDK. Additionally, the selected wallet type was not persisted after a successful sign-in, causing HD mode changes to be lost across sessions.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe0022f6-0e81-4581-8b25-57bcb21b7720">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe0022f6-0e81-4581-8b25-57bcb21b7720">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

