### PR TITLE
fix: trading address refresh bug and root cause

### DIFF
--- a/lib/bloc/coins_bloc/coins_bloc.dart
+++ b/lib/bloc/coins_bloc/coins_bloc.dart
@@ -315,6 +315,9 @@ class CoinsBloc extends Bloc<CoinsEvent, CoinsState> {
     Emitter<CoinsState> emit,
   ) async {
     try {
+      // Ensure any cached addresses/pubkeys from a previous wallet are cleared
+      // so that UI fetches fresh pubkeys for the newly logged-in wallet.
+      emit(state.copyWith(pubkeys: {}));
       _coinsRepo.flushCache();
       final Wallet currentWallet = event.signedInUser.wallet;
 
@@ -340,6 +343,9 @@ class CoinsBloc extends Bloc<CoinsEvent, CoinsState> {
     emit(
       state.copyWith(
         walletCoins: {},
+        // Clear pubkeys to avoid showing addresses from the previous wallet
+        // after logout or wallet switch.
+        pubkeys: {},
       ),
     );
     _coinsRepo.flushCache();


### PR DESCRIPTION
Clear cached pubkeys in `CoinsBloc` on wallet login and logout to fix stale trading addresses when switching wallets.

The bug occurred because `CoinsBloc.state.pubkeys` was not reset when a new wallet session began or an existing session ended, leading to UIs displaying addresses associated with a previously active wallet. This change ensures all address-dependent components (DEX, receive, withdraw, fiat onramp, Bitrefill) correctly reflect the active wallet's addresses.

---
<a href="https://cursor.com/background-agent?bcId=bc-90d42a08-f507-467c-809a-86133d5c7360">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-90d42a08-f507-467c-809a-86133d5c7360">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

