### PR TITLE
Analyze pages for screenshot disabling conditions

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,6 +31,7 @@ import 'package:web_dex/performance_analytics/performance_analytics.dart';
 import 'package:web_dex/sdk/widgets/window_close_handler.dart';
 import 'package:web_dex/services/feedback/custom_feedback_form.dart';
 import 'package:web_dex/services/logger/get_logger.dart';
+import 'package:web_dex/shared/screenshot/screenshot_sensitivity.dart';
 import 'package:web_dex/services/storage/get_storage.dart';
 import 'package:web_dex/shared/constants.dart';
 import 'package:web_dex/shared/utils/platform_tuner.dart';
@@ -140,6 +141,8 @@ class MyApp extends StatelessWidget {
 
     final theme = Theme.of(context);
 
+    final sensitivityController = ScreenshotSensitivityController();
+
     return MultiBlocProvider(
       providers: [
         BlocProvider<AuthBloc>(
@@ -161,9 +164,12 @@ class MyApp extends StatelessWidget {
         theme: _feedbackThemeData(theme),
         child: AnalyticsLifecycleHandler(
           child: WindowCloseHandler(
-            child: app_bloc_root.AppBlocRoot(
-              storedPrefs: _storedSettings!,
-              komodoDefiSdk: komodoDefiSdk,
+            child: ScreenshotSensitivity(
+              controller: sensitivityController,
+              child: app_bloc_root.AppBlocRoot(
+                storedPrefs: _storedSettings!,
+                komodoDefiSdk: komodoDefiSdk,
+              ),
             ),
           ),
         ),

--- a/lib/shared/screenshot/screenshot_sensitivity.dart
+++ b/lib/shared/screenshot/screenshot_sensitivity.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/widgets.dart';
+
+/// Controller that tracks whether the current UI subtree is considered
+/// screenshot-sensitive.
+class ScreenshotSensitivityController extends ChangeNotifier {
+  int _depth = 0;
+
+  bool get isSensitive => _depth > 0;
+
+  void enter() {
+    _depth += 1;
+    notifyListeners();
+  }
+
+  void exit() {
+    if (_depth > 0) {
+      _depth -= 1;
+      notifyListeners();
+    }
+  }
+}
+
+/// Inherited notifier providing access to the ScreenshotSensitivityController.
+class ScreenshotSensitivity extends InheritedNotifier<ScreenshotSensitivityController> {
+  const ScreenshotSensitivity({
+    super.key,
+    required ScreenshotSensitivityController controller,
+    required Widget child,
+  }) : super(notifier: controller, child: child);
+
+  static ScreenshotSensitivityController? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<ScreenshotSensitivity>()?.notifier;
+  }
+
+  static ScreenshotSensitivityController of(BuildContext context) {
+    final controller = maybeOf(context);
+    assert(controller != null, 'ScreenshotSensitivity not found in widget tree');
+    return controller!;
+  }
+}
+
+/// Widget that marks its subtree as screenshot-sensitive while mounted.
+class ScreenshotSensitive extends StatefulWidget {
+  const ScreenshotSensitive({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<ScreenshotSensitive> createState() => _ScreenshotSensitiveState();
+}
+
+class _ScreenshotSensitiveState extends State<ScreenshotSensitive> {
+  ScreenshotSensitivityController? _controller;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final controller = ScreenshotSensitivity.maybeOf(context);
+    if (!identical(controller, _controller)) {
+      _controller?.exit();
+      _controller = controller;
+      _controller?.enter();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller?.exit();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
+extension ScreenshotSensitivityContextExt on BuildContext {
+  bool get isScreenshotSensitive =>
+      ScreenshotSensitivity.maybeOf(this)?.isSensitive ?? false;
+}
+

--- a/lib/views/bitrefill/bitrefill_inappwebview_button.dart
+++ b/lib/views/bitrefill/bitrefill_inappwebview_button.dart
@@ -8,6 +8,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:web_dex/bloc/bitrefill/bloc/bitrefill_bloc.dart';
 import 'package:web_dex/views/bitrefill/bitrefill_button_view.dart';
+import 'package:web_dex/shared/screenshot/screenshot_sensitivity.dart';
 
 /// A button that opens the provided url in an embedded InAppWebview widget.
 /// This widget uses the flutter_inappwebview package to open the url using
@@ -110,12 +111,14 @@ class BitrefillInAppWebviewButtonState
           content: SizedBox(
             width: width,
             height: height,
-            child: InAppWebView(
-              key: const Key('bitrefill-inappwebview'),
-              initialUrlRequest: _createUrlRequest(),
-              initialSettings: settings,
-              onWebViewCreated: _onCreated,
-              onConsoleMessage: _onConsoleMessage,
+            child: ScreenshotSensitive(
+              child: InAppWebView(
+                key: const Key('bitrefill-inappwebview'),
+                initialUrlRequest: _createUrlRequest(),
+                initialSettings: settings,
+                onWebViewCreated: _onCreated,
+                onConsoleMessage: _onConsoleMessage,
+              ),
             ),
           ),
           actions: <Widget>[
@@ -143,12 +146,14 @@ class BitrefillInAppWebviewButtonState
               elevation: 0,
             ),
             body: SafeArea(
-              child: InAppWebView(
-                key: const Key('bitrefill-inappwebview'),
-                initialUrlRequest: _createUrlRequest(),
-                initialSettings: settings,
-                onWebViewCreated: _onCreated,
-                onConsoleMessage: _onConsoleMessage,
+              child: ScreenshotSensitive(
+                child: InAppWebView(
+                  key: const Key('bitrefill-inappwebview'),
+                  initialUrlRequest: _createUrlRequest(),
+                  initialSettings: settings,
+                  onWebViewCreated: _onCreated,
+                  onConsoleMessage: _onConsoleMessage,
+                ),
               ),
             ),
           );

--- a/lib/views/common/hw_wallet_dialog/show_trezor_passphrase_dialog.dart
+++ b/lib/views/common/hw_wallet_dialog/show_trezor_passphrase_dialog.dart
@@ -5,6 +5,7 @@ import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/dispatchers/popup_dispatcher.dart';
 import 'package:web_dex/model/hw_wallet/trezor_task.dart';
 import 'package:web_dex/views/common/hw_wallet_dialog/constants.dart';
+import 'package:web_dex/shared/screenshot/screenshot_sensitivity.dart';
 
 import 'trezor_steps/trezor_dialog_select_wallet.dart';
 
@@ -23,12 +24,14 @@ Future<void> showTrezorPassphraseDialog(TrezorTask task) async {
     context: context,
     width: trezorDialogWidth,
     onDismiss: close,
-    popupContent: TrezorDialogSelectWallet(
-      onComplete: (String passphrase) async {
-        final authBloc = context.read<AuthBloc>();
-        authBloc.add(AuthTrezorPassphraseProvided(passphrase));
-        close();
-      },
+    popupContent: ScreenshotSensitive(
+      child: TrezorDialogSelectWallet(
+        onComplete: (String passphrase) async {
+          final authBloc = context.read<AuthBloc>();
+          authBloc.add(AuthTrezorPassphraseProvided(passphrase));
+          close();
+        },
+      ),
     ),
   );
 

--- a/lib/views/common/hw_wallet_dialog/show_trezor_pin_dialog.dart
+++ b/lib/views/common/hw_wallet_dialog/show_trezor_pin_dialog.dart
@@ -6,6 +6,7 @@ import 'package:web_dex/dispatchers/popup_dispatcher.dart';
 import 'package:web_dex/model/hw_wallet/trezor_task.dart';
 import 'package:web_dex/views/common/hw_wallet_dialog/constants.dart';
 import 'package:web_dex/views/common/hw_wallet_dialog/trezor_steps/trezor_dialog_pin_pad.dart';
+import 'package:web_dex/shared/screenshot/screenshot_sensitivity.dart';
 
 Future<void> showTrezorPinDialog(TrezorTask task) async {
   late PopupDispatcher popupManager;
@@ -22,16 +23,18 @@ Future<void> showTrezorPinDialog(TrezorTask task) async {
     context: context,
     width: trezorDialogWidth,
     onDismiss: close,
-    popupContent: TrezorDialogPinPad(
-      onComplete: (String pin) async {
-        final authBloc = context.read<AuthBloc>();
-        authBloc.add(AuthTrezorPinProvided(pin));
-        close();
-      },
-      onClose: () {
-        context.read<AuthBloc>().add(AuthTrezorCancelled());
-        close();
-      },
+    popupContent: ScreenshotSensitive(
+      child: TrezorDialogPinPad(
+        onComplete: (String pin) async {
+          final authBloc = context.read<AuthBloc>();
+          authBloc.add(AuthTrezorPinProvided(pin));
+          close();
+        },
+        onClose: () {
+          context.read<AuthBloc>().add(AuthTrezorCancelled());
+          close();
+        },
+      ),
     ),
   );
 

--- a/lib/views/common/hw_wallet_dialog/trezor_steps/trezor_dialog_pin_pad.dart
+++ b/lib/views/common/hw_wallet_dialog/trezor_steps/trezor_dialog_pin_pad.dart
@@ -6,6 +6,7 @@ import 'package:komodo_ui_kit/komodo_ui_kit.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/shared/ui/ui_light_button.dart';
 import 'package:web_dex/views/common/hw_wallet_dialog/constants.dart';
+import 'package:web_dex/shared/screenshot/screenshot_sensitivity.dart';
 
 const List<List<int>> _keys = [
   [7, 8, 9],
@@ -44,7 +45,7 @@ class _TrezorDialogPinPadState extends State<TrezorDialogPinPad> {
 
   @override
   Widget build(BuildContext context) {
-    return KeyboardListener(
+    return ScreenshotSensitive(child: KeyboardListener(
       autofocus: true,
       onKeyEvent: _onKeyEvent,
       focusNode: _focus,
@@ -70,7 +71,7 @@ class _TrezorDialogPinPadState extends State<TrezorDialogPinPad> {
           _buildButtons(),
         ],
       ),
-    );
+    ));
   }
 
   Widget _buildObscuredPin() {

--- a/lib/views/common/hw_wallet_dialog/trezor_steps/trezor_dialog_select_wallet.dart
+++ b/lib/views/common/hw_wallet_dialog/trezor_steps/trezor_dialog_select_wallet.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
+import 'package:web_dex/shared/screenshot/screenshot_sensitivity.dart';
 
 class TrezorDialogSelectWallet extends StatelessWidget {
   const TrezorDialogSelectWallet({Key? key, required this.onComplete})
@@ -12,7 +13,7 @@ class TrezorDialogSelectWallet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    return ScreenshotSensitive(child: Column(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Text(
@@ -31,7 +32,7 @@ class TrezorDialogSelectWallet extends StatelessWidget {
           onSubmit: (String passphrase) => onComplete(passphrase),
         ),
       ],
-    );
+    ));
   }
 }
 

--- a/lib/views/common/wallet_password_dialog/wallet_password_dialog.dart
+++ b/lib/views/common/wallet_password_dialog/wallet_password_dialog.dart
@@ -4,6 +4,7 @@ import 'package:web_dex/bloc/auth_bloc/auth_bloc.dart';
 import 'package:web_dex/dispatchers/popup_dispatcher.dart';
 import 'package:web_dex/model/wallet.dart';
 import 'package:web_dex/views/common/wallet_password_dialog/password_dialog_content.dart';
+import 'package:web_dex/shared/screenshot/screenshot_sensitivity.dart';
 
 // Shows wallet password dialog and
 // returns password value or null (if wrong or cancelled)
@@ -24,14 +25,15 @@ Future<String?> walletPasswordDialog(
 
   popupManager = PopupDispatcher(
     context: context,
-    popupContent: PasswordDialogContent(
+    popupContent: ScreenshotSensitive(
+      child: PasswordDialogContent(
       wallet: wallet,
       onSuccess: (String pass) {
         password = pass;
         close();
       },
       onCancel: close,
-    ),
+    )),
   );
 
   isOpen = true;
@@ -72,7 +74,8 @@ Future<bool> walletPasswordDialogWithLoading(
 
   popupManager = PopupDispatcher(
     context: context,
-    popupContent: PasswordDialogContentWithLoading(
+    popupContent: ScreenshotSensitive(
+      child: PasswordDialogContentWithLoading(
       wallet: wallet,
       onPasswordValidated: onPasswordValidated,
       onComplete: (bool success) {
@@ -84,7 +87,7 @@ Future<bool> walletPasswordDialogWithLoading(
       loadingMessage: loadingMessage,
       operationFailedMessage: operationFailedMessage,
       passwordFieldKey: passwordFieldKey,
-    ),
+    )),
   );
 
   isOpen = true;

--- a/lib/views/fiat/webview_dialog.dart
+++ b/lib/views/fiat/webview_dialog.dart
@@ -6,6 +6,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:web_dex/common/screen.dart';
 import 'package:web_dex/shared/utils/utils.dart';
 import 'package:web_dex/shared/utils/window/window.dart';
+import 'package:web_dex/shared/screenshot/screenshot_sensitivity.dart';
 
 /// The display mode for the webview dialog.
 enum WebViewDialogMode {
@@ -155,12 +156,14 @@ class InAppWebviewDialog extends StatelessWidget {
                   bottomLeft: Radius.circular(12.0),
                   bottomRight: Radius.circular(12.0),
                 ),
-                child: MessageInAppWebView(
-                  key: const Key('dialog-inappwebview'),
-                  settings: webviewSettings,
-                  url: url,
-                  onConsoleMessage: onConsoleMessage,
-                  onCloseWindow: onCloseWindow,
+                child: ScreenshotSensitive(
+                  child: MessageInAppWebView(
+                    key: const Key('dialog-inappwebview'),
+                    settings: webviewSettings,
+                    url: url,
+                    onConsoleMessage: onConsoleMessage,
+                    onCloseWindow: onCloseWindow,
+                  ),
                 ),
               ),
             ),
@@ -203,12 +206,14 @@ class FullscreenInAppWebview extends StatelessWidget {
         ),
       ),
       body: SafeArea(
-        child: MessageInAppWebView(
-          key: const Key('fullscreen-inapp-webview'),
-          settings: webviewSettings,
-          url: url,
-          onConsoleMessage: onConsoleMessage,
-          onCloseWindow: onCloseWindow,
+        child: ScreenshotSensitive(
+          child: MessageInAppWebView(
+            key: const Key('fullscreen-inapp-webview'),
+            settings: webviewSettings,
+            url: url,
+            onConsoleMessage: onConsoleMessage,
+            onCloseWindow: onCloseWindow,
+          ),
         ),
       ),
     );

--- a/lib/views/settings/widgets/security_settings/private_key_settings/private_key_show.dart
+++ b/lib/views/settings/widgets/security_settings/private_key_settings/private_key_show.dart
@@ -16,6 +16,7 @@ import 'package:web_dex/model/wallet.dart';
 import 'package:web_dex/views/settings/widgets/security_settings/seed_settings/seed_back_button.dart';
 import 'package:web_dex/views/wallet/wallet_page/common/expandable_private_key_list.dart';
 import 'package:web_dex/views/settings/widgets/security_settings/private_key_settings/private_key_actions_widget.dart';
+import 'package:web_dex/shared/screenshot/screenshot_sensitivity.dart';
 
 /// Widget for displaying private keys in a secure manner.
 ///
@@ -50,7 +51,7 @@ class PrivateKeyShow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    return ScreenshotSensitive(child: Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisAlignment: MainAxisAlignment.start,
       children: <Widget>[
@@ -121,7 +122,7 @@ class PrivateKeyShow extends StatelessWidget {
           ],
         ),
       ],
-    );
+    ));
   }
 }
 

--- a/lib/views/settings/widgets/security_settings/seed_settings/seed_confirmation/seed_confirmation.dart
+++ b/lib/views/settings/widgets/security_settings/seed_settings/seed_confirmation/seed_confirmation.dart
@@ -13,6 +13,7 @@ import 'package:web_dex/model/wallet.dart';
 import 'package:web_dex/views/settings/widgets/security_settings/seed_settings/seed_back_button.dart';
 import 'package:web_dex/views/settings/widgets/security_settings/seed_settings/seed_word_button.dart';
 import 'package:komodo_ui_kit/komodo_ui_kit.dart';
+import 'package:web_dex/shared/screenshot/screenshot_sensitivity.dart';
 
 class SeedConfirmation extends StatefulWidget {
   const SeedConfirmation({required this.seedPhrase});
@@ -39,7 +40,7 @@ class _SeedConfirmationState extends State<SeedConfirmation> {
   @override
   Widget build(BuildContext context) {
     final scrollController = ScrollController();
-    return DexScrollbar(
+    return ScreenshotSensitive(child: DexScrollbar(
       isMobile: isMobile,
       scrollController: scrollController,
       child: SingleChildScrollView(
@@ -112,7 +113,7 @@ class _SeedConfirmationState extends State<SeedConfirmation> {
           ],
         ),
       ),
-    );
+    ));
   }
 
   void _onWordPressed(_SeedWord word) {

--- a/lib/views/settings/widgets/security_settings/seed_settings/seed_show.dart
+++ b/lib/views/settings/widgets/security_settings/seed_settings/seed_show.dart
@@ -20,6 +20,7 @@ import 'package:web_dex/shared/widgets/coin_item/coin_item.dart';
 import 'package:web_dex/shared/widgets/dry_intrinsic.dart';
 import 'package:web_dex/views/settings/widgets/security_settings/seed_settings/seed_back_button.dart';
 import 'package:web_dex/views/wallet/coin_details/receive/qr_code_address.dart';
+import 'package:web_dex/shared/screenshot/screenshot_sensitivity.dart';
 
 class SeedShow extends StatelessWidget {
   const SeedShow({
@@ -32,7 +33,7 @@ class SeedShow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final scrollController = ScrollController();
-    return DexScrollbar(
+    return ScreenshotSensitive(child: DexScrollbar(
       scrollController: scrollController,
       child: SingleChildScrollView(
         controller: scrollController,
@@ -89,7 +90,7 @@ class SeedShow extends StatelessWidget {
           ],
         ),
       ),
-    );
+    ));
   }
 }
 

--- a/lib/views/wallets_manager/widgets/wallet_creation.dart
+++ b/lib/views/wallets_manager/widgets/wallet_creation.dart
@@ -13,6 +13,7 @@ import 'package:web_dex/shared/widgets/disclaimer/eula_tos_checkboxes.dart';
 import 'package:web_dex/shared/widgets/quick_login_switch.dart';
 import 'package:web_dex/views/wallets_manager/widgets/creation_password_fields.dart';
 import 'package:web_dex/views/wallets_manager/widgets/hdwallet_mode_switch.dart';
+import 'package:web_dex/shared/screenshot/screenshot_sensitivity.dart';
 
 class WalletCreation extends StatefulWidget {
   const WalletCreation({
@@ -91,7 +92,7 @@ class _WalletCreationState extends State<WalletCreation> {
         }
       },
       child: AutofillGroup(
-        child: Form(
+        child: ScreenshotSensitive(child: Form(
           key: _formKey,
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -136,7 +137,7 @@ class _WalletCreationState extends State<WalletCreation> {
               ),
             ],
           ),
-        ),
+        )),
       ),
     );
   }

--- a/lib/views/wallets_manager/widgets/wallet_deleting.dart
+++ b/lib/views/wallets_manager/widgets/wallet_deleting.dart
@@ -9,6 +9,7 @@ import 'package:web_dex/blocs/wallets_repository.dart';
 import 'package:web_dex/generated/codegen_loader.g.dart';
 import 'package:web_dex/model/wallet.dart';
 import 'package:web_dex/shared/widgets/password_visibility_control.dart';
+import 'package:web_dex/shared/screenshot/screenshot_sensitivity.dart';
 
 class WalletDeleting extends StatefulWidget {
   const WalletDeleting({
@@ -37,7 +38,7 @@ class _WalletDeletingState extends State<WalletDeleting> {
 
   @override
   Widget build(BuildContext context) {
-    return Form(
+    return ScreenshotSensitive(child: Form(
       key: _formKey,
       child: Column(
         children: [
@@ -83,7 +84,7 @@ class _WalletDeletingState extends State<WalletDeleting> {
           ),
         ],
       ),
-    );
+    ));
   }
 
   Widget _buildHeader() {

--- a/lib/views/wallets_manager/widgets/wallet_import_by_file.dart
+++ b/lib/views/wallets_manager/widgets/wallet_import_by_file.dart
@@ -16,6 +16,7 @@ import 'package:web_dex/shared/widgets/password_visibility_control.dart';
 import 'package:web_dex/shared/widgets/quick_login_switch.dart';
 import 'package:web_dex/views/wallets_manager/widgets/custom_seed_checkbox.dart';
 import 'package:web_dex/views/wallets_manager/widgets/hdwallet_mode_switch.dart';
+import 'package:web_dex/shared/screenshot/screenshot_sensitivity.dart';
 
 class WalletFileData {
   const WalletFileData({required this.content, required this.name});
@@ -93,7 +94,7 @@ class _WalletImportByFileState extends State<WalletImportByFile> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    return ScreenshotSensitive(child: Column(
       mainAxisSize: MainAxisSize.min,
       children: [
         Text(
@@ -210,7 +211,7 @@ class _WalletImportByFileState extends State<WalletImportByFile> {
           ),
         ),
       ],
-    );
+    ));
   }
 
   @override

--- a/lib/views/wallets_manager/widgets/wallet_login.dart
+++ b/lib/views/wallets_manager/widgets/wallet_login.dart
@@ -15,6 +15,7 @@ import 'package:web_dex/model/wallet.dart';
 import 'package:web_dex/shared/widgets/password_visibility_control.dart';
 import 'package:web_dex/shared/widgets/quick_login_switch.dart';
 import 'package:web_dex/views/wallets_manager/widgets/hdwallet_mode_switch.dart';
+import 'package:web_dex/shared/screenshot/screenshot_sensitivity.dart';
 
 class WalletLogIn extends StatefulWidget {
   const WalletLogIn({
@@ -102,7 +103,7 @@ class _WalletLogInState extends State<WalletLogIn> {
             : state.authError?.message;
 
         return AutofillGroup(
-          child: Column(
+          child: ScreenshotSensitive(child: Column(
             mainAxisSize: isMobile ? MainAxisSize.max : MainAxisSize.min,
             children: [
               Text(
@@ -165,7 +166,7 @@ class _WalletLogInState extends State<WalletLogIn> {
                 text: LocaleKeys.cancel.tr(),
               ),
             ],
-          ),
+          )),
         );
       },
     );

--- a/lib/views/wallets_manager/widgets/wallet_simple_import.dart
+++ b/lib/views/wallets_manager/widgets/wallet_simple_import.dart
@@ -19,6 +19,7 @@ import 'package:web_dex/shared/widgets/quick_login_switch.dart';
 import 'package:web_dex/views/wallets_manager/widgets/creation_password_fields.dart';
 import 'package:web_dex/views/wallets_manager/widgets/custom_seed_checkbox.dart';
 import 'package:web_dex/views/wallets_manager/widgets/hdwallet_mode_switch.dart';
+import 'package:web_dex/shared/screenshot/screenshot_sensitivity.dart';
 
 class WalletSimpleImport extends StatefulWidget {
   const WalletSimpleImport({
@@ -95,7 +96,7 @@ class _WalletImportWrapperState extends State<WalletSimpleImport> {
         }
       },
       child: AutofillGroup(
-        child: Column(
+        child: ScreenshotSensitive(child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
             SelectableText(
@@ -140,7 +141,7 @@ class _WalletImportWrapperState extends State<WalletSimpleImport> {
               ),
             ),
           ],
-        ),
+        )),
       ),
     );
   }


### PR DESCRIPTION
Disable feedback screenshots on sensitive pages to prevent leakage of user secrets.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f77bdea-a649-45ee-b5fd-eee44d04ca05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f77bdea-a649-45ee-b5fd-eee44d04ca05">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

