### PR TITLE
Fix/weak passwd setting

### DIFF
--- a/lib/shared/widgets/hidden_without_wallet.dart
+++ b/lib/shared/widgets/hidden_without_wallet.dart
@@ -5,20 +5,23 @@ import 'package:web_dex/model/wallet.dart';
 
 class HiddenWithoutWallet extends StatelessWidget {
   const HiddenWithoutWallet(
-      {Key? key, required this.child, this.isHiddenForHw = false})
+      {Key? key, required this.child, this.isHiddenForHw = false, this.isHiddenElse = true})
       : super(key: key);
   final Widget child;
   final bool isHiddenForHw;
+  final bool isHiddenElse;
 
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<AuthBloc, AuthBlocState>(builder: (context, state) {
       final Wallet? currentWallet = state.currentUser?.wallet;
       if (currentWallet == null) {
-        return const SizedBox.shrink();
+        if (isHiddenElse) {
+          return const SizedBox.shrink();
+        }
       }
 
-      if (isHiddenForHw && currentWallet.isHW) {
+      if (isHiddenForHw && currentWallet?.isHW == true) {
         return const SizedBox.shrink();
       }
 

--- a/lib/views/settings/widgets/general_settings/general_settings.dart
+++ b/lib/views/settings/widgets/general_settings/general_settings.dart
@@ -32,6 +32,7 @@ class GeneralSettings extends StatelessWidget {
         const SizedBox(height: 25),
         const HiddenWithoutWallet(
           isHiddenForHw: true,
+          isHiddenElse: false,
           child: SettingsManageWeakPasswords(),
         ),
         const SizedBox(height: 25),


### PR DESCRIPTION
Due to [a bug](https://github.com/KomodoPlatform/komodo-wallet/issues/3100) introduced in https://github.com/KomodoPlatform/komodo-wallet/pull/2999, the "allow weak password" toggle was hidden unless authenticated.

This PR restores the previous ability to use this toggle before login. 