### PR TITLE
chore: update SDK submodule to dev branch (679fd92)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "sdk"]
 	path = sdk
 	url = https://github.com/KomodoPlatform/komodo-defi-sdk-flutter.git
-	branch = chore/kw-release-v0.9.3
+	branch = dev
 	update = checkout
 	fetchRecurseSubmodules = on-demand
 	ignore = dirty


### PR DESCRIPTION
This PR updates the SDK submodule to track the `dev` branch and updates the pinned commit to 679fd92.

## Changes
- Updated `.gitmodules` to track the `dev` branch instead of `chore/kw-release-v0.9.3`
- Updated SDK submodule to commit `679fd92` (latest on dev branch)

## SDK Commit Details
Latest commit: `679fd92` - chore: update API branch to hotfix-remove-memorydb-size-metric (#234)