### PR TITLE
add GitHub Actions workflow to validate Linux build script

### DIFF
--- a/.github/workflows/docker-linux-build.yml
+++ b/.github/workflows/docker-linux-build.yml
@@ -1,0 +1,37 @@
+name: Build Linux Dekstop in Docker
+# Note: This workflow almost entirely mirrors the existing Jenkins Pipeline.
+
+on:
+  pull_request:
+    branches:
+      [
+        dev,
+        main,
+        release/*,
+        hotfix/*,
+        bugfix/*,
+        feature/*,
+        chore/*,
+        build/*,
+        ci/*,
+      ]
+    paths:
+      - ".docker/**"
+      - "linux/**"
+      - "pubspec.yaml"
+      - "pubspec.lock"
+  workflow_dispatch:
+
+jobs:
+  build-linux-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Linux Desktop
+        env:
+          GITHUB_API_PUBLIC_READONLY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x .docker/build.sh
+          sh .docker/build.sh linux release


### PR DESCRIPTION
Introduce docker-linux-build.yml workflow that runs .docker/build.sh for Linux builds inside Docker. This allows us to continuously verify that the build script works as expected and that the Linux application can be successfully built in a clean environment.

By having this check in CI, we ensure that end users will also be able to build the application themselves using .docker/build.sh, which is the only officially recommended build path.

**p.s.** Please don’t review or merge it while this "p.s." note is present - it’s still a work in progress.