### PR TITLE
chore: upgrade Flutter to 3.35.1; roll SDK deps; improve roll script

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,3 @@
+# Add directories or file patterns to ignore during indexing (e.g. foo/ or *.csv)
+AGENTS/
+AGENTS.md

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/ubuntu:22.04
 
-ENV FLUTTER_VERSION="3.32.5"
+ENV FLUTTER_VERSION="3.35.1"
 ENV USER="komodo"
 ENV USER_ID=1000
 ENV PATH=$PATH:/opt/flutter/bin

--- a/.github/actions/flutter-deps/action.yml
+++ b/.github/actions/flutter-deps/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: subosito/flutter-action@v2
       with:
         # NB! Keep up-to-date with the flutter version used for development
-        flutter-version: "3.32.5"
+        flutter-version: "3.35.1"
         channel: "stable"
 
     - name: Prepare build directory

--- a/.github/scripts/roll_sdk_packages.sh
+++ b/.github/scripts/roll_sdk_packages.sh
@@ -417,9 +417,17 @@ for PUBSPEC in $PUBSPEC_FILES; do
       if [ ${#SDK_HOSTED_PACKAGES[@]} -gt 0 ]; then
         if [ "$UPGRADE_SDK_MAJOR" = true ]; then
           log_info "Upgrading hosted SDK packages (allowing major): ${SDK_HOSTED_PACKAGES[*]}"
+          # Backup pubspec.yaml to preserve formatting/comments
+          PUBSPEC_BAK_FILE="$PUBSPEC.bak_major"
+          cp "$PUBSPEC" "$PUBSPEC_BAK_FILE"
           if ! flutter pub upgrade --major-versions ${SDK_HOSTED_PACKAGES[@]}; then
             log_warning "Failed to upgrade hosted packages (major) in $PROJECT_NAME"
+            # Restore original pubspec.yaml to retain structure
+            mv -f "$PUBSPEC_BAK_FILE" "$PUBSPEC"
             PACKAGE_UPDATE_FAILED=true
+          else
+            # Restore original pubspec.yaml to retain structure; later we'll update versions inline
+            mv -f "$PUBSPEC_BAK_FILE" "$PUBSPEC"
           fi
         else
           log_info "Upgrading hosted SDK packages: ${SDK_HOSTED_PACKAGES[*]}"

--- a/.github/scripts/roll_sdk_packages.sh
+++ b/.github/scripts/roll_sdk_packages.sh
@@ -424,10 +424,12 @@ for PUBSPEC in $PUBSPEC_FILES; do
             log_warning "Failed to upgrade hosted packages (major) in $PROJECT_NAME"
             # Restore original pubspec.yaml to retain structure
             mv -f "$PUBSPEC_BAK_FILE" "$PUBSPEC"
+            rm -f "$PUBSPEC_BAK_FILE" || true
             PACKAGE_UPDATE_FAILED=true
           else
             # Restore original pubspec.yaml to retain structure; later we'll update versions inline
             mv -f "$PUBSPEC_BAK_FILE" "$PUBSPEC"
+            rm -f "$PUBSPEC_BAK_FILE" || true
           fi
         else
           log_info "Upgrading hosted SDK packages: ${SDK_HOSTED_PACKAGES[*]}"
@@ -537,6 +539,9 @@ if [ -n "${GITHUB_OUTPUT}" ]; then
     echo "updates_found=false" >> $GITHUB_OUTPUT
     log_info "No rolls needed."
     # Exit with special code 100 to indicate no changes needed (not a failure)
+    # Ensure any temporary backups are removed even when no changes are detected
+    find "$REPO_ROOT" -name "*.bak" -type f -delete || true
+    find "$REPO_ROOT" -name "*.bak_major" -type f -delete || true
     exit 100
   fi
 else
@@ -547,6 +552,9 @@ else
   else
     log_info "No rolls needed."
     # Exit with special code 100 to indicate no changes needed (not a failure)
+    # Ensure any temporary backups are removed even when no changes are detected
+    find "$REPO_ROOT" -name "*.bak" -type f -delete || true
+    find "$REPO_ROOT" -name "*.bak_major" -type f -delete || true
     exit 100
   fi
 fi

--- a/.github/workflows/roll-sdk-packages.yml
+++ b/.github/workflows/roll-sdk-packages.yml
@@ -45,7 +45,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           # NB! Keep up-to-date with the flutter version used for development
-          flutter-version: "3.32.5"
+          flutter-version: "3.35.1"
           channel: "stable"
 
       - name: Determine configuration

--- a/app_theme/pubspec.lock
+++ b/app_theme/pubspec.lock
@@ -55,10 +55,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
-  flutter: ">=3.32.5"
+  dart: ">=3.8.1 <4.0.0"
+  flutter: ">=3.35.1"

--- a/app_theme/pubspec.yaml
+++ b/app_theme/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.1
 # homepage:
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
-  flutter: ^3.32.5
+  sdk: ">=3.8.1 <4.0.0"
+  flutter: ">=3.35.1 <4.0.0"
 
 dependencies:
   flutter:

--- a/docs/FLUTTER_VERSION.md
+++ b/docs/FLUTTER_VERSION.md
@@ -2,7 +2,7 @@
 
 ## Supported Flutter Version
 
-This project supports Flutter `3.32.5` (latest stable release). We aim to keep the project up-to-date with the most recent stable Flutter versions.
+This project supports Flutter `3.35.1` (latest stable release). We aim to keep the project up-to-date with the most recent stable Flutter versions.
 
 ## Recommended Approach: Multiple Flutter Versions
 
@@ -15,14 +15,14 @@ See our guide on [Multiple Flutter Versions](MULTIPLE_FLUTTER_VERSIONS.md) for d
 While it's possible to pin your global Flutter installation to a specific version, **this approach is not recommended** due to:
 
 - Lack of isolation between projects
-- Known issues with `flutter pub get` when using Flutter 3.32.5
+- Known issues with `flutter pub get` when using Flutter 3.35.1
 - Difficulty switching between versions for different projects
 
 If you still choose to use this method, you can run:
 
 ```bash
 cd ~/flutter
-git checkout 3.32.5
+git checkout 3.35.1
 flutter doctor
 ```
 

--- a/docs/MULTIPLE_FLUTTER_VERSIONS.md
+++ b/docs/MULTIPLE_FLUTTER_VERSIONS.md
@@ -57,11 +57,12 @@ sudo pacman -R flutter   # for Arch
 
 2. Launch Flutter Sidekick
 
-3. Click on "Versions" in the sidebar and download Flutter version `3.32.5`
+3. Click on "Versions" in the sidebar and download Flutter version `3.35.1`
 
 4. Set this version as the global default by clicking the "Set as Global" button
 
 5. Add Flutter to your PATH:
+
    - Click on "Settings" in the sidebar
    - Find the path to the FVM installation directory (typically `~/.fvm/default/bin` on macOS/Linux or `%LOCALAPPDATA%\fvm\default\bin` on Windows)
    - Add this path to your system's PATH environment variable
@@ -91,11 +92,11 @@ sudo pacman -R flutter   # for Arch
    curl -fsSL https://fvm.app/install.sh | bash
    ```
 
-2. Install and use Flutter 3.32.5:
+2. Install and use Flutter 3.35.1:
 
    ```bash
-   fvm install 3.32.5
-   fvm global 3.32.5
+   fvm install 3.35.1
+   fvm global 3.35.1
    ```
 
 3. Add FVM's default Flutter version to your PATH by adding the following to your `~/.bashrc`, `~/.zshrc`, or equivalent:
@@ -130,14 +131,15 @@ sudo pacman -R flutter   # for Arch
    choco install fvm
    ```
 
-3. Install and use Flutter 3.32.5:
+3. Install and use Flutter 3.35.1:
 
    ```powershell
-   fvm install 3.32.5
-   fvm global 3.32.5
+   fvm install 3.35.1
+   fvm global 3.35.1
    ```
 
 4. Add FVM's Flutter version to your PATH:
+
    - Open "Edit environment variables for your account"
    - Edit the Path variable
    - Add `%LOCALAPPDATA%\fvm\default\bin`
@@ -156,7 +158,7 @@ To use a specific Flutter version for a project:
 2. Run:
 
    ```bash
-   fvm use 3.32.5
+   fvm use 3.35.1
    ```
 
 This will create a `.fvmrc` file in your project, which specifies the Flutter version to use for this project.
@@ -174,7 +176,7 @@ For optimal integration with VS Code:
 
      ```json
      {
-       "dart.flutterSdkPath": ".fvm/flutter_sdk",
+       "dart.flutterSdkPath": ".fvm/flutter_sdk"
        // Or if you're using a global FVM version:
        // "dart.flutterSdkPath": "${userHome}/.fvm/default/bin/flutter"
      }

--- a/docs/SDK_DEPENDENCY_MANAGEMENT.md
+++ b/docs/SDK_DEPENDENCY_MANAGEMENT.md
@@ -77,6 +77,7 @@ For development or testing purposes, you can run the SDK roll script manually on
    - Check the changes in the `pubspec.yaml` and `pubspec.lock` files
 
 5. If you want to commit these changes:
+
    ```bash
    git add **/pubspec.yaml **/pubspec.lock
    git commit -m "chore: roll SDK packages"
@@ -125,9 +126,17 @@ flutter doctor
 
 ## SDK Package Identification
 
-The script identifies SDK packages by looking for packages with names matching those in the `SDK_PACKAGES` array in the script, which refer to external packages from the KomodoPlatform SDK repository. These are typically defined as git dependencies in your `pubspec.yaml` files.
+The script identifies SDK packages by looking for packages with names matching those in the `SDK_PACKAGES` array in the script. These refer to external packages from the KomodoPlatform SDK repository and can be declared in your `pubspec.yaml` files in two ways:
 
-Local packages that are part of this repository (like `komodo_ui_kit` and `komodo_persistence_layer`) are not considered SDK packages and will not be updated by this script unless they depend on SDK packages themselves.
+- Git dependency (Option 2): declared with a `git:` section pointing to the `KomodoPlatform/komodo-defi-sdk-flutter` repository
+- Hosted dependency (Option 3): declared as a standard hosted package on pub.dev with a version constraint (for example, `^0.3.0`)
+
+Local packages that are part of this repository (like `komodo_ui_kit` and `komodo_persistence_layer`) are not considered external SDK packages and will not be updated by this script unless they themselves depend on SDK packages.
+
+When running in SDK-only mode (`UPGRADE_ALL_PACKAGES=false`):
+
+- Hosted SDK dependencies are bumped to the latest available version on pub.dev by executing `flutter pub add <package>`, which updates the version constraint in `pubspec.yaml` and refreshes the lockfile.
+- Git-based SDK dependencies are refreshed with `flutter pub upgrade --unlock-transitive <packages>` to update the lockfile according to the configured `ref`.
 
 ## Error Handling
 

--- a/packages/komodo_persistence_layer/pubspec.yaml
+++ b/packages/komodo_persistence_layer/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
+  sdk: ">=3.8.1 <4.0.0"
 
 # Add regular dependencies here.
 dependencies:

--- a/packages/komodo_ui_kit/pubspec.lock
+++ b/packages/komodo_ui_kit/pubspec.lock
@@ -102,26 +102,26 @@ packages:
     dependency: transitive
     description:
       name: komodo_defi_rpc_methods
-      sha256: d8910f43f456e9c88d828489dff6111816f036a3dd5fc93b1986c6f71d78a525
+      sha256: "7ca9953e29ded777e2b335841940c440fb3313a0b0fe7038a90f895d2709f45a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0+1"
+    version: "0.3.1+1"
   komodo_defi_types:
     dependency: "direct main"
     description:
       name: komodo_defi_types
-      sha256: dff90bef918d7309f1f524e52b0c10d5ca96cb67c1c9df8f071c8de7e8aa7628
+      sha256: "69b1076abca0451d260c66650f7d32d1a6605d5443a6e38300ba81bff5a5db04"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0+2"
+    version: "0.3.2+1"
   komodo_ui:
     dependency: "direct main"
     description:
       name: komodo_ui
-      sha256: "4ec10c5fe64cb65ce583abd35eadb0fccfce2b0ba9d6ba8bcb87c01baa7d6776"
+      sha256: "2ced7a730c396718725195d81065086a86f6a41bce1bb57ad986c27e030d15e6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0+1"
+    version: "0.3.0+3"
   lints:
     dependency: transitive
     description:
@@ -130,6 +130,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   material_color_utilities:
     dependency: transitive
     description:

--- a/packages/komodo_ui_kit/pubspec.lock
+++ b/packages/komodo_ui_kit/pubspec.lock
@@ -83,7 +83,7 @@ packages:
     source: hosted
     version: "3.1.0"
   intl:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: intl
       sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
@@ -101,30 +101,27 @@ packages:
   komodo_defi_rpc_methods:
     dependency: transitive
     description:
-      path: "packages/komodo_defi_rpc_methods"
-      ref: dev
-      resolved-ref: d5b5c38da93e62f59bffb8e6b3e1e7ceb3fb91d5
-      url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
-    source: git
-    version: "0.3.0+0"
+      name: komodo_defi_rpc_methods
+      sha256: d8910f43f456e9c88d828489dff6111816f036a3dd5fc93b1986c6f71d78a525
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0+1"
   komodo_defi_types:
     dependency: "direct main"
     description:
-      path: "packages/komodo_defi_types"
-      ref: dev
-      resolved-ref: d5b5c38da93e62f59bffb8e6b3e1e7ceb3fb91d5
-      url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
-    source: git
-    version: "0.3.0+0"
+      name: komodo_defi_types
+      sha256: dff90bef918d7309f1f524e52b0c10d5ca96cb67c1c9df8f071c8de7e8aa7628
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0+2"
   komodo_ui:
     dependency: "direct main"
     description:
-      path: "packages/komodo_ui"
-      ref: dev
-      resolved-ref: d5b5c38da93e62f59bffb8e6b3e1e7ceb3fb91d5
-      url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
-    source: git
-    version: "0.3.0+0"
+      name: komodo_ui
+      sha256: "4ec10c5fe64cb65ce583abd35eadb0fccfce2b0ba9d6ba8bcb87c01baa7d6776"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0+1"
   lints:
     dependency: transitive
     description:
@@ -198,10 +195,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   web:
     dependency: transitive
     description:
@@ -211,5 +208,5 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.32.5"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.1"

--- a/packages/komodo_ui_kit/pubspec.yaml
+++ b/packages/komodo_ui_kit/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
     #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
     #   path: packages/komodo_defi_types
     #   ref: dev
-    ^0.3.0 # Option 3: Pub.dev dependency
+    ^0.3.2+1 # Option 3: Pub.dev dependency
 
   komodo_ui:
     # path: ../../sdk/packages/komodo_ui # Option 1: Local directory. Requires symlink to the SDK in the root of the project
@@ -26,7 +26,7 @@ dependencies:
     #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
     #   path: packages/komodo_ui
     #   ref: dev
-    ^0.3.0 # Option 3: Pub.dev dependency
+    ^0.3.0+3 # Option 3: Pub.dev dependency
 
 dev_dependencies:
   flutter_lints: ^5.0.0 # flutter.dev

--- a/packages/komodo_ui_kit/pubspec.yaml
+++ b/packages/komodo_ui_kit/pubspec.yaml
@@ -13,17 +13,20 @@ dependencies:
     path: ../../app_theme/
 
   komodo_defi_types:
-    git:
-      url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
-      path: packages/komodo_defi_types
-      ref: dev
+    # path: ../../sdk/packages/komodo_defi_types # Option 1: Local directory. Requires symlink to the SDK in the root of the project
+    # git: # Option 2: Git dependency
+    #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
+    #   path: packages/komodo_defi_types
+    #   ref: dev
+    ^0.3.0 # Option 3: Pub.dev dependency
 
   komodo_ui:
-    # path: ../../sdk/packages/komodo_ui # Requires symlink to the SDK in the root of the project
-    git:
-      url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
-      path: packages/komodo_ui
-      ref: dev
+    # path: ../../sdk/packages/komodo_ui # Option 1: Local directory. Requires symlink to the SDK in the root of the project
+    # git: # Option 2: Git dependency
+    #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
+    #   path: packages/komodo_ui
+    #   ref: dev
+    ^0.3.0 # Option 3: Pub.dev dependency
 
 dev_dependencies:
   flutter_lints: ^5.0.0 # flutter.dev

--- a/packages/komodo_ui_kit/pubspec.yaml
+++ b/packages/komodo_ui_kit/pubspec.yaml
@@ -3,18 +3,16 @@ description: Komodo Wallet's UI Kit Flutter package.
 publish_to: none
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
-  flutter: ^3.32.5
+  sdk: ">=3.8.1 <4.0.0"
+  flutter: ">=3.35.1 <4.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.20.2 # flutter.dev
   app_theme:
     path: ../../app_theme/
 
   komodo_defi_types:
-    # path: ../../sdk/packages/komodo_defi_types # Requires symlink to the SDK in the root of the project
     git:
       url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
       path: packages/komodo_defi_types

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -188,10 +188,10 @@ packages:
     dependency: "direct main"
     description:
       name: dragon_logs
-      sha256: e697f25bd0f27b0b85af42aff7f55f003fe045c0e3eeda6164bf97aab1525804
+      sha256: e7ef209485f2fd1f267b01773d3ab5018ee2129aa70c37892f87c863dcac8043
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0+1"
   easy_localization:
     dependency: "direct main"
     description:
@@ -264,14 +264,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.1.2"
-  file_system_access_api:
-    dependency: transitive
-    description:
-      name: file_system_access_api
-      sha256: c961c5020ab4e5f05200dbdd9809c5256c3dc4a1fe5746ca7d8cf8e8cc11c47d
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.0"
   firebase_analytics:
     dependency: "direct main"
     description:
@@ -654,75 +646,67 @@ packages:
   komodo_cex_market_data:
     dependency: "direct main"
     description:
-      path: "packages/komodo_cex_market_data"
-      ref: dev
-      resolved-ref: d5b5c38da93e62f59bffb8e6b3e1e7ceb3fb91d5
-      url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
-    source: git
-    version: "0.0.1"
+      name: komodo_cex_market_data
+      sha256: c4a1dd6cc734b58328b93c58147c7ba022285205150115c0a7f861d9cc6a12ef
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2+1"
   komodo_coin_updates:
     dependency: transitive
     description:
-      path: "packages/komodo_coin_updates"
-      ref: dev
-      resolved-ref: d5b5c38da93e62f59bffb8e6b3e1e7ceb3fb91d5
-      url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
-    source: git
-    version: "1.0.0"
+      name: komodo_coin_updates
+      sha256: "092814ca1f44106a6a38cea22d68fda1df06467960772dc2aef9a23d2dbedc84"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   komodo_coins:
     dependency: transitive
     description:
-      path: "packages/komodo_coins"
-      ref: dev
-      resolved-ref: d5b5c38da93e62f59bffb8e6b3e1e7ceb3fb91d5
-      url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
-    source: git
-    version: "0.3.0+0"
+      name: komodo_coins
+      sha256: "237cb4fae02634f41576a1f5cc08130dc5b58c5f95c9a53cd747cc9b849b0e4b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0+1"
   komodo_defi_framework:
     dependency: transitive
     description:
-      path: "packages/komodo_defi_framework"
-      ref: dev
-      resolved-ref: d5b5c38da93e62f59bffb8e6b3e1e7ceb3fb91d5
-      url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
-    source: git
-    version: "0.3.0+0"
+      name: komodo_defi_framework
+      sha256: "1419add64e8049b7717c18a944bc58dfae5039315e1abef1a4fd6b8a70d0cbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0+1"
   komodo_defi_local_auth:
     dependency: transitive
     description:
-      path: "packages/komodo_defi_local_auth"
-      ref: dev
-      resolved-ref: d5b5c38da93e62f59bffb8e6b3e1e7ceb3fb91d5
-      url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
-    source: git
-    version: "0.3.0+0"
+      name: komodo_defi_local_auth
+      sha256: "0ccce6e31a6577e571d77704e1b6c628186e3bf86d64ec129ae88ace909a94b3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0+1"
   komodo_defi_rpc_methods:
     dependency: transitive
     description:
-      path: "packages/komodo_defi_rpc_methods"
-      ref: dev
-      resolved-ref: d5b5c38da93e62f59bffb8e6b3e1e7ceb3fb91d5
-      url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
-    source: git
-    version: "0.3.0+0"
+      name: komodo_defi_rpc_methods
+      sha256: d8910f43f456e9c88d828489dff6111816f036a3dd5fc93b1986c6f71d78a525
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0+1"
   komodo_defi_sdk:
     dependency: "direct main"
     description:
-      path: "packages/komodo_defi_sdk"
-      ref: dev
-      resolved-ref: d5b5c38da93e62f59bffb8e6b3e1e7ceb3fb91d5
-      url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
-    source: git
-    version: "0.3.0+0"
+      name: komodo_defi_sdk
+      sha256: "0fcf055e3b8dc0f8b93895ca7f527f5feb9deb883691e12271cc1da2eaa325a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0+1"
   komodo_defi_types:
     dependency: "direct main"
     description:
-      path: "packages/komodo_defi_types"
-      ref: dev
-      resolved-ref: d5b5c38da93e62f59bffb8e6b3e1e7ceb3fb91d5
-      url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
-    source: git
-    version: "0.3.0+0"
+      name: komodo_defi_types
+      sha256: dff90bef918d7309f1f524e52b0c10d5ca96cb67c1c9df8f071c8de7e8aa7628
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0+2"
   komodo_persistence_layer:
     dependency: "direct main"
     description:
@@ -733,12 +717,11 @@ packages:
   komodo_ui:
     dependency: "direct main"
     description:
-      path: "packages/komodo_ui"
-      ref: dev
-      resolved-ref: d5b5c38da93e62f59bffb8e6b3e1e7ceb3fb91d5
-      url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
-    source: git
-    version: "0.3.0+0"
+      name: komodo_ui
+      sha256: "4ec10c5fe64cb65ce583abd35eadb0fccfce2b0ba9d6ba8bcb87c01baa7d6776"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0+1"
   komodo_ui_kit:
     dependency: "direct main"
     description:
@@ -749,36 +732,35 @@ packages:
   komodo_wallet_build_transformer:
     dependency: transitive
     description:
-      path: "packages/komodo_wallet_build_transformer"
-      ref: dev
-      resolved-ref: d5b5c38da93e62f59bffb8e6b3e1e7ceb3fb91d5
-      url: "https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git"
-    source: git
-    version: "0.3.0+0"
+      name: komodo_wallet_build_transformer
+      sha256: e729dd905d317e0151edfffcf8242f88fe14a24a2cd986cd4a635ad9d241b52b
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0+1"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.1"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -1284,26 +1266,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
+      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.15"
+    version: "1.26.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.8"
+    version: "0.6.11"
   typed_data:
     dependency: transitive
     description:
@@ -1428,18 +1410,18 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   very_good_analysis:
     dependency: transitive
     description:
       name: very_good_analysis
-      sha256: c529563be4cbba1137386f2720fb7ed69e942012a28b13398d8a5e3e6ef551a7
+      sha256: e479fbc0941009262343db308133e121bf8660c2c81d48dd8e952df7b7e1e382
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "9.0.0"
   video_player:
     dependency: "direct main"
     description:
@@ -1578,5 +1560,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.1 <4.0.0"
-  flutter: ">=3.32.5"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -180,10 +180,10 @@ packages:
     dependency: "direct main"
     description:
       name: dragon_charts_flutter
-      sha256: "663e73aeae425ec503942bde4ea40caa665c82250e760d20a1df2b89a16ffb3c"
+      sha256: a55562f94a54a8e329075a88be7578d1b22d4996b869440978f9cdbb62782739
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1-dev.1"
+    version: "0.1.1-dev.3"
   dragon_logs:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -188,10 +188,10 @@ packages:
     dependency: "direct main"
     description:
       name: dragon_logs
-      sha256: e7ef209485f2fd1f267b01773d3ab5018ee2129aa70c37892f87c863dcac8043
+      sha256: "42794f6cda139b00b4c964b1ed7e4d8649238af3049df065bbfedc42f953f7fa"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0+1"
+    version: "2.0.0"
   easy_localization:
     dependency: "direct main"
     description:
@@ -566,6 +566,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
+  hive_ce:
+    dependency: transitive
+    description:
+      name: hive_ce
+      sha256: "708bb39050998707c5d422752159f91944d3c81ab42d80e1bd0ee37d8e130658"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.3"
+  hive_ce_flutter:
+    dependency: transitive
+    description:
+      name: hive_ce_flutter
+      sha256: a0989670652eab097b47544f1e5a4456e861b1b01b050098ea0b80a5fabe9909
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
   hive_flutter:
     dependency: "direct main"
     description:
@@ -627,6 +643,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  isolate_channel:
+    dependency: transitive
+    description:
+      name: isolate_channel
+      sha256: f3d36f783b301e6b312c3450eeb2656b0e7d1db81331af2a151d9083a3f6b18d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2+1"
   js:
     dependency: "direct main"
     description:
@@ -647,66 +671,66 @@ packages:
     dependency: "direct main"
     description:
       name: komodo_cex_market_data
-      sha256: c4a1dd6cc734b58328b93c58147c7ba022285205150115c0a7f861d9cc6a12ef
+      sha256: f4c541d37d44fc53c36a300a83866ee3c696c1d6e0084b612d86234e0f5063c4
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.2+1"
+    version: "0.0.3+1"
   komodo_coin_updates:
     dependency: transitive
     description:
       name: komodo_coin_updates
-      sha256: "092814ca1f44106a6a38cea22d68fda1df06467960772dc2aef9a23d2dbedc84"
+      sha256: "029843316ba5841601a3051a59bd13685b132b163a8ec8c07001fba1345a1f8c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.1"
   komodo_coins:
     dependency: transitive
     description:
       name: komodo_coins
-      sha256: "237cb4fae02634f41576a1f5cc08130dc5b58c5f95c9a53cd747cc9b849b0e4b"
+      sha256: "1e5c4122a25351c3ae59f2cc35366b5362537eb72b75ade68d86ff3f5baac493"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0+1"
+    version: "0.3.1+2"
   komodo_defi_framework:
     dependency: transitive
     description:
       name: komodo_defi_framework
-      sha256: "1419add64e8049b7717c18a944bc58dfae5039315e1abef1a4fd6b8a70d0cbcd"
+      sha256: "791844cbab8e19e48f6d351e80b5b90838aad5ed0b9598b828fb86dd12fc7f58"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0+1"
+    version: "0.3.1+2"
   komodo_defi_local_auth:
     dependency: transitive
     description:
       name: komodo_defi_local_auth
-      sha256: "0ccce6e31a6577e571d77704e1b6c628186e3bf86d64ec129ae88ace909a94b3"
+      sha256: becd422c6c0d63ed8db298a24856866d57fb6099125f3dea74f3bdf3aafb7aee
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0+1"
+    version: "0.3.1+2"
   komodo_defi_rpc_methods:
     dependency: transitive
     description:
       name: komodo_defi_rpc_methods
-      sha256: d8910f43f456e9c88d828489dff6111816f036a3dd5fc93b1986c6f71d78a525
+      sha256: "7ca9953e29ded777e2b335841940c440fb3313a0b0fe7038a90f895d2709f45a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0+1"
+    version: "0.3.1+1"
   komodo_defi_sdk:
     dependency: "direct main"
     description:
       name: komodo_defi_sdk
-      sha256: "0fcf055e3b8dc0f8b93895ca7f527f5feb9deb883691e12271cc1da2eaa325a0"
+      sha256: "26c0ec50657def4aa26cfb4c9ea30a6f90df51c502c94031050a61a5201bc0e6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0+1"
+    version: "0.4.0+3"
   komodo_defi_types:
     dependency: "direct main"
     description:
       name: komodo_defi_types
-      sha256: dff90bef918d7309f1f524e52b0c10d5ca96cb67c1c9df8f071c8de7e8aa7628
+      sha256: "69b1076abca0451d260c66650f7d32d1a6605d5443a6e38300ba81bff5a5db04"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0+2"
+    version: "0.3.2+1"
   komodo_persistence_layer:
     dependency: "direct main"
     description:
@@ -718,10 +742,10 @@ packages:
     dependency: "direct main"
     description:
       name: komodo_ui
-      sha256: "4ec10c5fe64cb65ce583abd35eadb0fccfce2b0ba9d6ba8bcb87c01baa7d6776"
+      sha256: "2ced7a730c396718725195d81065086a86f6a41bce1bb57ad986c27e030d15e6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0+1"
+    version: "0.3.0+3"
   komodo_ui_kit:
     dependency: "direct main"
     description:
@@ -733,10 +757,10 @@ packages:
     dependency: transitive
     description:
       name: komodo_wallet_build_transformer
-      sha256: e729dd905d317e0151edfffcf8242f88fe14a24a2cd986cd4a635ad9d241b52b
+      sha256: "6bc264119d55b0c64706307f4b346dd059af6868b084241493fff0a7605624f6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0+1"
+    version: "0.4.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -1077,18 +1101,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      sha256: d7dc0630a923883c6328ca31b89aa682bacbf2f8304162d29f7c6aaff03a27a1
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.4"
+    version: "11.1.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "6.1.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1414,14 +1438,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  very_good_analysis:
-    dependency: transitive
-    description:
-      name: very_good_analysis
-      sha256: e479fbc0941009262343db308133e121bf8660c2c81d48dd8e952df7b7e1e382
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.0.0"
   video_player:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: web_dex # Use `lowercase_with_underscores` for package names
-description: komodo atomicDEX web wallet
+description: Komodo Wallet
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `pub publish`. This is preferred for private packages.
@@ -41,20 +41,23 @@ dependencies:
   komodo_persistence_layer:
     path: packages/komodo_persistence_layer
 
-  komodo_cex_market_data:
-    # path: sdk/packages/komodo_cex_market_data # Requires symlink to the SDK in the root of the project
-    git:
-      url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
-      path: packages/komodo_cex_market_data
-      ref: dev
-
   ## ---- KomodoPlatform pub.dev packages (First-party)
 
+  komodo_cex_market_data:
+    # path: sdk/packages/komodo_cex_market_data # Option 1: Local directory. Requires symlink to the SDK in the root of the project
+    # git: # Option 2: Git dependency
+    #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
+    #   path: packages/komodo_cex_market_data
+    #   ref: dev
+    ^0.0.2 # Option 3: Pub.dev dependency
+
   dragon_logs:
-    git:
-      url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
-      path: packages/dragon_logs
-      ref: dev
+    # path: sdk/packages/dragon_logs # Option 1: Local directory. Requires symlink to the SDK in the root of the project
+    # git: # Option 2: Git dependency
+    #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
+    #   path: packages/dragon_logs
+    #   ref: dev
+    ^1.2.0+1 # Option 3: Pub.dev dependency
 
   ## ---- Dart.dev, Flutter.dev
   args: ^2.7.0 # dart.dev
@@ -130,10 +133,12 @@ dependencies:
 
   # TODO: review required
   dragon_charts_flutter:
-    git:
-      url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
-      path: packages/dragon_charts_flutter
-      ref: dev
+    # path: sdk/packages/dragon_charts_flutter # Option 1: Local directory. Requires symlink to the SDK in the root of the project
+    # git: # Option 2: Git dependency
+    #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
+    #   path: packages/dragon_charts_flutter
+    #   ref: dev
+    ^0.1.1-dev.1 # Option 3: Pub.dev dependency
 
   bloc_concurrency: 0.3.0
   file_picker: ^10.0.0
@@ -146,26 +151,31 @@ dependencies:
   uuid: 4.5.1 # sdk depends on this version
   flutter_bloc: ^9.1.0 # sdk depends on this version, and hosted instead of git reference
   get_it: ^8.0.3 # sdk depends on this version, and hosted instead of git reference
-  komodo_defi_sdk: # TODO: change to pub.dev version?
-    # path: sdk/packages/komodo_defi_sdk # Requires symlink to the SDK in the root of the project
-    git:
-      url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
-      path: packages/komodo_defi_sdk
-      ref: dev
+
+  komodo_defi_sdk:
+    # path: sdk/packages/komodo_defi_sdk # Option 1: Local directory. Requires symlink to the SDK in the root of the project
+    # git: # Option 2: Git dependency
+    #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
+    #   path: packages/komodo_defi_sdk
+    #   ref: dev
+    ^0.3.0 # Option 3: Pub.dev dependency
 
   komodo_defi_types:
-    # path: sdk/packages/komodo_defi_types # Requires symlink to the SDK in the root of the project
-    git:
-      url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
-      path: packages/komodo_defi_types
-      ref: dev
+    # path: sdk/packages/komodo_defi_types # Option 1: Local directory. Requires symlink to the SDK in the root of the project
+    # git: # Option 2: Git dependency
+    #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
+    #   path: packages/komodo_defi_types
+    #   ref: dev
+    ^0.3.0 # Option 3: Pub.dev dependency
 
   komodo_ui:
-    # path: sdk/packages/komodo_ui # Requires symlink to the SDK in the root of the project
-    git:
-      url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
-      path: packages/komodo_ui
-      ref: dev
+    # path: sdk/packages/komodo_ui # Option 1: Local directory. Requires symlink to the SDK in the root of the project
+    # git: # Option 2: Git dependency
+    #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
+    #   path: packages/komodo_ui
+    #   ref: dev
+    ^0.3.0 # Option 3: Pub.dev dependency
+
   feedback: ^3.1.0
   ntp: ^2.0.0
   flutter_window_close: ^1.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
     #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
     #   path: packages/komodo_cex_market_data
     #   ref: dev
-    ^0.0.2 # Option 3: Pub.dev dependency
+    ^0.0.2+1 # Option 3: Pub.dev dependency
 
   dragon_logs:
     # path: sdk/packages/dragon_logs # Option 1: Local directory. Requires symlink to the SDK in the root of the project
@@ -138,7 +138,7 @@ dependencies:
     #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
     #   path: packages/dragon_charts_flutter
     #   ref: dev
-    ^0.1.1-dev.1 # Option 3: Pub.dev dependency
+    ^0.1.1-dev.3 # Option 3: Pub.dev dependency
 
   bloc_concurrency: 0.3.0
   file_picker: ^10.0.0
@@ -158,7 +158,7 @@ dependencies:
     #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
     #   path: packages/komodo_defi_sdk
     #   ref: dev
-    ^0.3.0 # Option 3: Pub.dev dependency
+    ^0.3.0+1 # Option 3: Pub.dev dependency
 
   komodo_defi_types:
     # path: sdk/packages/komodo_defi_types # Option 1: Local directory. Requires symlink to the SDK in the root of the project
@@ -166,7 +166,7 @@ dependencies:
     #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
     #   path: packages/komodo_defi_types
     #   ref: dev
-    ^0.3.0 # Option 3: Pub.dev dependency
+    ^0.3.0+2 # Option 3: Pub.dev dependency
 
   komodo_ui:
     # path: sdk/packages/komodo_ui # Option 1: Local directory. Requires symlink to the SDK in the root of the project
@@ -174,7 +174,7 @@ dependencies:
     #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
     #   path: packages/komodo_ui
     #   ref: dev
-    ^0.3.0 # Option 3: Pub.dev dependency
+    ^0.3.0+1 # Option 3: Pub.dev dependency
 
   feedback: ^3.1.0
   ntp: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,8 +18,8 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 0.9.2+0
 
 environment:
-  sdk: ^3.8.1
-  flutter: ^3.32.5
+  sdk: ">=3.8.1 <4.0.0"
+  flutter: ">=3.35.1 <4.0.0"
 
 dependencies:
   ## ---- Flutter SDK
@@ -50,7 +50,11 @@ dependencies:
 
   ## ---- KomodoPlatform pub.dev packages (First-party)
 
-  dragon_logs: 1.1.0
+  dragon_logs:
+    git:
+      url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
+      path: packages/dragon_logs
+      ref: dev
 
   ## ---- Dart.dev, Flutter.dev
   args: ^2.7.0 # dart.dev
@@ -125,7 +129,12 @@ dependencies:
   formz: 0.8.0
 
   # TODO: review required
-  dragon_charts_flutter: 0.1.1-dev.1
+  dragon_charts_flutter:
+    git:
+      url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
+      path: packages/dragon_charts_flutter
+      ref: dev
+
   bloc_concurrency: 0.3.0
   file_picker: ^10.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
     #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
     #   path: packages/komodo_cex_market_data
     #   ref: dev
-    ^0.0.2+1 # Option 3: Pub.dev dependency
+    ^0.0.3+1 # Option 3: Pub.dev dependency
 
   dragon_logs:
     # path: sdk/packages/dragon_logs # Option 1: Local directory. Requires symlink to the SDK in the root of the project
@@ -57,7 +57,7 @@ dependencies:
     #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
     #   path: packages/dragon_logs
     #   ref: dev
-    ^1.2.0+1 # Option 3: Pub.dev dependency
+    ^2.0.0 # Option 3: Pub.dev dependency
 
   ## ---- Dart.dev, Flutter.dev
   args: ^2.7.0 # dart.dev
@@ -96,7 +96,7 @@ dependencies:
   package_info_plus: 8.3.0
 
   # Approved via https://github.com/KomodoPlatform/komodo-wallet/pull/1106 (Outdated)
-  share_plus: 10.1.4
+  share_plus: 11.1.0
 
   ## ---- 3d party
 
@@ -158,7 +158,7 @@ dependencies:
     #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
     #   path: packages/komodo_defi_sdk
     #   ref: dev
-    ^0.3.0+1 # Option 3: Pub.dev dependency
+    ^0.4.0+3 # Option 3: Pub.dev dependency
 
   komodo_defi_types:
     # path: sdk/packages/komodo_defi_types # Option 1: Local directory. Requires symlink to the SDK in the root of the project
@@ -166,7 +166,7 @@ dependencies:
     #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
     #   path: packages/komodo_defi_types
     #   ref: dev
-    ^0.3.0+2 # Option 3: Pub.dev dependency
+    ^0.3.2+1 # Option 3: Pub.dev dependency
 
   komodo_ui:
     # path: sdk/packages/komodo_ui # Option 1: Local directory. Requires symlink to the SDK in the root of the project
@@ -174,7 +174,7 @@ dependencies:
     #   url: https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
     #   path: packages/komodo_ui
     #   ref: dev
-    ^0.3.0+1 # Option 3: Pub.dev dependency
+    ^0.3.0+3 # Option 3: Pub.dev dependency
 
   feedback: ^3.1.0
   ntp: ^2.0.0


### PR DESCRIPTION
Overview

- Upgrade Flutter to 3.35.1
- Roll SDK deps to pub.dev hosted; update pubspecs/locks
- Enhance .github/scripts/roll_sdk_packages.sh: CLI flags, --major-sdk-only, preserve pubspec structure, clean *.bak files
- Update docs: FLUTTER_VERSION.md, MULTIPLE_FLUTTER_VERSIONS.md, SDK_DEPENDENCY_MANAGEMENT.md
- Update CI/workflows and devcontainer
- Add .cursorignore

Diff stats
- 15 files changed, 467 insertions(+), 224 deletions(-)

Validation
- Run: flutter pub get; flutter analyze; flutter test
- CI should pass with Flutter 3.35.1

Notes
- No runtime Dart code changes; low risk
