### PR TITLE
chore: update SDK to chore/kw-release-v0.9.3 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "sdk"]
 	path = sdk
 	url = https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
-	branch = dev
+	branch = chore/kw-release-v0.9.3
 	update = checkout
 	fetchRecurseSubmodules = on-demand
 	ignore = dirty


### PR DESCRIPTION
Updates the SDK submodule to track the `chore/kw-release-v0.9.3` branch instead of `dev`.

**Changes:**
- Updated `.gitmodules` to reference `chore/kw-release-v0.9.3` branch
- Updated SDK submodule to commit `72c9de3b370f1b4169ebbb3150e8adedf4ed3b23`

This aligns the project with the SDK release branch for v0.9.3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `sdk` submodule to branch `chore/kw-release-v0.9.3` and updates it to commit `72c9de3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b411f42acd8f3982709dd185e5017de29a1b161. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->