### PR TITLE
Make contact details mandatory with opt-out

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -304,6 +304,7 @@
   "feedbackFormDescribeTitle": "Your feedback",
   "feedbackFormContactRequired": "How can we contact you?",
   "feedbackFormContactOptional": "How can we contact you? (Optional)",
+  "feedbackFormNoContactOptOut": "I don't want to share contact info",
   "feedbackFormMessageHint": "Enter your feedback here...",
   "feedbackFormBugReport": "Bug Report",
   "feedbackFormFeatureRequest": "Feature Request",

--- a/lib/bloc/feedback_form/feedback_form_event.dart
+++ b/lib/bloc/feedback_form/feedback_form_event.dart
@@ -43,6 +43,15 @@ class FeedbackFormContactDetailsChanged extends FeedbackFormEvent {
   List<Object?> get props => [details];
 }
 
+class FeedbackFormContactOptOutToggled extends FeedbackFormEvent {
+  const FeedbackFormContactOptOutToggled(this.value);
+
+  final bool value;
+
+  @override
+  List<Object?> get props => [value];
+}
+
 class FeedbackFormSubmitted extends FeedbackFormEvent {
   const FeedbackFormSubmitted();
 }

--- a/lib/bloc/feedback_form/feedback_form_state.dart
+++ b/lib/bloc/feedback_form/feedback_form_state.dart
@@ -12,6 +12,7 @@ class FeedbackFormState extends Equatable {
     this.contactDetailsError,
     this.status = FeedbackFormStatus.initial,
     this.errorMessage,
+    this.contactOptOut = false,
   });
 
   final FeedbackType? feedbackType;
@@ -22,6 +23,7 @@ class FeedbackFormState extends Equatable {
   final String? contactDetailsError;
   final FeedbackFormStatus status;
   final String? errorMessage;
+  final bool contactOptOut;
 
   bool get isValid =>
       feedbackType != null &&
@@ -38,6 +40,7 @@ class FeedbackFormState extends Equatable {
     String? contactDetailsError,
     FeedbackFormStatus? status,
     String? errorMessage,
+    bool? contactOptOut,
   }) {
     return FeedbackFormState(
       feedbackType: feedbackType ?? this.feedbackType,
@@ -48,6 +51,7 @@ class FeedbackFormState extends Equatable {
       contactDetailsError: contactDetailsError,
       status: status ?? this.status,
       errorMessage: errorMessage ?? this.errorMessage,
+      contactOptOut: contactOptOut ?? this.contactOptOut,
     );
   }
 
@@ -61,5 +65,6 @@ class FeedbackFormState extends Equatable {
         contactDetailsError,
         status,
         errorMessage,
+        contactOptOut,
       ];
 }


### PR DESCRIPTION
Make contact details mandatory by default for feedback, allowing opt-out via a checkbox, except for support and missing coins queries.

---
<a href="https://cursor.com/background-agent?bcId=bc-71cb662d-637e-4e49-8d21-aca8578a8ec4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-71cb662d-637e-4e49-8d21-aca8578a8ec4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

