### PR TITLE
Investigate and resolve precision loss in wallet

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -468,6 +468,7 @@
   "nothingFound": "Nothing found",
   "half": "Half",
   "max": "Max",
+  "exact": "Exact",
   "reactivating": "Reactivating",
   "weFailedCoinActivate": "We failed to activate {} :(",
   "failedActivate": "Failed to activate",

--- a/lib/generated/codegen_loader.g.dart
+++ b/lib/generated/codegen_loader.g.dart
@@ -465,6 +465,7 @@ abstract class  LocaleKeys {
   static const nothingFound = 'nothingFound';
   static const half = 'half';
   static const max = 'max';
+  static const exact = 'exact';
   static const reactivating = 'reactivating';
   static const weFailedCoinActivate = 'weFailedCoinActivate';
   static const failedActivate = 'failedActivate';

--- a/lib/shared/utils/utils.dart
+++ b/lib/shared/utils/utils.dart
@@ -139,9 +139,11 @@ Rational? fract2rat(Map<String, dynamic>? fract, [bool willLog = true]) {
   if (fract == null) return null;
 
   try {
+    final String numerStr = fract['numer'].toString();
+    final String denomStr = fract['denom'].toString();
     final rat = Rational(
-      BigInt.from(double.parse(fract['numer'])),
-      BigInt.from(double.parse(fract['denom'])),
+      BigInt.parse(numerStr),
+      BigInt.parse(denomStr),
     );
     return rat;
   } catch (e) {

--- a/lib/views/dex/simple/form/taker/coin_item/taker_form_sell_item.dart
+++ b/lib/views/dex/simple/form/taker/coin_item/taker_form_sell_item.dart
@@ -50,6 +50,8 @@ class _SellHeader extends StatelessWidget {
       actions: [
         Flexible(child: _AvailableGroup()),
         const SizedBox(width: 8),
+        _ExactButton(),
+        const SizedBox(width: 3),
         _MaxButton(),
         const SizedBox(width: 3),
         _HalfButton(),
@@ -83,5 +85,15 @@ class _MaxButton extends DexSmallButton {
   _MaxButton()
       : super(LocaleKeys.max.tr(), (context) {
           context.read<TakerBloc>().add(TakerAmountButtonClick(1));
+        });
+}
+
+class _ExactButton extends DexSmallButton {
+  _ExactButton()
+      : super(LocaleKeys.exact.tr(), (context) {
+          final state = context.read<TakerBloc>().state;
+          final order = state.selectedOrder;
+          if (order == null) return;
+          context.read<TakerBloc>().add(TakerSetSellAmount(order.maxVolume));
         });
 }

--- a/test_units/tests/utils/convert_fract_rat_test.dart
+++ b/test_units/tests/utils/convert_fract_rat_test.dart
@@ -34,4 +34,25 @@ void testRatToFracAndViseVersa() {
     Rational? result = fract2rat(invalidFract, false);
     expect(result, isNull);
   });
+
+  test('fract2rat handles very large integers without precision loss', () {
+    // 10^50 / 10^20 = 10^30
+    final numer = '100000000000000000000000000000000000000000000000000';
+    final denom = '100000000000000000000';
+    final rat = fract2rat({'numer': numer, 'denom': denom}, false)!;
+    expect(rat.numerator, BigInt.parse(numer));
+    expect(rat.denominator, BigInt.parse(denom));
+    // Ensure round-trip
+    final back = rat2fract(rat, false)!;
+    expect(back['numer'], numer);
+    expect(back['denom'], denom);
+  });
+
+  test('fract2rat correctly parses strings that would overflow double', () {
+    final numer = '340282366920938463463374607431768211457'; // > 2^128
+    final denom = '1';
+    final rat = fract2rat({'numer': numer, 'denom': denom}, false)!;
+    expect(rat.numerator, BigInt.parse(numer));
+    expect(rat.denominator, BigInt.one);
+  });
 }


### PR DESCRIPTION
Fix precision loss in fraction parsing and add an "Exact" taker amount option to resolve order matching issues for large volumes.

The `fract2rat` utility previously converted fraction numerator/denominator via `double.parse` before converting to `BigInt`, which introduced precision loss for large values. This caused mismatches, particularly when a maker's `min_vol` was exactly equal to `max_vol`, preventing takers from matching these orders precisely. The "Exact" button provides a direct way to use the maker's precise `maxVolume` without UI-induced rounding.

---
<a href="https://cursor.com/background-agent?bcId=bc-309068ff-64b4-4330-a11d-35dfeef5f0e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-309068ff-64b4-4330-a11d-35dfeef5f0e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

